### PR TITLE
PR: version 0.2.0.2

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayLapTimeDelta/LapTimeDeltaOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayLapTimeDelta/LapTimeDeltaOverlay.cs
@@ -99,10 +99,11 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayLapDelta
             float delta = (float)pageGraphics.DeltaLapTimeMillis / 1000;
             delta.Clip(-_config.Delta.MaxDelta, _config.Delta.MaxDelta);
 
+            float halfBarWidth = _config.Bar.Width / 2f;
+
             if (delta > 0)
             {
                 float fillPercent = delta / _config.Delta.MaxDelta;
-                float halfBarWidth = _config.Bar.Width / 2f;
                 float drawWidth = halfBarWidth * fillPercent;
                 drawWidth.ClipMin(1);
 
@@ -113,7 +114,6 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayLapDelta
             if (delta < 0)
             {
                 float fillPercent = delta / -_config.Delta.MaxDelta;
-                float halfBarWidth = _config.Bar.Width / 2f;
                 float drawWidth = halfBarWidth * fillPercent;
                 drawWidth.ClipMin(1);
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayLapTimeDelta/LapTimeDeltaOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayLapTimeDelta/LapTimeDeltaOverlay.cs
@@ -138,7 +138,7 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayLapDelta
 
             int x = _config.Bar.Width / 2;
             int y = _config.Bar.Height + 2;
-            DrawTextWithOutline(g, Color.White, currentDelta, x, y);
+            DrawTextWithOutline(g, pageGraphics.IsValidLap ? Color.White : Color.Red, currentDelta, x, y);
         }
 
         private void DrawTextWithOutline(Graphics g, Color textColor, string text, int x, int y)

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayWheelSlip/WheelSlipOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayWheelSlip/WheelSlipOverlay.cs
@@ -25,6 +25,10 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayWheelSlip
                 [ToolTip("Adjust maximum amount of wheel slip displayed.")]
                 [FloatRange(0.5f, 10f, 0.1f, 1)]
                 public float MaxSlipAmount { get; set; } = 2f;
+
+                [ToolTip("Adjust the amount of slip required to show either over or understeer colors.\nThis is blue for understeer and red for oversteer.")]
+                [FloatRange(0.1f, 1.5f, 0.1f, 1)]
+                public float IndicatorOffset { get; set; } = 0.3f;
             }
 
             [ConfigGrouping("Shape", "Adjust the shape.")]
@@ -100,8 +104,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayWheelSlip
             float slipRatioFront = (pagePhysics.WheelSlip[(int)Wheel.FrontLeft] + pagePhysics.WheelSlip[(int)Wheel.FrontRight]) / 2;
             float slipRatioRear = (pagePhysics.WheelSlip[(int)Wheel.RearLeft] + pagePhysics.WheelSlip[(int)Wheel.RearRight]) / 2;
 
-            bool isUnderSteering = slipRatioFront > slipRatioRear + 0.3;
-            bool isOverSteering = slipRatioRear > slipRatioFront + 0.3;
+            bool isUnderSteering = slipRatioFront > slipRatioRear + _config.Data.IndicatorOffset;
+            bool isOverSteering = slipRatioRear > slipRatioFront + _config.Data.IndicatorOffset;
 
             Color oversteer = Color.FromArgb(185, 255, 0, 0);
             Color understeer = Color.FromArgb(185, 0, 0, 255);

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayWheelSlip/WheelSlipOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayWheelSlip/WheelSlipOverlay.cs
@@ -97,13 +97,23 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayWheelSlip
             int wheelSize = _config.Shape.WheelSize;
             int gap = 8;
 
