### PR TITLE
Setup Conversions added by KrisV147: MaseratiMCGT4, Mclaren570SGT4, MercedesAMGGT4 and Porsche718CaymanGT4MR

### DIFF
--- a/ACC_Manager/ACC_Manager.csproj
+++ b/ACC_Manager/ACC_Manager.csproj
@@ -374,6 +374,7 @@
     <Compile Include="SetupParser\Cars\GT4\ChevroletCamaroGT4R.cs" />
     <Compile Include="SetupParser\Cars\GT4\GinettaG55GT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\KTMXbowGT4.cs" />
+    <Compile Include="SetupParser\Cars\GT4\MaseratiMCGT4.cs" />
     <Compile Include="SharedMemory\StructExtensions.cs" />
     <Compile Include="Controls\Telemetry\TelemetryDebug.xaml.cs">
       <DependentUpon>TelemetryDebug.xaml</DependentUpon>

--- a/ACC_Manager/ACC_Manager.csproj
+++ b/ACC_Manager/ACC_Manager.csproj
@@ -377,6 +377,7 @@
     <Compile Include="SetupParser\Cars\GT4\MaseratiMCGT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\Mclaren570SGT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\MercedesAMGGT4.cs" />
+    <Compile Include="SetupParser\Cars\GT4\Porsche718CaymanGT4MR.cs" />
     <Compile Include="SharedMemory\StructExtensions.cs" />
     <Compile Include="Controls\Telemetry\TelemetryDebug.xaml.cs">
       <DependentUpon>TelemetryDebug.xaml</DependentUpon>

--- a/ACC_Manager/ACC_Manager.csproj
+++ b/ACC_Manager/ACC_Manager.csproj
@@ -376,6 +376,7 @@
     <Compile Include="SetupParser\Cars\GT4\KTMXbowGT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\MaseratiMCGT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\Mclaren570SGT4.cs" />
+    <Compile Include="SetupParser\Cars\GT4\MercedesAMGGT4.cs" />
     <Compile Include="SharedMemory\StructExtensions.cs" />
     <Compile Include="Controls\Telemetry\TelemetryDebug.xaml.cs">
       <DependentUpon>TelemetryDebug.xaml</DependentUpon>

--- a/ACC_Manager/ACC_Manager.csproj
+++ b/ACC_Manager/ACC_Manager.csproj
@@ -375,6 +375,7 @@
     <Compile Include="SetupParser\Cars\GT4\GinettaG55GT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\KTMXbowGT4.cs" />
     <Compile Include="SetupParser\Cars\GT4\MaseratiMCGT4.cs" />
+    <Compile Include="SetupParser\Cars\GT4\Mclaren570SGT4.cs" />
     <Compile Include="SharedMemory\StructExtensions.cs" />
     <Compile Include="Controls\Telemetry\TelemetryDebug.xaml.cs">
       <DependentUpon>TelemetryDebug.xaml</DependentUpon>

