### PR TITLE
version 0.1.9.6

### DIFF
--- a/Race_Element.Data.ACC/Tyres/TyresTracker.cs
+++ b/Race_Element.Data.ACC/Tyres/TyresTracker.cs
@@ -69,22 +69,17 @@ namespace RaceElement.Data.ACC.Tyres
                         CheckTyreSetChange(currentTyreSetIndex);
                         CheckWetTyreSetChange(graphicsPage);
 
-                        _isInPitLane = graphicsPage.IsInPitLane;
-                        if (_isInPitLane)
+                        if (graphicsPage.IsSetupMenuVisible)
                         {
-                            // Assume that during a practice session you always exit the pits with fresh tyres.
-                            if (graphicsPage.SessionType == ACCSharedMemory.AcSessionType.AC_PRACTICE)
-                            {
-                                ResetPressureLosses();
-                                SendTyresInfoUpdate();
-                            }
+                            ResetPressureLosses();
+                            SendTyresInfoUpdate();
                         }
                         else
                         {
-                            UpdatePressureLosses(currentReading);
+                            _isInPitLane = graphicsPage.IsInPitLane;
+                            if (!_isInPitLane)
+                                UpdatePressureLosses(currentReading);
                         }
-
-
 
                         _lastPressureReading = currentReading;
                     }
@@ -157,7 +152,7 @@ namespace RaceElement.Data.ACC.Tyres
             if (!hasTyreSetChanged)
                 return;
 
-            Debug.WriteLine($"TyresTracker: Tyre set has changed from [{_lastTyreSetIndexValue.ToString()}] to [{currentTyreSetIndex.ToString()}]");
+            Debug.WriteLine($"TyresTracker: Tyre set has changed from [{_lastTyreSetIndexValue}] to [{currentTyreSetIndex}]");
 
             ResetPressureLosses();
             SendTyresInfoUpdate();

--- a/Race_Element.Data.ACC/Tyres/TyresTracker.cs
+++ b/Race_Element.Data.ACC/Tyres/TyresTracker.cs
@@ -70,8 +70,21 @@ namespace RaceElement.Data.ACC.Tyres
                         CheckWetTyreSetChange(graphicsPage);
 
                         _isInPitLane = graphicsPage.IsInPitLane;
-                        if (!_isInPitLane)
+                        if (_isInPitLane)
+                        {
+                            // Assume that during a practice session you always exit the pits with fresh tyres.
+                            if (graphicsPage.SessionType == ACCSharedMemory.AcSessionType.AC_PRACTICE)
+                            {
+                                ResetPressureLosses();
+                                SendTyresInfoUpdate();
+                            }
+                        }
+                        else
+                        {
                             UpdatePressureLosses(currentReading);
+                        }
+
+
 
                         _lastPressureReading = currentReading;
                     }

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayDamage/DamageOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayDamage/DamageOverlay.cs
@@ -5,7 +5,6 @@ using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.Configuration;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.Util;
-using System.IO;
 using RaceElement.Util.SystemExtensions;
 
 namespace RaceElement.HUD.ACC.Overlays.OverlayDamage
@@ -18,6 +17,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayDamage
         private readonly DamageConfiguration _config = new DamageConfiguration();
         private sealed class DamageConfiguration : OverlayConfiguration
         {
+            public DamageConfiguration() => AllowRescale = true;
+
             [ConfigGrouping("Damage", "Changes the behavior of the Damage HUD")]
             public DamageGrouping Damage { get; set; } = new DamageGrouping();
             public class DamageGrouping
@@ -27,11 +28,6 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayDamage
 
                 [ToolTip("Only show the HUD when there is actual damage on the car.")]
                 public bool AutoHide { get; set; } = true;
-            }
-
-            public DamageConfiguration()
-            {
-                AllowRescale = true;
             }
         }
 
