### PR TITLE
Update FuelInfoOverlay.cs

### DIFF
--- a/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -31,8 +31,8 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
         public FuelInfoOverlay(Rectangle rectangle) : base(rectangle, "Fuel Info Overlay")
         {
             this.Width = 240;
-            infoPanel = new InfoPanel(10, this.Width - 1);
-            this.Height = this.infoPanel.FontHeight * 10;
+            infoPanel = new InfoPanel(11, this.Width - 1);
+            this.Height = this.infoPanel.FontHeight * 10; // Put me back to 6 before release please :)
             RefreshRateHz = 5;
         }
 
@@ -105,8 +105,8 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
             }
             //Magic End (Advanced)
 
-            infoPanel.AddLine("Riddle AVG Fuel", fuelTest.ToString("F2"));
-            infoPanel.AddLine("ACC AVG Fuel", pageGraphics.FuelXLap.ToString("F2"));
+            infoPanel.AddLine("Riddle Fuel", fuelTest.ToString("F2"));
+            infoPanel.AddLine("ACC Fuel", pageGraphics.FuelXLap.ToString("F2"));
 
             infoPanel.Draw(g);
         }

--- a/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -100,7 +100,7 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
 
         private Brush GetFuelTimeBrush(double fuelTimeLeft, double stintDebug)
         {
-            Brush brush = Brushes.White;
+            Brush brush;
             if (stintDebug > -1)
                 brush = fuelTimeLeft <= stintDebug ? Brushes.Red : Brushes.LimeGreen;
             else

--- a/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -100,15 +100,12 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
 
         private Brush GetFuelTimeBrush(double fuelTimeLeft, double stintDebug)
         {
-            _ = Brushes.White;
+            Brush brush = Brushes.White;
             if (stintDebug > -1)
-                if (fuelTimeLeft <= stintDebug)
-                    return _ = Brushes.Red;
-                else return _ = Brushes.LimeGreen;
+                brush = fuelTimeLeft <= stintDebug ? Brushes.Red : Brushes.LimeGreen;
             else
-            if (fuelTimeLeft <= pageGraphics.SessionTimeLeft)
-                return _ = Brushes.Red;
-            else return _ = Brushes.LimeGreen;
+                brush = fuelTimeLeft <= pageGraphics.SessionTimeLeft ? Brushes.Red : Brushes.LimeGreen;
+            return brush;
         }
 
         public override bool ShouldRender()

--- a/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using ACC_Manager.Util.NumberExtensions;
+using ACCManager.HUD.ACC.Data.Tracker.Laps;
 using ACCManager.HUD.Overlay.Internal;
 using ACCManager.HUD.Overlay.Util;
 using System;
@@ -31,7 +32,7 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
         {
             this.Width = 240;
             infoPanel = new InfoPanel(10, this.Width - 1);
-            this.Height = this.infoPanel.FontHeight * 6;
+            this.Height = this.infoPanel.FontHeight * 10;
             RefreshRateHz = 5;
         }
 
@@ -67,10 +68,15 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
             TimeSpan time2 = TimeSpan.FromMilliseconds(fuelTimeCalc);
             string fuelTime = time2.ToString(@"hh\:mm\:ss");
 
+            //*************** TESTING *************************
+            //double fuelChecking = LapTracker.Instance.Laps.Count < 2 ? -1 : pageGraphics.FuelXLap;
+
+            double fuelTest = LapTracker.Instance.Laps.GetAverageFuelUsage(5); // using (5) latest laps for fuel average
+            //*************************************************
             Brush fuelBarBrush = pagePhysics.Fuel / pageStatic.MaxFuel < 0.15 ? Brushes.Red : Brushes.OrangeRed;
             //Start (Basic)
             infoPanel.AddProgressBarWithCenteredText($"{pagePhysics.Fuel:F2} L", 0, pageStatic.MaxFuel, pagePhysics.Fuel, fuelBarBrush);
-            infoPanel.AddLine("Laps Left", $"{ pageGraphics.FuelEstimatedLaps:F1} : {pageGraphics.FuelXLap:F2}L");
+            infoPanel.AddLine("Laps Left", $"{pageGraphics.FuelEstimatedLaps:F1} : {pageGraphics.FuelXLap:F2}L");
             if (this.config.IncludeFuelBuffer)
                 infoPanel.AddLine("Fuel-End+", $"{fuelToEndBuffer:F1} : Add {fuelToAddBuffer:F0}");
             else
@@ -98,6 +104,10 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
                     infoPanel.AddLine("Stint Fuel", stintFuel.ToString("F1"));
             }
             //Magic End (Advanced)
+
+            infoPanel.AddLine("Riddle AVG Fuel", fuelTest.ToString("F2"));
+            infoPanel.AddLine("ACC AVG Fuel", pageGraphics.FuelXLap.ToString("F2"));
+
             infoPanel.Draw(g);
         }
 

--- a/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -80,7 +80,18 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayFuelInfo
             if (this.config.ShowAdvancedInfo)
             {
                 infoPanel.AddLine("Stint Time", stintTime);
-                infoPanel.AddLine("Fuel Time", fuelTime);
+
+                if (stintDebug > 0)
+                    if (fuelTimeCalc <= stintDebug)
+                        infoPanel.AddLine("Fuel Time", fuelTime, Brushes.Red);
+                    else
+                        infoPanel.AddLine("Fuel Time", fuelTime, Brushes.LimeGreen);
+                else
+                    if (fuelTimeCalc <= pageGraphics.SessionTimeLeft)
+                    infoPanel.AddLine("Fuel Time", fuelTime, Brushes.Red);
+                else
+                    infoPanel.AddLine("Fuel Time", fuelTime, Brushes.LimeGreen);
+
                 if (this.config.IncludeFuelBuffer)
                     infoPanel.AddLine("Stint Fuel+", stintFuelBuffer.ToString("F1"));
                 else


### PR DESCRIPTION
Added a bunch of if/else because who needs CPU power for gaming???

Added fueltime colouring in 2 separate instances. Checking against stint time or session time, depending on whether there are stints or not. if you have less fuel time than stint/session = red, otherwise green.

Aim was to have a quick visual reference of whether you were ok for fuel or not.