--- a/ACC_Manager/SetupParser/Cars/GT4/GinettaG55GT4.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/GinettaG55GT4.cs
@@ -7,7 +7,6 @@ using static ACCSetupApp.SetupParser.SetupConverter;
 
 namespace ACCSetupApp.SetupParser.Cars.GT4
 {
-
     internal class GinettaG55GT4 : ICarSetupConversion
     {
         public string CarName => "Ginetta G55 GT4 2012";

--- a/ACC_Manager/SetupParser/Cars/GT4/KTMXbowGT4.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/KTMXbowGT4.cs
@@ -7,7 +7,6 @@ using static ACCSetupApp.SetupParser.SetupConverter;
 
 namespace ACCSetupApp.SetupParser.Cars.GT4
 {
-
     internal class KTMXbowGT4 : ICarSetupConversion
     {
         public string CarName => "Ktm Xbow GT4 2016";

--- a/ACC_Manager/SetupParser/Cars/GT4/MaseratiMCGT4.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/MaseratiMCGT4.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static ACCSetupApp.SetupParser.SetupConverter;
+
+namespace ACCSetupApp.SetupParser.Cars.GT4
+{
+    internal class MaseratiMCGT4 : ICarSetupConversion
+    {
+        public string CarName => "Maserati Gran Turismo MC GT4 2016";
+
+        public string ParseName => "maserati_mc_gt4";
+
+        CarClasses ICarSetupConversion.CarClass => CarClasses.GT4;
+
+        AbstractTyresSetup ICarSetupConversion.TyresSetup => new TyreSetup();
+        private class TyreSetup : AbstractTyresSetup
+        {
+            public override double Camber(Wheel wheel, List<int> rawValue)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return Math.Round(-4.3 + 0.1 * rawValue[(int)wheel], 2);
+                    case Position.Rear: return Math.Round(-2.8 + 0.1 * rawValue[(int)wheel], 2);
+                    default: return -1;
+                }
+            }
+
+            private readonly double[] casters = new double[] {
+                3.4, 3.7, 3.9, 4.1, 4.3, 4.5, 4.7, 5.0, 5.2, 5.4, 5.6
+            };
+            public override double Caster(int rawValue)
+            {
+                return Math.Round(casters[rawValue], 2);
+            }
+
+            public override double Toe(Wheel wheel, List<int> rawValue)
+            {
+                return Math.Round(-0.4 + 0.01 * rawValue[(int)wheel], 2);
+            }
+        }
+
+        IMechanicalSetup ICarSetupConversion.MechanicalSetup => new MechSetup();
+        private class MechSetup : IMechanicalSetup
+        {
+            public int AntiRollBarFront(int rawValue)
+            {
+                return 0 + rawValue + 1;
+            }
+
+            public int AntiRollBarRear(int rawValue)
+            {
+                return 0 + rawValue + 1;
+            }
+
+            public double BrakeBias(int rawValue)
+            {
+                return Math.Round(49 + 0.2 * rawValue, 2);
+            }
+
+            public int BrakePower(int rawValue)
+            {
+                return 80 + rawValue;
+            }
+
+            public int BumpstopRange(List<int> rawValue, Wheel wheel)
+            {
+                return rawValue[(int)wheel];
+            }
+
+            public int BumpstopRate(List<int> rawValue, Wheel wheel)
+            {
+                return 300 + 100 * rawValue[(int)wheel];
+            }
+
+            public int PreloadDifferential(int rawValue)
+            {
+                return 20 + rawValue * 10;
+            }
+
+            public double SteeringRatio(int rawValue)
+            {
+                return Math.Round(14d + rawValue, 2);
+            }
+
+            private readonly int[] fronts = new int[] { 116000, 151000, 186000 };
+            private readonly int[] rears = new int[] { 113000, 138000, 163000 };
+            public int WheelRate(List<int> rawValue, Wheel wheel)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return fronts[rawValue[(int)wheel]];
+                    case Position.Rear: return rears[rawValue[(int)wheel]];
+                    default: return -1;
+                }
+            }
+        }
+
+        IDamperSetup ICarSetupConversion.DamperSetup => DefaultDamperSetup;
+
+        IAeroBalance ICarSetupConversion.AeroBalance => new AeroSetup();
+        private class AeroSetup : IAeroBalance
+        {
+            public int BrakeDucts(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RearWing(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RideHeight(List<int> rawValue, Position position)
+            {
+                switch (position)
+                {
+                    case Position.Front: return 80 + rawValue[0];
+                    case Position.Rear: return 105 + rawValue[2];
+                    default: return -1;
+                }
+            }
+
+            public int Splitter(int rawValue)
+            {
+                return rawValue;
+            }
+        }
+    }
+}

--- a/ACC_Manager/SetupParser/Cars/GT4/Mclaren570SGT4.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/Mclaren570SGT4.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static ACCSetupApp.SetupParser.SetupConverter;
+
+namespace ACCSetupApp.SetupParser.Cars.GT4
+{
+    internal class Mclaren570SGT4 : ICarSetupConversion
+    {
+        public string CarName => "McLaren 570s GT4 2016";
+
+        public string ParseName => "mclaren_570s_gt4";
+
+        CarClasses ICarSetupConversion.CarClass => CarClasses.GT4;
+
+        AbstractTyresSetup ICarSetupConversion.TyresSetup => new TyreSetup();
+        private class TyreSetup : AbstractTyresSetup
+        {
+            public override double Camber(Wheel wheel, List<int> rawValue)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return Math.Round(-5.0 + 0.1 * rawValue[(int)wheel], 2);
+                    case Position.Rear: return Math.Round(-5.0 + 0.1 * rawValue[(int)wheel], 2);
+                    default: return -1;
+                }
+            }
+
+            private readonly double[] casters = new double[] {
+                5.3, 5.6, 5.8, 6.0, 6.3, 6.5, 6.8, 7.0, 7.3, 7.5, 7.8,
+                8.0, 8.2, 8.5, 8.7, 9.0, 9.2, 9.4, 9.7, 9.9, 10.2
+            };
+            public override double Caster(int rawValue)
+            {
+                return Math.Round(casters[rawValue], 2);
+            }
+
+            public override double Toe(Wheel wheel, List<int> rawValue)
+            {
+                return Math.Round(-0.4 + 0.01 * rawValue[(int)wheel], 2);
+            }
+        }
+
+        IMechanicalSetup ICarSetupConversion.MechanicalSetup => new MechSetup();
+        private class MechSetup : IMechanicalSetup
+        {
+            public int AntiRollBarFront(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public int AntiRollBarRear(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public double BrakeBias(int rawValue)
+            {
+                return Math.Round(60 + 0.2 * rawValue, 2);
+            }
+
+            public int BrakePower(int rawValue)
+            {
+                return 80 + rawValue;
+            }
+
+            public int BumpstopRange(List<int> rawValue, Wheel wheel)
+            {
+                return rawValue[(int)wheel];
+            }
+
+            public int BumpstopRate(List<int> rawValue, Wheel wheel)
+            {
+                return 300 + 100 * rawValue[(int)wheel];
+            }
+
+            public int PreloadDifferential(int rawValue)
+            {
+                return 0 + rawValue * 10;
+            }
+
+            public double SteeringRatio(int rawValue)
+            {
+                return Math.Round(11d + rawValue, 2);
+            }
+
+            private readonly int[] fronts = new int[] { 140000, 175000 };
+            private readonly int[] rears = new int[] { 162850, 175520 };
+            public int WheelRate(List<int> rawValue, Wheel wheel)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return fronts[rawValue[(int)wheel]];
+                    case Position.Rear: return rears[rawValue[(int)wheel]];
+                    default: return -1;
+                }
+            }
+        }
+
+        IDamperSetup ICarSetupConversion.DamperSetup => DefaultDamperSetup;
+
+        IAeroBalance ICarSetupConversion.AeroBalance => new AeroSetup();
+        private class AeroSetup : IAeroBalance
+        {
+            public int BrakeDucts(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RearWing(int rawValue)
+            {
+                return rawValue + 1;
+            }
+
+            public int RideHeight(List<int> rawValue, Position position)
+            {
+                switch (position)
+                {
+                    case Position.Front: return 100 + rawValue[0];
+                    case Position.Rear: return 100 + rawValue[2];
+                    default: return -1;
+                }
+            }
+
+            public int Splitter(int rawValue)
+            {
+                return rawValue;
+            }
+        }
+    }
+}

--- a/ACC_Manager/SetupParser/Cars/GT4/MercedesAMGGT4.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/MercedesAMGGT4.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static ACCSetupApp.SetupParser.SetupConverter;
+
+namespace ACCSetupApp.SetupParser.Cars.GT4
+{
+    internal class MercedesAMGGT4 : ICarSetupConversion
+    {
+        public string CarName => "Mercedes AMG GT4 2016";
+
+        public string ParseName => "mercedes_amg_gt4";
+
+        CarClasses ICarSetupConversion.CarClass => CarClasses.GT4;
+
+        AbstractTyresSetup ICarSetupConversion.TyresSetup => new TyreSetup();
+        private class TyreSetup : AbstractTyresSetup
+        {
+            public override double Camber(Wheel wheel, List<int> rawValue)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return Math.Round(-4.5 + 0.1 * rawValue[(int)wheel], 2);
+                    case Position.Rear: return Math.Round(-3.5 + 0.1 * rawValue[(int)wheel], 2);
+                    default: return -1;
+                }
+            }
+
+            private readonly double[] casters = new double[] {
+                9.2, 9.4, 9.5, 9.7, 9.9, 10.1, 10.3, 10.5, 10.7, 10.8, 11.0, 11.2, 11.4, 11.6, 11.8,
+                11.9, 12.1, 12.3, 12.5, 12.7, 12.8, 13.0, 13.2, 13.4, 13.6, 13.7, 13.9, 14.1, 14.3,
+                14.5, 14.6, 14.8, 15.0, 15.2, 15.4, 15.5, 15.7, 15.9, 16.1, 16.2, 16.4
+            };
+            public override double Caster(int rawValue)
+            {
+                return Math.Round(casters[rawValue], 2);
+            }
+
+            public override double Toe(Wheel wheel, List<int> rawValue)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return Math.Round(-0.2 + 0.01 * rawValue[(int)wheel], 2);
+                    case Position.Rear: return Math.Round(0.0 + 0.01 * rawValue[(int)wheel], 2);
+                    default: return -1;
+                }
+            }
+        }
+
+        IMechanicalSetup ICarSetupConversion.MechanicalSetup => new MechSetup();
+        private class MechSetup : IMechanicalSetup
+        {
+            public int AntiRollBarFront(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public int AntiRollBarRear(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public double BrakeBias(int rawValue)
+            {
+                return Math.Round(51 + 0.3 * rawValue, 2);
+            }
+
+            public int BrakePower(int rawValue)
+            {
+                return 80 + rawValue;
+            }
+
+            public int BumpstopRange(List<int> rawValue, Wheel wheel)
+            {
+                return rawValue[(int)wheel];
+            }
+
+            public int BumpstopRate(List<int> rawValue, Wheel wheel)
+            {
+                return 300 + 100 * rawValue[(int)wheel];
+            }
+
+            public int PreloadDifferential(int rawValue)
+            {
+                return 10 + rawValue * 10;
+            }
+
+            public double SteeringRatio(int rawValue)
+            {
+                return Math.Round(10d + rawValue, 2);
+            }
+
+            private readonly int[] fronts = new int[] { 78000, 88000, 104000 };
+            private readonly int[] rears = new int[] { 66000 };
+            public int WheelRate(List<int> rawValue, Wheel wheel)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return fronts[rawValue[(int)wheel]];
+                    case Position.Rear: return rears[rawValue[(int)wheel]];
+                    default: return -1;
+                }
+            }
+        }
+
+        IDamperSetup ICarSetupConversion.DamperSetup => DefaultDamperSetup;
+
+        IAeroBalance ICarSetupConversion.AeroBalance => new AeroSetup();
+        private class AeroSetup : IAeroBalance
+        {
+            public int BrakeDucts(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RearWing(int rawValue)
+            {
+                return rawValue + 1;
+            }
+
+            public int RideHeight(List<int> rawValue, Position position)
+            {
+                switch (position)
+                {
+                    case Position.Front: return 103 + rawValue[0];
+                    case Position.Rear: return 101 + rawValue[2];
+                    default: return -1;
+                }
+            }
+
+            public int Splitter(int rawValue)
+            {
+                return rawValue;
+            }
+        }
+    }
+}

