### PR TITLE
Now lap info delta bar background color indicates if a lap is valid 

### DIFF
--- a/ACC_Manager.HUD.ACC/Overlays/OverlayLapInfo/LapInfoOverlay.cs
+++ b/ACC_Manager.HUD.ACC/Overlays/OverlayLapInfo/LapInfoOverlay.cs
@@ -82,7 +82,7 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayLapDelta
         public sealed override void Render(Graphics g)
         {
             double delta = (double)pageGraphics.DeltaLapTimeMillis / 1000;
-            DeltaBar deltaBar = new DeltaBar(-this._config.MaxDelta, this._config.MaxDelta, delta) { DrawBackground = true };
+            DeltaBar deltaBar = new DeltaBar(-this._config.MaxDelta, this._config.MaxDelta, delta) { DrawBackground = true , IsValidLap = pageGraphics.IsValidLap };
             deltaBar.Draw(g, 0, 0, _overlayWidth, _table.FontHeight);
 
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;

--- a/ACC_Manager.HUD/Overlay/OverlayUtil/DeltaBar.cs
+++ b/ACC_Manager.HUD/Overlay/OverlayUtil/DeltaBar.cs
@@ -19,6 +19,7 @@ namespace ACCManager.HUD.Overlay.OverlayUtil
         private double Average { get; set; }
 
         public bool DrawBackground = false;
+        public bool IsValidLap = false;
         public bool DrawOutline = true;
         public Color PositiveColor = Color.OrangeRed;
         public Color NegativeColor = Color.LimeGreen;
@@ -40,8 +41,12 @@ namespace ACCManager.HUD.Overlay.OverlayUtil
 
             Color drawingColor = Color.White;
 
-            if (DrawBackground)
-                g.FillRectangle(new SolidBrush(Color.FromArgb(120, Color.Black)), new Rectangle(x, y, width, height));
+            if (DrawBackground) { 
+                if (IsValidLap)
+                    g.FillRectangle(new SolidBrush(Color.FromArgb(120, Color.Black)), new Rectangle(x, y, width, height));
+                else
+                    g.FillRectangle(new SolidBrush(Color.FromArgb(120, Color.DarkRed)), new Rectangle(x, y, width, height));
+            }
 
             if (Value < Average)
             {
@@ -77,6 +82,10 @@ namespace ACCManager.HUD.Overlay.OverlayUtil
             if (DrawOutline)
             {
                 Brush outlineBrush = new SolidBrush(drawingColor);
+                
+                if (!IsValidLap)
+                    outlineBrush = new SolidBrush(Color.DarkRed);
+
                 g.DrawRectangle(new Pen(outlineBrush), new Rectangle(x, y, width, height));
             }
 


### PR DESCRIPTION
With this little mod the delta bar backgound color and outline indicates if a lap is valid:
- lap valid: colors as before
- lap invalid: dark red color. 

Other delta bar colors and behaviors remain the same.

This is very usefull in practice session because the game doesn't alert you cut the track. With that hind is much easier to find the limit.