-            DrawWheelSlip(g, baseX + 0, baseY + 0, wheelSize, Wheel.FrontLeft);
-            DrawWheelSlip(g, baseX + wheelSize + gap, baseY + 0, wheelSize, Wheel.FrontRight);
-            DrawWheelSlip(g, baseX + 0, baseY + wheelSize + gap, wheelSize, Wheel.RearLeft);
-            DrawWheelSlip(g, baseX + wheelSize + gap, baseY + wheelSize + gap, wheelSize, Wheel.RearRight);
+            float slipRatioFront = (pagePhysics.WheelSlip[(int)Wheel.FrontLeft] + pagePhysics.WheelSlip[(int)Wheel.FrontRight]) / 2;
+            float slipRatioRear = (pagePhysics.WheelSlip[(int)Wheel.RearLeft] + pagePhysics.WheelSlip[(int)Wheel.RearRight]) / 2;
+
+            bool isUnderSteering = slipRatioFront > slipRatioRear + 0.3;
+            bool isOverSteering = slipRatioRear > slipRatioFront + 0.3;
+
+            Color oversteer = Color.FromArgb(185, 255, 0, 0);
+            Color understeer = Color.FromArgb(185, 0, 0, 255);
+            Color neutral = Color.FromArgb(185, 255, 255, 255);
+
+            DrawWheelSlip(g, baseX + 0, baseY + 0, wheelSize, Wheel.FrontLeft, isUnderSteering ? understeer : neutral);
+            DrawWheelSlip(g, baseX + wheelSize + gap, baseY + 0, wheelSize, Wheel.FrontRight, isUnderSteering ? understeer : neutral);
+            DrawWheelSlip(g, baseX + 0, baseY + wheelSize + gap, wheelSize, Wheel.RearLeft, isOverSteering ? oversteer : neutral);
+            DrawWheelSlip(g, baseX + wheelSize + gap, baseY + wheelSize + gap, wheelSize, Wheel.RearRight, isOverSteering ? oversteer : neutral);
         }
 
-        private void DrawWheelSlip(Graphics g, int x, int y, int size, Wheel wheel)
+        private void DrawWheelSlip(Graphics g, int x, int y, int size, Wheel wheel, Color color)
         {
             var wheelRect = new Rectangle(x, y, size, size);
 
@@ -124,7 +134,7 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayWheelSlip
             using GraphicsPath gradientPath = new GraphicsPath();
             gradientPath.AddEllipse(wheelRect);
             using PathGradientBrush pthGrBrush = new PathGradientBrush(gradientPath);
-            pthGrBrush.CenterColor = Color.FromArgb(185, 255, 0, 0);
+            pthGrBrush.CenterColor = color;
             pthGrBrush.SurroundColors = new Color[] { Color.FromArgb(40, 0, 0, 0) };
 
             g.FillEllipse(pthGrBrush, centerX, centerY, size / 2 * percentage / 100);

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
@@ -269,7 +269,7 @@ Description = "(BETA) A table representing a leaderboard.")]
                             }
                         }
 
-                        firstRow[3] = $"L{kv.Value.RealtimeCarUpdate.Laps} | ";
+                        firstRow[3] = $"L{kv.Value.RealtimeCarUpdate.Laps + 1} | ";
 
                         if (Tracks.Any())
                         {
@@ -408,7 +408,7 @@ Description = "(BETA) A table representing a leaderboard.")]
                                         if (b.Value.RealtimeCarUpdate.CarLocation == CarLocationEnum.Pitlane || b.Value.RealtimeCarUpdate.CarLocation == CarLocationEnum.NONE)
                                             bSpline = 0;
 
