### PR TITLE
Add tyre pressure loss on TyreInfoOverlay

### DIFF
--- a/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
+++ b/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Tracks\Data\Zandvoort.cs" />
     <Compile Include="Tracks\Data\Zolder.cs" />
     <Compile Include="Tracks\TrackData.cs" />
+    <Compile Include="Tyres\TyresTracker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Race_Element.Data.ACC/Tracker/TrackerDispose.cs
+++ b/Race_Element.Data.ACC/Tracker/TrackerDispose.cs
@@ -2,6 +2,7 @@
 using RaceElement.Data.ACC.EntryList;
 using RaceElement.Data.ACC.Session;
 using RaceElement.Data.ACC.Tracker.Laps;
+using RaceElement.Data.ACC.Tyres;
 using System.Diagnostics;
 
 namespace RaceElement.Data.ACC.Tracker
@@ -19,6 +20,7 @@ namespace RaceElement.Data.ACC.Tracker
 
             RaceSessionTracker.Instance.Stop();
             LapTracker.Instance.Stop();
+            TyresTracker.Instance.Stop();
 
             RaceWeekendDatabase.Close();
         }

--- a/Race_Element.Data.ACC/Tracker/TrackerStarter.cs
+++ b/Race_Element.Data.ACC/Tracker/TrackerStarter.cs
@@ -1,5 +1,6 @@
 ﻿using RaceElement.Data.ACC.Session;
 using RaceElement.Data.ACC.Tracker.Laps;
+using RaceElement.Data.ACC.Tyres;
 using System.Diagnostics;
 using System.Threading;
 
@@ -13,6 +14,7 @@ namespace RaceElement.Data.ACC.Tracker
             {
                 _ = LapTracker.Instance;
                 _ = RaceSessionTracker.Instance;
+                _ = TyresTracker.Instance;
 
                 Debug.WriteLine("Started ACC.Trackers");
 

--- a/Race_Element.Data.ACC/Tyres/TyresTracker.cs
+++ b/Race_Element.Data.ACC/Tyres/TyresTracker.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using RaceElement.Util;
+
+namespace RaceElement.Data.ACC.Tyres
+{
+    public class TyresTracker
+    {
+        public class TyresInfo
+        {
+            public float[] PressureLoss { get; internal set; }
+        }
+
+        private static TyresTracker _instance;
+
+        public static TyresTracker Instance
+        {
+            get { return _instance ??= new TyresTracker(); }
+        }
+
+        public event EventHandler<TyresInfo> OnTyresInfoChanged;
+
+        private bool _isTracking;
+        private float[] _lastPressureReading;
+        private float[] _lastPressureLosses = { 0, 0, 0, 0 };
+        private int _lastTyreSetIndexValue;
+        private bool _isInPitLane = false;
+
+        private TyresTracker()
+        {
+            if (!_isTracking)
+                Start();
+        }
+
+        public static TyresInfo GetPreviewTyresInfo()
+        {
+            return new TyresInfo
+            {
+                PressureLoss = new[] { 0.12f, 0.23f, 0.34f, 0.45f }
+            };
+        }
+
+        private void Start()
+        {
+            if (_isTracking)
+                return;
+
+            _isTracking = true;
+            new Thread(x =>
+            {
+                ResetPressureLosses();
+                SendTyresInfoUpdate();
+
+                while (_isTracking)
+                {
+                    try
+                    {
+                        Thread.Sleep(100);
+
+                        var physicsPage = ACCSharedMemory.Instance.ReadPhysicsPageFile(true);
+                        float[] currentReading = physicsPage.WheelPressure;
+
+                        var graphicsPage = ACCSharedMemory.Instance.ReadGraphicsPageFile(true);
+                        int currentTyreSetIndex = graphicsPage.currentTyreSet;
+                        CheckTyreSetChange(currentTyreSetIndex);
+                        CheckWetTyreSetChange(graphicsPage);
+
+                        _isInPitLane = graphicsPage.IsInPitLane;
+                        if (!_isInPitLane)
+                            UpdatePressureLosses(currentReading);
+
+                        _lastPressureReading = currentReading;
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"TyresTracker: {ex}");
+                        LogWriter.WriteToLog($"TyresTracker: {ex}");
+                    }
+                }
+
+                _instance = null;
+                _isTracking = false;
+            }).Start();
+        }
+
+        internal void Stop()
+        {
+            _isTracking = false;
+        }
+
+        private void ResetPressureLosses()
+        {
+            _lastPressureLosses = new float[] { 0, 0, 0, 0 };
+        }
+
+        private void SendTyresInfoUpdate()
+        {
+            TyresInfo tyresInfo = new TyresInfo
+            {
+                PressureLoss = _lastPressureLosses
+            };
+
+            Debug.WriteLine($"TyresTracker: TyresInfo changed: | PressureLoss: [{string.Join(", ", tyresInfo.PressureLoss)}]");
+
+            OnTyresInfoChanged?.Invoke(this, tyresInfo);
+        }
+
+        private void UpdatePressureLosses(IEnumerable<float> currentReading)
+        {
+            if (_lastPressureReading == null)
+                return;
+
+            float[] pressureVariation = _lastPressureReading
+                .Zip(currentReading, (last, current) => current - last)
+                .ToArray();
+
+            if (pressureVariation.Sum() == 0)
+                return;
+
+            // Debug.WriteLine($"TyresTracker: Pressure variation: [{string.Join(", ", pressureVariation)}]");
+
+            bool hasLostPressure = false;
+            for (int i = 0; i < 4; ++i)
+            {
+                if (!(pressureVariation[i] <= -0.03f) || !(pressureVariation[i] > -3f))
+                    continue;
+
+                _lastPressureLosses[i] += pressureVariation[i] * -1;
+                hasLostPressure = true;
+            }
+
+            if (hasLostPressure)
+                SendTyresInfoUpdate();
+        }
+
+        private void CheckTyreSetChange(int currentTyreSetIndex)
+        {
+            var hasTyreSetChanged = _lastTyreSetIndexValue != currentTyreSetIndex;
+            if (!hasTyreSetChanged)
+                return;
+
+            Debug.WriteLine($"TyresTracker: Tyre set has changed from [{_lastTyreSetIndexValue.ToString()}] to [{currentTyreSetIndex.ToString()}]");
+
+            ResetPressureLosses();
+            SendTyresInfoUpdate();
+            _lastTyreSetIndexValue = currentTyreSetIndex;
+        }
+
+        private void CheckWetTyreSetChange(ACCSharedMemory.SPageFileGraphic graphicsPage)
+        {
+            bool hasLeftPitlane = _isInPitLane && !graphicsPage.IsInPitLane;
+
+            if (graphicsPage.TyreCompound != "wet_compound" || !hasLeftPitlane)
+                return;
+
+            // Workaround as wet tyre sets have no index to check
+            Debug.WriteLine("TyresTracker: Reset pressure loss as leaving pit lane with a wet set on is considered as a new set");
+            ResetPressureLosses();
+            SendTyresInfoUpdate();
+        }
+    }
+}