@@ -64,20 +60,20 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayDamage
 
         public DamageOverlay(Rectangle rectangle) : base(rectangle, "Damage")
         {
-            this.RefreshRateHz = 1;
-
-            this.Width = OriginalWidth;
-            this.Height = OriginalHeight;
+            Width = OriginalWidth;
+            Height = OriginalHeight;
+            RefreshRateHz = 1;
         }
 
         public override void BeforeStart()
         {
+            int scaledWidth = (int)(this.Width * this.Scale) - 1;
+            int scaledHeight = (int)(this.Height * this.Scale) - 1;
+
             _font = FontUtil.FontSegoeMono(11 * this.Scale);
 
             CreatePathShapes();
 
-            int scaledWidth = (int)(this.Width * this.Scale) - 1;
-            int scaledHeight = (int)(this.Height * this.Scale) - 1;
             _carOutline = new CachedBitmap(scaledWidth, scaledHeight, g =>
             {
                 float horizontalPadding = scaledWidth * 0.05f;

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayEcuMapInfo/EcuMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayEcuMapInfo/EcuMapOverlay.cs
@@ -12,7 +12,7 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayEcuMapInfo
         private const int PanelWidth = 270;
         private readonly InfoPanel _panel = new InfoPanel(10, PanelWidth);
 
-        private EcuMapConfiguration _config = new EcuMapConfiguration();
+        private readonly EcuMapConfiguration _config = new EcuMapConfiguration();
         private sealed class EcuMapConfiguration : OverlayConfiguration
         {
             [ConfigGrouping("Info Panel", "Show or hide additional information in the panel.")]
@@ -57,7 +57,6 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayEcuMapInfo
             {
                 _panel.AddLine("Car", "Not supported");
                 _panel.AddLine("Model", pageStatic.CarModel);
-                _panel.AddLine("Condition", "");
                 _panel.AddLine("Map", $"{pageGraphics.EngineMap + 1}");
             }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayFuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayFuelInfo/FuelInfoOverlay.cs
@@ -7,9 +7,9 @@ using System.Drawing;
 
 namespace RaceElement.HUD.ACC.Overlays.OverlayFuelInfo
 {
-    [Overlay(Name = "Fuel Info", 
+    [Overlay(Name = "Fuel Info",
         Description = "A panel showing information about the fuel: laps left, fuel to end of race. Optionally showing stint information.",
-        Version = 1.00, 
+        Version = 1.00,
         OverlayType = OverlayType.Release,
         OverlayCategory = OverlayCategory.Car)]
     internal sealed class FuelInfoOverlay : AbstractOverlay
@@ -32,6 +32,9 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayFuelInfo
 
                 [ToolTip("Displays stint time remaining and the suggested amount of fuel to the end of the stint or the session.")]
                 public bool StintInfo { get; set; } = true;
+
+                [ToolTip("When viewing the setup menu it will still display the HUD.\nOverriding the default.")]
+                public bool ShowInSetup { get; set; } = false;
             }
 
             [ConfigGrouping("Colors", "Adjust colors for the fuel bar.")]
@@ -75,6 +78,14 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayFuelInfo
 
             if (!_config.InfoPanel.FuelTime)
                 this.Height -= _infoPanel.FontHeight;
+        }
+
+        public sealed override bool ShouldRender()
+        {
+            if (_config.InfoPanel.ShowInSetup && pageGraphics.IsSetupMenuVisible)
+                return true;
+
+            return base.ShouldRender();
         }
 
         public sealed override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayTyreInfo/TyreInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayTyreInfo/TyreInfoOverlay.cs
@@ -37,7 +37,7 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayTyreInfo
 
                 [ToolTip("Defines the amount of decimals for the tyre pressure text.")]
                 [IntRange(1, 2, 1)]
-                public int Decimals { get; set; } = 1;
+                public int Decimals { get; set; } = 2;
             }
 
             public TyreInfoConfig()

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
-            {"0.1.9.6", "- TODO!." },
+            {"0.1.9.6", "- Reset tyre pressure loss in free practice sessions when visiting the setup screen." },
             {"0.1.9.4", "- Race Element GUI: Set Default Window Opacity to 100%, now only transparent whilst dragging."+
                         "\n- You can now drag and drop setups from the web directly ontop of race element(for example from discord). It will download it for you and show it in the importer."+
                         "\n- Lap Info HUD: removed lap delta bar as there is a lap delta HUD."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,8 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.1.9.6", "- Reset tyre pressure loss in free practice sessions when visiting the setup screen in-game."+
-                        "\n- Fuel Info HUD: Added option to show the hud when viewing the setup screen in-game."},
+                        "\n- Fuel Info HUD: Added option to show the hud when viewing the setup screen in-game."+
+                        "\n- Tyre Info HUD: Set default amount of decimals to 2."},
             {"0.1.9.4", "- Race Element GUI: Set Default Window Opacity to 100%, now only transparent whilst dragging."+
                         "\n- You can now drag and drop setups from the web directly ontop of race element(for example from discord). It will download it for you and show it in the importer."+
                         "\n- Lap Info HUD: removed lap delta bar as there is a lap delta HUD."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
-            {"0.1.9.6", "- Reset tyre pressure loss in free practice sessions when visiting the setup screen." },
+            {"0.1.9.6", "- Reset tyre pressure loss in free practice sessions when visiting the setup screen in-game."+
+                        "\n- Fuel Info HUD: Added option to show the hud when viewing the setup screen in-game."},
             {"0.1.9.4", "- Race Element GUI: Set Default Window Opacity to 100%, now only transparent whilst dragging."+
                         "\n- You can now drag and drop setups from the web directly ontop of race element(for example from discord). It will download it for you and show it in the importer."+
                         "\n- Lap Info HUD: removed lap delta bar as there is a lap delta HUD."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -8,7 +8,8 @@ namespace RaceElement.Controls
         {
             {"0.1.9.6", "- Reset tyre pressure loss in free practice sessions when visiting the setup screen in-game."+
                         "\n- Fuel Info HUD: Added option to show the hud when viewing the setup screen in-game."+
-                        "\n- Tyre Info HUD: Set default amount of decimals to 2."},
+                        "\n- Tyre Info HUD: Set default amount of decimals to 2."+
+                        "\n- Data Tab: Now opens current month automatically in the tree view."},
             {"0.1.9.4", "- Race Element GUI: Set Default Window Opacity to 100%, now only transparent whilst dragging."+
                         "\n- You can now drag and drop setups from the web directly ontop of race element(for example from discord). It will download it for you and show it in the importer."+
                         "\n- Lap Info HUD: removed lap delta bar as there is a lap delta HUD."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
+            {"0.1.9.6", "- TODO!." },
             {"0.1.9.4", "- Race Element GUI: Set Default Window Opacity to 100%, now only transparent whilst dragging."+
                         "\n- You can now drag and drop setups from the web directly ontop of race element(for example from discord). It will download it for you and show it in the importer."+
                         "\n- Lap Info HUD: removed lap delta bar as there is a lap delta HUD."},

--- a/Race_Element/Controls/Telemetry/RaceSessions/RaceSessionBrowser.xaml.cs
+++ b/Race_Element/Controls/Telemetry/RaceSessions/RaceSessionBrowser.xaml.cs
@@ -100,6 +100,8 @@ namespace RaceElement.Controls
                 {
                     localRaceWeekends.Items.Clear();
 
+                    DateTime now = DateTime.Now;
+
                     Thickness itemThickness = new Thickness(2, 5, 2, 5);
                     foreach (var yearGroup in yearGroupings)
                     {
@@ -109,6 +111,9 @@ namespace RaceElement.Controls
                             Cursor = Cursors.Hand,
                             Padding = itemThickness,
                         };
+                        if (yearGroup.Key == now.Year)
+                            yearItem.IsExpanded = true;
+
                         localRaceWeekends.Items.Add(yearItem);
 
                         var monthGroupings = yearGroup.GroupBy(x => x.CreationTimeUtc.Month);
@@ -120,6 +125,8 @@ namespace RaceElement.Controls
                                 Cursor = Cursors.Hand,
                                 Padding = itemThickness,
                             };
+                            if (yearItem.IsExpanded && monthGroup.Key == now.Month)
+                                monthItem.IsExpanded = true;
                             yearItem.Items.Add(monthItem);
 
                             foreach (var file in monthGroup.OrderByDescending(x => x.CreationTimeUtc))

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.1.9.4")]
-[assembly: AssemblyFileVersion("0.1.9.4")]
+[assembly: AssemblyVersion("0.1.9.5")]
+[assembly: AssemblyFileVersion("0.1.9.5")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.1.9.5")]
-[assembly: AssemblyFileVersion("0.1.9.5")]
+[assembly: AssemblyVersion("0.1.9.6")]
+[assembly: AssemblyFileVersion("0.1.9.6")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -116,8 +116,8 @@
     <PackageReference Include="DdsFileTypePlusHack" Version="1.0.4" />
     <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="all" />
     <PackageReference Include="LiteDB" Version="5.0.16" />
-    <PackageReference Include="MaterialDesignColors" Version="2.1.2" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
+    <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -154,8 +154,8 @@
     <PackageReference Include="Quartz" Version="3.6.2" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
-    <PackageReference Include="ScottPlot" Version="4.1.63" />
-    <PackageReference Include="ScottPlot.WPF" Version="4.1.63" />
+    <PackageReference Include="ScottPlot" Version="4.1.64" />
+    <PackageReference Include="ScottPlot.WPF" Version="4.1.64" />
     <PackageReference Include="SharpCompress" Version="0.33.0" />
     <PackageReference Include="SLOBSharp" Version="1.1.4" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />


### PR DESCRIPTION
- Reset tyre pressure loss in free practice sessions when visiting the setup screen in-game.
- Fuel Info HUD: Added option to show the hud when viewing the setup screen in-game.
- Tyre Info HUD: Set default amount of decimals to 2.
- Data Tab: Now opens current month automatically in the tree view.