### PR TITLE
Fix refresh rate of overlays

### DIFF
--- a/ACC_Manager.HUD/Overlay/Internal/AbstractOverlay.cs
+++ b/ACC_Manager.HUD/Overlay/Internal/AbstractOverlay.cs
@@ -179,27 +179,35 @@ namespace ACCManager.HUD.Overlay.Internal
                 Draw = true;
                 this.Show();
 
-                new Thread(x =>
+                if (!RequestsDrawItself)
                 {
-                    this.RefreshRateHz.Clip(1, 100);
-                    while (Draw)
+                    new Thread(x =>
                     {
-                        lock (this)
+                        var lastRefreshTime = DateTime.UtcNow;
+                        while (Draw)
                         {
-                            Thread.Sleep(1000 / RefreshRateHz);
-                            if (this == null || this._disposed)
+                            lock (this)
                             {
-                                this.Stop();
-                                return;
-                            }
+                                var currenTime = DateTime.UtcNow;
+                                var nextRefreshTime = lastRefreshTime.AddSeconds(1.0 / this.RefreshRateHz);
+                                var waitTime = nextRefreshTime - currenTime;
+                                lastRefreshTime = nextRefreshTime;
+                                if (waitTime.Ticks > 0)
+                                    Thread.Sleep(waitTime);
 
-                            if (!RequestsDrawItself)
+                                if (this == null || this._disposed)
+                                {
+                                    this.Stop();
+                                    return;
+                                }
+
                                 this.UpdateLayeredWindow();
+                            }
                         }
-                    }
 
-                    this.Stop();
-                }).Start();
+                        this.Stop();
+                    }).Start();
+                }
             }
             catch (Exception ex) { Debug.WriteLine(ex); }
         }


### PR DESCRIPTION
The update thread now measures the time it took to refresh the overlay so it can match the set refresh rate precisely.