-                                  
+
 
                                         var aLaps = a.Value.RealtimeCarUpdate.Laps;
                                         var bLaps = b.Value.RealtimeCarUpdate.Laps;

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,8 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.2.0.2", "- Laptime Delta HUD: text turns red on invalidated lap."+
-                        "\n- All steering locks are now displayed in the Settings -> Hardware tab."},
+                        "\n- All steering locks are now displayed in the Settings -> Hardware tab."+
+                        "\n- Wheel Slip HUD: Add slip offset to configuration, this allows you to configure the amount of over/under-steer before colors indicate either of them."},
             {"0.2.0.0", "- Fix 296 GT3 steering, now 800." },
             {"0.1.9.8", "- Steering Locks: Added McLaren 720s Evo GT3 and updated Ferrari 296 GT3."+
                         "\n- Setup Viewer: Added support for new McLaren 720s Evo GT3."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
+            {"0.2.0.2", "- Laptime Delta HUD: text turns red on invalidated lap." },
             {"0.2.0.0", "- Fix 296 GT3 steering, now 800." },
             {"0.1.9.8", "- Steering Locks: Added McLaren 720s Evo GT3 and updated Ferrari 296 GT3."+
                         "\n- Setup Viewer: Added support for new McLaren 720s Evo GT3."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
-            {"0.2.0.2", "- Laptime Delta HUD: text turns red on invalidated lap." },
+            {"0.2.0.2", "- Laptime Delta HUD: text turns red on invalidated lap."+
+                        "\n- All steering locks are now displayed in the Settings -> Hardware tab."},
             {"0.2.0.0", "- Fix 296 GT3 steering, now 800." },
             {"0.1.9.8", "- Steering Locks: Added McLaren 720s Evo GT3 and updated Ferrari 296 GT3."+
                         "\n- Setup Viewer: Added support for new McLaren 720s Evo GT3."},

--- a/Race_Element/Controls/Settings/Hardware.xaml
+++ b/Race_Element/Controls/Settings/Hardware.xaml
@@ -7,7 +7,11 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Center">
             <Label HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="18">Automatic Steering Hard Lock</Label>
             <TextBlock TextAlignment="Left">
                 In ACC, set the steering rotation in-game to 10.<LineBreak/>
@@ -23,6 +27,22 @@
                 <Label VerticalAlignment="Center">Enable Automatic Steering Hard Lock</Label>
             </StackPanel>
             <Button x:Name="buttonCheckSteeringLockSupport" Margin="0,5,0,0">Check whether wheelbase is supported</Button>
+
+
         </StackPanel>
+
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30"/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Label Grid.Row="0" FontSize="16" Content="All Steering locks, Lock to Lock. (when your hardware is not supported)"/>
+
+            <ScrollViewer Grid.Row="1">
+                <StackPanel x:Name="stackerAllLocks">
+
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
     </Grid>
 </UserControl>

--- a/Race_Element/Controls/Settings/Hardware.xaml.cs
+++ b/Race_Element/Controls/Settings/Hardware.xaml.cs
@@ -4,6 +4,11 @@ using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using RaceElement.Data.ACC.Cars;
+using static RaceElement.Data.ConversionFactory;
+using SharpCompress;
+using RaceElement.Data;
+using System.Linq;
 
 namespace RaceElement.Controls
 {
@@ -22,7 +27,11 @@ namespace RaceElement.Controls
             buttonCheckSteeringLockSupport.Click += ButtonCheckSteeringLockSupport_Click;
 
             _hardwareSettings = new HardwareSettings();
-            this.Loaded += (s, e) => LoadSettings();
+            this.Loaded += (s, e) =>
+            {
+                PopulateSteeringLocks();
+                LoadSettings();
+            };
         }
 
         private void ButtonCheckSteeringLockSupport_Click(object sender, RoutedEventArgs e)
@@ -57,6 +66,30 @@ namespace RaceElement.Controls
             SteeringLockTracker.Instance.StartTracking();
             TitleBar.Instance.SetIcons(TitleBar.ActivatedIcons.AutomaticSteeringHardLock, true);
             //MainWindow.Instance.EnqueueSnackbarMessage("Enabled automatic hardware steering lock.");
+        }
+
+        private void PopulateSteeringLocks()
+        {
+            stackerAllLocks.Children.Clear();
+
+            CarModels[] carModels = (CarModels[])Enum.GetValues(typeof(CarModels));
+            carModels.ForEach(carModel =>
+            {
+                var search = ConversionFactory.ParseNames.Where(x => x.Value == carModel);
+                if (search.Any())
+                {
+                    int lockToLock = SteeringLock.Get(search.First().Key);
+                    string carName = ConversionFactory.GetNameFromCarModel(carModel);
+
+                    Label label = new Label()
+                    {
+                        Content = $"{lockToLock} - {carName}",
+                    };
+                    stackerAllLocks.Children.Add(label);
+                }
+
+
+            });
         }
 
         private void LoadSettings()

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.2.0.1")]
+[assembly: AssemblyFileVersion("0.2.0.1")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.0.1")]
-[assembly: AssemblyFileVersion("0.2.0.1")]
+[assembly: AssemblyVersion("0.2.0.2")]
+[assembly: AssemblyFileVersion("0.2.0.2")]
 [assembly: NeutralResourcesLanguage("")]


### PR DESCRIPTION
- Laptime Delta HUD: text turns red on invalidated lap.
- All steering locks are now displayed in the Settings -> Hardware tab.
- Wheel Slip HUD: Add slip offset to configuration, this allows you to configure the amount of over/under-steer before colors indicate either of them.