--- a/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
@@ -63,6 +63,10 @@ namespace RaceElement.HUD.Overlay.Internal
             catch (Exception) { }
         }
 
+        public virtual void SetupPreviewData()
+        {
+        }
+
         public bool DefaultShouldRender()
         {
             if (HudSettings.Cached.DemoMode)

--- a/Race_Element/Controls/HUD/PreviewCache.cs
+++ b/Race_Element/Controls/HUD/PreviewCache.cs
@@ -121,6 +121,7 @@ namespace RaceElement.Controls.HUD
             overlay.pageStatic.CarModel = "porsche_991ii_gt3_r";
             overlay.pageStatic.Track = "Spa";
 
+            overlay.SetupPreviewData();
 
             try
             {


### PR DESCRIPTION
This PR adds the ability to display the loss of pressure per tyre.

A had to use a workaround for the wet tyre sets, as I'm using the index of the tyre set to check if it has changed in order to reset the pressure losses. The wet tyre sets **do not have an index**, so I'm always assuming that leaving the pitlane with a wet set on is to be considered as a new set and thus, reseting the pressure losses.

If you have a better idea to handle this edge case, I'm all ears! 

I also added a way to compute some arbitrary data when building an overlay's preview, which can be used when relying on a tracker's internal data.

**Preview**
![image](https://user-images.githubusercontent.com/31368191/222983121-e63176b4-0cb4-4f87-9cd9-cd1e7550a876.png)

**In-game**
![image](https://user-images.githubusercontent.com/31368191/222983126-642664f8-9002-4f54-a36a-2fe9c130ce98.png)

We could use this new TyreTracker on the pressure graph overlay too I guess.