--- a/ACC_Manager/SetupParser/Cars/GT4/Porsche718CaymanGT4MR.cs
+++ b/ACC_Manager/SetupParser/Cars/GT4/Porsche718CaymanGT4MR.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static ACCSetupApp.SetupParser.SetupConverter;
+
+namespace ACCSetupApp.SetupParser.Cars.GT4
+{
+    internal class Porsche718CaymanGT4MR : ICarSetupConversion
+    {
+        public string CarName => "Porsche 718 Cayman GT4 MR 2019";
+
+        public string ParseName => "porsche_718_cayman_gt4_mr";
+
+        CarClasses ICarSetupConversion.CarClass => CarClasses.GT4;
+
+        AbstractTyresSetup ICarSetupConversion.TyresSetup => new TyreSetup();
+        private class TyreSetup : AbstractTyresSetup
+        {
+            public override double Camber(Wheel wheel, List<int> rawValue)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return Math.Round(-5.0 + 0.1 * rawValue[(int)wheel], 2);
+                    case Position.Rear: return Math.Round(-5.0 + 0.1 * rawValue[(int)wheel], 2);
+                    default: return -1;
+                }
+            }
+
+            private readonly double[] casters = new double[] {
+                7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8,
+                8.9, 9.0, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2
+            };
+            public override double Caster(int rawValue)
+            {
+                return Math.Round(casters[rawValue], 2);
+            }
+
+            public override double Toe(Wheel wheel, List<int> rawValue)
+            {
+                return Math.Round(-0.4 + 0.01 * rawValue[(int)wheel], 2);
+            }
+        }
+
+        IMechanicalSetup ICarSetupConversion.MechanicalSetup => new MechSetup();
+        private class MechSetup : IMechanicalSetup
+        {
+            public int AntiRollBarFront(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public int AntiRollBarRear(int rawValue)
+            {
+                return 0 + rawValue;
+            }
+
+            public double BrakeBias(int rawValue)
+            {
+                return Math.Round(45 + 0.2 * rawValue, 2);
+            }
+
+            public int BrakePower(int rawValue)
+            {
+                return 80 + rawValue;
+            }
+
+            public int BumpstopRange(List<int> rawValue, Wheel wheel)
+            {
+                return rawValue[(int)wheel];
+            }
+
+            public int BumpstopRate(List<int> rawValue, Wheel wheel)
+            {
+                return 300 + 100 * rawValue[(int)wheel];
+            }
+
+            public int PreloadDifferential(int rawValue)
+            {
+                return 10 + rawValue * 10;
+            }
+
+            public double SteeringRatio(int rawValue)
+            {
+                return Math.Round(15d + rawValue, 2);
+            }
+
+            private readonly int[] fronts = new int[] { 99000, 108000, 116000, 124000 };
+            private readonly int[] rears = new int[] { 91000, 99000, 108000, 116000, 124000 };
+            public int WheelRate(List<int> rawValue, Wheel wheel)
+            {
+                switch (GetPosition(wheel))
+                {
+                    case Position.Front: return fronts[rawValue[(int)wheel]];
+                    case Position.Rear: return rears[rawValue[(int)wheel]];
+                    default: return -1;
+                }
+            }
+        }
+
+        IDamperSetup ICarSetupConversion.DamperSetup => DefaultDamperSetup;
+
+        IAeroBalance ICarSetupConversion.AeroBalance => new AeroSetup();
+        private class AeroSetup : IAeroBalance
+        {
+            public int BrakeDucts(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RearWing(int rawValue)
+            {
+                return rawValue;
+            }
+
+            public int RideHeight(List<int> rawValue, Position position)
+            {
+                switch (position)
+                {
+                    case Position.Front: return 96 + rawValue[0];
+                    case Position.Rear: return 84 + rawValue[2];
+                    default: return -1;
+                }
+            }
+
+            public int Splitter(int rawValue)
+            {
+                return rawValue;
+            }
+        }
+    }
+}

--- a/ACC_Manager/SetupParser/ConversionFactory.cs
+++ b/ACC_Manager/SetupParser/ConversionFactory.cs
@@ -37,7 +37,8 @@ namespace ACCSetupApp.SetupParser
             {"chevrolet_camaro_gt4r", new ChevroletCamaroGT4R() },
             {"ginetta_g55_gt4", new GinettaG55GT4() },
             {"ktm_xbow_gt4", new KTMXbowGT4() },
-            {"maserati_mc_gt4", new MaseratiMCGT4() }
+            {"maserati_mc_gt4", new MaseratiMCGT4() },
+            {"mclaren_570s_gt4", new Mclaren570SGT4() }
         };
         internal ICarSetupConversion GetConversion(string parseName)
         {
@@ -104,7 +105,8 @@ namespace ACCSetupApp.SetupParser
             {"chevrolet_camaro_gt4r", "Chevrolet Camaro GT4 R 2017"},
             {"ginetta_g55_gt4", "Ginetta G55 GT4 2012"},
             {"ktm_xbow_gt4", "Ktm Xbow GT4 2016"},
-            {"maserati_mc_gt4", "Maserati Gran Turismo MC GT4 2016"}
+            {"maserati_mc_gt4", "Maserati Gran Turismo MC GT4 2016"},
+            {"mclaren_570s_gt4", "McLaren 570s GT4 2016"}
         };
         internal string ParseCarName(string parseName)
         {

--- a/ACC_Manager/SetupParser/ConversionFactory.cs
+++ b/ACC_Manager/SetupParser/ConversionFactory.cs
@@ -36,7 +36,8 @@ namespace ACCSetupApp.SetupParser
             {"bmw_m4_gt4", new BMWM4GT4() },
             {"chevrolet_camaro_gt4r", new ChevroletCamaroGT4R() },
             {"ginetta_g55_gt4", new GinettaG55GT4() },
-            {"ktm_xbow_gt4", new KTMXbowGT4() }
+            {"ktm_xbow_gt4", new KTMXbowGT4() },
+            {"maserati_mc_gt4", new MaseratiMCGT4() }
         };
         internal ICarSetupConversion GetConversion(string parseName)
         {
@@ -102,7 +103,8 @@ namespace ACCSetupApp.SetupParser
             {"bmw_m4_gt4", "BMW M4 GT4 2018"},
             {"chevrolet_camaro_gt4r", "Chevrolet Camaro GT4 R 2017"},
             {"ginetta_g55_gt4", "Ginetta G55 GT4 2012"},
-            {"ktm_xbow_gt4", "Ktm Xbow GT4 2016"}
+            {"ktm_xbow_gt4", "Ktm Xbow GT4 2016"},
+            {"maserati_mc_gt4", "Maserati Gran Turismo MC GT4 2016"}
         };
         internal string ParseCarName(string parseName)
         {

--- a/ACC_Manager/SetupParser/ConversionFactory.cs
+++ b/ACC_Manager/SetupParser/ConversionFactory.cs
@@ -38,7 +38,8 @@ namespace ACCSetupApp.SetupParser
             {"ginetta_g55_gt4", new GinettaG55GT4() },
             {"ktm_xbow_gt4", new KTMXbowGT4() },
             {"maserati_mc_gt4", new MaseratiMCGT4() },
-            {"mclaren_570s_gt4", new Mclaren570SGT4() }
+            {"mclaren_570s_gt4", new Mclaren570SGT4() },
+            {"mercedes_amg_gt4", new MercedesAMGGT4() }
         };
         internal ICarSetupConversion GetConversion(string parseName)
         {
@@ -106,7 +107,8 @@ namespace ACCSetupApp.SetupParser
             {"ginetta_g55_gt4", "Ginetta G55 GT4 2012"},
             {"ktm_xbow_gt4", "Ktm Xbow GT4 2016"},
             {"maserati_mc_gt4", "Maserati Gran Turismo MC GT4 2016"},
-            {"mclaren_570s_gt4", "McLaren 570s GT4 2016"}
+            {"mclaren_570s_gt4", "McLaren 570s GT4 2016"},
+            {"mercedes_amg_gt4", "Mercedes AMG GT4 2016"}
         };
         internal string ParseCarName(string parseName)
         {

--- a/ACC_Manager/SetupParser/ConversionFactory.cs
+++ b/ACC_Manager/SetupParser/ConversionFactory.cs
@@ -39,7 +39,8 @@ namespace ACCSetupApp.SetupParser
             {"ktm_xbow_gt4", new KTMXbowGT4() },
             {"maserati_mc_gt4", new MaseratiMCGT4() },
             {"mclaren_570s_gt4", new Mclaren570SGT4() },
-            {"mercedes_amg_gt4", new MercedesAMGGT4() }
+            {"mercedes_amg_gt4", new MercedesAMGGT4() },
+            {"porsche_718_cayman_gt4_mr", new Porsche718CaymanGT4MR() }
         };
         internal ICarSetupConversion GetConversion(string parseName)
         {
@@ -108,7 +109,8 @@ namespace ACCSetupApp.SetupParser
             {"ktm_xbow_gt4", "Ktm Xbow GT4 2016"},
             {"maserati_mc_gt4", "Maserati Gran Turismo MC GT4 2016"},
             {"mclaren_570s_gt4", "McLaren 570s GT4 2016"},
-            {"mercedes_amg_gt4", "Mercedes AMG GT4 2016"}
+            {"mercedes_amg_gt4", "Mercedes AMG GT4 2016"},
+            {"porsche_718_cayman_gt4_mr", "Porsche 718 Cayman GT4 MR 2019"}
         };
         internal string ParseCarName(string parseName)
         {


### PR DESCRIPTION
Maserati has a few quirks that i wouldnt mind going through with you.

example though . . . 

Front ARB, TC and ABS cannot be changed, but the saved setups for default safe and aggressive contain different numbers and therefore show as differences.

Maybe a change on how we handle values that cant be changed in-game? Would require manual input though, as i dont think there are any triggers in the setups themselves. 