### PR TITLE
0.2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ![Race Element - Name](https://user-images.githubusercontent.com/4581237/209894151-3f8a5dc5-45de-4d7c-a46a-8c5a2a57cd91.png)
 
 
-[![Build status](https://ci.appveyor.com/api/projects/status/wnbn1pdscccqwegg?svg=true)](https://ci.appveyor.com/project/RiddleTime/race-element)
 [![Discord](https://badgen.net/discord/members/26AAEW5mUq?icon=discord&color=5562ea&label=Race%20Element)](https://discord.gg/26AAEW5mUq)
 [![Hits](https://hits.seeyoufarm.com/api/count/keep/badge.svg?url=https%3A%2F%2Fgithub.com%2FRiddleTime%2FRace-Element&count_bg=%23FF4500&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=Usage%3A+Today+%2F+All-time&edge_flat=false)](https://hits.seeyoufarm.com)
 

--- a/Race_Element.Data.ACC/Config/CameraSettingService.cs
+++ b/Race_Element.Data.ACC/Config/CameraSettingService.cs
@@ -1,0 +1,176 @@
+﻿using Newtonsoft.Json;
+using RaceElement.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.Data.ACC.Config
+{
+    public class CameraSettingService
+    {
+        private readonly CameraSettings cameraSettings = new CameraSettings();
+
+        public CameraSettingService()
+        {
+            var json = cameraSettings.Get(false);
+            if (json != null)
+                Debug.WriteLine(JsonConvert.SerializeObject(json, Formatting.Indented));
+        }
+
+        public CameraSettings Settings() => cameraSettings;
+
+        public void ResetTvCamSettings()
+        {
+            var settings = cameraSettings.Get(false);
+
+            settings.TVCamFocusedAperture = 2.7999999523162842;
+            settings.TVCamStaticAperture = 16;
+            settings.TVCamStaticFocusDistance = 100000;
+            settings.TVCamConstrainAspectRatio = 0;
+
+            cameraSettings.Save(settings);
+        }
+
+        public void ResetHelicamCamera()
+        {
+            var settings = cameraSettings.Get(false);
+
+            settings.HelicamDistance = 6000;
+            settings.HelicamFOV = 60;
+            settings.HelicamTargetMoreCars = 1;
+            settings.HelicamTargetCarsMaxDist = 2000;
+            settings.HelicamTargetInterpTime = 1;
+
+            cameraSettings.Save(settings);
+        }
+
+        public class CameraSettings : AbstractSettingsJson<CameraSettingsJson>
+        {
+            public override string Path => FileUtil.AccConfigPath;
+
+            public override string FileName => "cameraSettings.json";
+
+            public override CameraSettingsJson Default()
+            {
+                return new CameraSettingsJson();
+            }
+        }
+
+        public class CameraSettingsJson : IGenericSettingsJson
+        {
+            [JsonProperty("version")]
+            public int Version { get; set; }
+
+            [JsonProperty("lastUsedCamIndex")]
+            public int LastUsedCamIndex { get; set; }
+
+            [JsonProperty("lastUsedOnboardIndex")]
+            public int LastUsedOnboardIndex { get; set; }
+
+            [JsonProperty("generalMovement")]
+            public int GeneralMovement { get; set; }
+
+            [JsonProperty("onboardMovement")]
+            public int OnboardMovement { get; set; }
+
+            [JsonProperty("dashcamFactor")]
+            public double DashcamFactor { get; set; }
+
+            [JsonProperty("panniniProjection")]
+            public int PanniniProjection { get; set; }
+
+            [JsonProperty("helicamDistance")]
+            public int HelicamDistance { get; set; }
+
+            [JsonProperty("helicamFOV")]
+            public int HelicamFOV { get; set; }
+
+            [JsonProperty("helicamTargetMoreCars")]
+            public int HelicamTargetMoreCars { get; set; }
+
+            [JsonProperty("helicamTargetCarsMaxDist")]
+            public int HelicamTargetCarsMaxDist { get; set; }
+
+            [JsonProperty("helicamTargetInterpTime")]
+            public int HelicamTargetInterpTime { get; set; }
+
+            [JsonProperty("helicamDebug")]
+            public int HelicamDebug { get; set; }
+
+            [JsonProperty("cameraFOV")]
+            public List<int> CameraFOV { get; set; }
+
+            [JsonProperty("mapCarCameraData")]
+            public object MapCarCameraData { get; set; }
+
+            [JsonProperty("lookWithSteerGain")]
+            public int LookWithSteerGain { get; set; }
+
+            [JsonProperty("lookWithSteerGamma")]
+            public double LookWithSteerGamma { get; set; }
+
+            [JsonProperty("lookWithSteerSmoothing")]
+            public double LookWithSteerSmoothing { get; set; }
+
+            [JsonProperty("lookAroundSpeed")]
+            public int LookAroundSpeed { get; set; }
+
+            [JsonProperty("horizonLock")]
+            public double HorizonLock { get; set; }
+
+            [JsonProperty("enableTrackIR")]
+            public int EnableTrackIR { get; set; }
+
+            [JsonProperty("tripleWidth")]
+            public int TripleWidth { get; set; }
+
+            [JsonProperty("tripleDistance")]
+            public int TripleDistance { get; set; }
+
+            [JsonProperty("tripleAngle")]
+            public int TripleAngle { get; set; }
+
+            [JsonProperty("tripleBezel")]
+            public int TripleBezel { get; set; }
+
+            [JsonProperty("hDRExposure")]
+            public double HDRExposure { get; set; }
+
+            [JsonProperty("hDRContrast")]
+            public double HDRContrast { get; set; }
+
+            [JsonProperty("mirrorFOV")]
+            public int MirrorFOV { get; set; }
+
+            [JsonProperty("useGamepadForFreeCamera")]
+            public int UseGamepadForFreeCamera { get; set; }
+
+            [JsonProperty("virtualMirrorSize")]
+            public double VirtualMirrorSize { get; set; }
+
+            [JsonProperty("virtualMirrorVerticalOffset")]
+            public int VirtualMirrorVerticalOffset { get; set; }
+
+            [JsonProperty("virtualMirrorHorizontalOffset")]
+            public int VirtualMirrorHorizontalOffset { get; set; }
+
+            [JsonProperty("tVCamFocusedAperture")]
+            public double TVCamFocusedAperture { get; set; }
+
+            [JsonProperty("tVCamStaticAperture")]
+            public int TVCamStaticAperture { get; set; }
+
+            [JsonProperty("tVCamStaticFocusDistance")]
+            public int TVCamStaticFocusDistance { get; set; }
+
+            [JsonProperty("tVCamConstrainAspectRatio")]
+            public int TVCamConstrainAspectRatio { get; set; }
+
+            [JsonProperty("freeCamDOFEnabled")]
+            public int FreeCamDOFEnabled { get; set; }
+        }
+    }
+}

--- a/Race_Element.Data.ACC/Config/CameraSettingService.cs
+++ b/Race_Element.Data.ACC/Config/CameraSettingService.cs
@@ -13,13 +13,6 @@ namespace RaceElement.Data.ACC.Config
     {
         private readonly CameraSettings cameraSettings = new CameraSettings();
 
-        public CameraSettingService()
-        {
-            var json = cameraSettings.Get(false);
-            if (json != null)
-                Debug.WriteLine(JsonConvert.SerializeObject(json, Formatting.Indented));
-        }
-
         public CameraSettings Settings() => cameraSettings;
 
         public void ResetTvCamSettings()
@@ -53,10 +46,7 @@ namespace RaceElement.Data.ACC.Config
 
             public override string FileName => "cameraSettings.json";
 
-            public override CameraSettingsJson Default()
-            {
-                return new CameraSettingsJson();
-            }
+            public override CameraSettingsJson Default()    => new CameraSettingsJson();
         }
 
         public class CameraSettingsJson : IGenericSettingsJson

--- a/Race_Element.Data.ACC/Config/HudSettingsService.cs
+++ b/Race_Element.Data.ACC/Config/HudSettingsService.cs
@@ -1,0 +1,167 @@
+﻿using Newtonsoft.Json;
+using RaceElement.Util;
+
+namespace RaceElement.Data.ACC.Config
+{
+    public class HudSettingsService
+    {
+        private readonly AccHudSettings hudSettings = new AccHudSettings();
+
+        public AccHudSettings Settings() => hudSettings;
+
+        public class AccHudSettings : AbstractSettingsJson<AccHudSettingsJson>
+        {
+            public override string Path => FileUtil.AccConfigPath;
+            public override string FileName => "hud.json";
+
+            public override AccHudSettingsJson Default() => new AccHudSettingsJson();
+        }
+
+        public class AccHudSettingsJson : IGenericSettingsJson
+        {
+            [JsonProperty("safezoneLeft")]
+            public int SafezoneLeft { get; set; }
+
+            [JsonProperty("safezoneTop")]
+            public int SafezoneTop { get; set; }
+
+            [JsonProperty("safezoneRight")]
+            public int SafezoneRight { get; set; }
+
+            [JsonProperty("safezoneBottom")]
+            public int SafezoneBottom { get; set; }
+
+            [JsonProperty("defaultHUDPage")]
+            public int DefaultHUDPage { get; set; }
+
+            [JsonProperty("newOverlayHUDPage")]
+            public int NewOverlayHUDPage { get; set; }
+
+            [JsonProperty("raceNotificationsVisible")]
+            public int RaceNotificationsVisible { get; set; }
+
+            [JsonProperty("ratingWidgetVisible")]
+            public int RatingWidgetVisible { get; set; }
+
+            [JsonProperty("ratingWidgetPracticeFocus")]
+            public int RatingWidgetPracticeFocus { get; set; }
+
+            [JsonProperty("ratingSensitiveWidgetVisibility")]
+            public bool RatingSensitiveWidgetVisibility { get; set; }
+
+            [JsonProperty("basicCarInfoVisible")]
+            public int BasicCarInfoVisible { get; set; }
+
+            [JsonProperty("fPSVisible")]
+            public int FPSVisible { get; set; }
+
+            [JsonProperty("electronicsVisible")]
+            public int ElectronicsVisible { get; set; }
+
+            [JsonProperty("hotlapStandingVisible")]
+            public int HotlapStandingVisible { get; set; }
+
+            [JsonProperty("laptimeInfo01Visible")]
+            public int LaptimeInfo01Visible { get; set; }
+
+            [JsonProperty("leaderboardVisible")]
+            public int LeaderboardVisible { get; set; }
+
+            [JsonProperty("trackMapVisible")]
+            public int TrackMapVisible { get; set; }
+
+            [JsonProperty("raceDirectorInvestigationVisible")]
+            public int RaceDirectorInvestigationVisible { get; set; }
+
+            [JsonProperty("raceRealtimeStandingVisible")]
+            public int RaceRealtimeStandingVisible { get; set; }
+
+            [JsonProperty("raceStandingVisible")]
+            public int RaceStandingVisible { get; set; }
+
+            [JsonProperty("radarVisible")]
+            public int RadarVisible { get; set; }
+
+            [JsonProperty("sessionInfoVisible")]
+            public int SessionInfoVisible { get; set; }
+
+            [JsonProperty("tyreTemps01Visible")]
+            public int TyreTemps01Visible { get; set; }
+
+            [JsonProperty("timeLeftWidgetVisible")]
+            public int TimeLeftWidgetVisible { get; set; }
+
+            [JsonProperty("wrongWayVisible")]
+            public int WrongWayVisible { get; set; }
+
+            [JsonProperty("virtualMirrorVisible")]
+            public int VirtualMirrorVisible { get; set; }
+
+            [JsonProperty("serverStatsVisible")]
+            public int ServerStatsVisible { get; set; }
+
+            [JsonProperty("proximityIndicatorsVisible")]
+            public int ProximityIndicatorsVisible { get; set; }
+
+            [JsonProperty("useMPH")]
+            public int UseMPH { get; set; }
+
+            [JsonProperty("greenLightsVisible")]
+            public int GreenLightsVisible { get; set; }
+
+            [JsonProperty("showDriverNamePlates")]
+            public int ShowDriverNamePlates { get; set; }
+
+            [JsonProperty("chatPopupOnMessage")]
+            public int ChatPopupOnMessage { get; set; }
+
+            [JsonProperty("chatMaxMessageCount")]
+            public int ChatMaxMessageCount { get; set; }
+
+            [JsonProperty("chatShowTimestamps")]
+            public int ChatShowTimestamps { get; set; }
+
+            [JsonProperty("chatFadeoutSeconds")]
+            public int ChatFadeoutSeconds { get; set; }
+
+            [JsonProperty("communicationPanelVisible")]
+            public int CommunicationPanelVisible { get; set; }
+
+            [JsonProperty("communicationPanelMinPriority")]
+            public int CommunicationPanelMinPriority { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleTotal")]
+            public int CommunicationPanelMaxVisibleTotal { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleSticky")]
+            public int CommunicationPanelMaxVisibleSticky { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleNormal")]
+            public int CommunicationPanelMaxVisibleNormal { get; set; }
+
+            [JsonProperty("communicationPanelInCenter")]
+            public int CommunicationPanelInCenter { get; set; }
+
+            [JsonProperty("overallHUDScale")]
+            public double OverallHUDScale { get; set; }
+
+            [JsonProperty("pitInfoAlwaysVisible")]
+            public int PitInfoAlwaysVisible { get; set; }
+
+            [JsonProperty("lightIndicators")]
+            public int LightIndicators { get; set; }
+
+            [JsonProperty("cameraSetNameLabel")]
+            public int CameraSetNameLabel { get; set; }
+
+            [JsonProperty("lastMfdScreen")]
+            public int LastMfdScreen { get; set; }
+
+            [JsonProperty("autoSwitchPitMFD")]
+            public bool AutoSwitchPitMFD { get; set; }
+
+            [JsonProperty("realtimeStandingPitFilter")]
+            public int RealtimeStandingPitFilter { get; set; }
+        }
+    }
+}

--- a/Race_Element.Data.ACC/Config/MenuSettingsService.cs
+++ b/Race_Element.Data.ACC/Config/MenuSettingsService.cs
@@ -1,0 +1,158 @@
+﻿using Newtonsoft.Json;
+using RaceElement.Util;
+using System.Collections.Generic;
+
+namespace RaceElement.Data.ACC.Config
+{
+    public class MenuSettingsService
+    {
+        private readonly MenuSettings cameraSettings = new MenuSettings();
+
+        public MenuSettings Settings() => cameraSettings;
+
+        public void ResetLiverySettings()
+        {
+            var settings = cameraSettings.Get(false);
+            settings.TexDDS = 1;
+            settings.TexCap = 1;
+            cameraSettings.Save(settings);
+        }
+
+        public class MenuSettings : AbstractSettingsJson<MenuSettingsJson>
+        {
+            public override string Path => FileUtil.AccConfigPath;
+
+            public override string FileName => "menuSettings.json";
+
+            public override MenuSettingsJson Default() => new MenuSettingsJson();
+        }
+
+        public class MenuSettingsJson : IGenericSettingsJson
+        {
+            [JsonProperty("singlePlayerSeason")]
+            public string SinglePlayerSeason { get; set; }
+
+            [JsonProperty("seasonGameMode")]
+            public object SeasonGameMode { get; set; }
+
+            [JsonProperty("seasonRaceEventData")]
+            public object SeasonRaceEventData { get; set; }
+
+            [JsonProperty("globalSeasonTrackName")]
+            public object GlobalSeasonTrackName { get; set; }
+
+            [JsonProperty("globalOpponentCount")]
+            public int GlobalOpponentCount { get; set; }
+
+            [JsonProperty("globalOpponentSkill")]
+            public int GlobalOpponentSkill { get; set; }
+
+            [JsonProperty("globalOpponentAggro")]
+            public int GlobalOpponentAggro { get; set; }
+
+            [JsonProperty("globalPositionOnGrid")]
+            public int GlobalPositionOnGrid { get; set; }
+
+            [JsonProperty("globalCarGroupRatios")]
+            public object GlobalCarGroupRatios { get; set; }
+
+            [JsonProperty("useNewGenGT3")]
+            public int UseNewGenGT3 { get; set; }
+
+            [JsonProperty("weatherType")]
+            public string WeatherType { get; set; }
+
+            [JsonProperty("bUseEnduranceKit")]
+            public bool BUseEnduranceKit { get; set; }
+
+            [JsonProperty("audio")]
+            public object Audio { get; set; }
+
+            [JsonProperty("currentLanguage")]
+            public string CurrentLanguage { get; set; }
+
+            [JsonProperty("multiplayerCarGroupSelection")]
+            public object MultiplayerCarGroupSelection { get; set; }
+
+            [JsonProperty("templateOverrides")]
+            public object TemplateOverrides { get; set; }
+
+            [JsonProperty("serverPasswords")]
+            public object ServerPasswords { get; set; }
+
+            [JsonProperty("specialEventPage")]
+            public int SpecialEventPage { get; set; }
+
+            [JsonProperty("isPrivacyPolicyAccepted")]
+            public bool IsPrivacyPolicyAccepted { get; set; }
+
+            [JsonProperty("lastNewsItemIdRead")]
+            public string LastNewsItemIdRead { get; set; }
+
+            [JsonProperty("useFallbackControlPage")]
+            public bool UseFallbackControlPage { get; set; }
+
+            [JsonProperty("isNativeDBoxEnabled")]
+            public bool IsNativeDBoxEnabled { get; set; }
+
+            [JsonProperty("isNativeFanatecLedsEnabled")]
+            public bool IsNativeFanatecLedsEnabled { get; set; }
+
+            [JsonProperty("isFirstLaunchDataInserted")]
+            public bool IsFirstLaunchDataInserted { get; set; }
+
+            [JsonProperty("skipIntroSequence")]
+            public bool SkipIntroSequence { get; set; }
+
+            [JsonProperty("pitcrewAnimationEnabled")]
+            public bool PitcrewAnimationEnabled { get; set; }
+
+            [JsonProperty("pitmarkersVisible")]
+            public bool PitmarkersVisible { get; set; }
+
+            [JsonProperty("graphicOptions")]
+            public object GraphicOptions { get; set; }
+
+            [JsonProperty("texCap")]
+            public int TexCap { get; set; }
+
+            [JsonProperty("texDDS")]
+            public int TexDDS { get; set; }
+
+            [JsonProperty("texMips")]
+            public int TexMips { get; set; }
+
+            [JsonProperty("customGraphicOptions")]
+            public object CustomGraphicOptions { get; set; }
+
+            [JsonProperty("customDriverInfoNames")]
+            public List<object> CustomDriverInfoNames { get; set; }
+
+            [JsonProperty("lastFilter")]
+            public string LastFilter { get; set; }
+
+            [JsonProperty("lastSeasonFilter")]
+            public string LastSeasonFilter { get; set; }
+
+            [JsonProperty("mPShowroomCarGroup")]
+            public string MPShowroomCarGroup { get; set; }
+
+            [JsonProperty("mPShowroomCarGroupFilter")]
+            public string MPShowroomCarGroupFilter { get; set; }
+
+            [JsonProperty("mPServerListCarGroupFilter")]
+            public string MPServerListCarGroupFilter { get; set; }
+
+            [JsonProperty("mpServerListFilter")]
+            public object MpServerListFilter { get; set; }
+
+            [JsonProperty("carsPreloadMode")]
+            public int CarsPreloadMode { get; set; }
+
+            [JsonProperty("carsPreloadLimitMB")]
+            public int CarsPreloadLimitMB { get; set; }
+        }
+
+
+    }
+}

--- a/Race_Element.Data.ACC/Database/GameData/DbTrackData.cs
+++ b/Race_Element.Data.ACC/Database/GameData/DbTrackData.cs
@@ -64,7 +64,7 @@ namespace RaceElement.Data.ACC.Database.GameData
             var result = Collection.FindOne(x => x.ParseName == trackParseName);
             if (result == null)
             {
-                AbstractTrackData trackData = NewTracks.FirstOrDefault(x => x.GameName == trackParseName);
+                AbstractTrackData trackData = TrackData.Tracks.FirstOrDefault(x => x.GameName == trackParseName);
                 Insert(new DbTrackData() { ParseName = trackParseName, Id = trackData.Guid });
                 result = Collection.FindOne(x => x.ParseName == trackParseName);
             }

--- a/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
+++ b/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Cars\Damage.cs" />
     <Compile Include="Cars\SteeringLock.cs" />
     <Compile Include="Config\CameraSettingService.cs" />
+    <Compile Include="Config\HudSettingsService.cs" />
     <Compile Include="Config\MenuSettingsService.cs" />
     <Compile Include="Core\AccProcess.cs" />
     <Compile Include="Core\Config\ReplayJson.cs" />

--- a/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
+++ b/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Cars\Damage.cs" />
     <Compile Include="Cars\SteeringLock.cs" />
     <Compile Include="Config\CameraSettingService.cs" />
+    <Compile Include="Config\MenuSettingsService.cs" />
     <Compile Include="Core\AccProcess.cs" />
     <Compile Include="Core\Config\ReplayJson.cs" />
     <Compile Include="Core\Game\AccScheduler.cs" />

--- a/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
+++ b/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Cars\BrakeBias.cs" />
     <Compile Include="Cars\Damage.cs" />
     <Compile Include="Cars\SteeringLock.cs" />
+    <Compile Include="Config\CameraSettingService.cs" />
     <Compile Include="Core\AccProcess.cs" />
     <Compile Include="Core\Config\ReplayJson.cs" />
     <Compile Include="Core\Game\AccScheduler.cs" />

--- a/Race_Element.Data.ACC/Tracks/TrackData.cs
+++ b/Race_Element.Data.ACC/Tracks/TrackData.cs
@@ -24,7 +24,7 @@ namespace RaceElement.Data.ACC.Tracks
         }
 
         private static readonly List<AbstractTrackData> _tracks = new List<AbstractTrackData>();
-        public static List<AbstractTrackData> NewTracks
+        public static List<AbstractTrackData> Tracks
         {
             get
             {

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayDamage/DamageOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayDamage/DamageOverlay.cs
@@ -24,11 +24,11 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayDamage
             public DamageGrouping Damage { get; set; } = new DamageGrouping();
             public class DamageGrouping
             {
-                [ToolTip("Displays the total repair time in the center of the HUD with red colored text.")]
-                public bool TotalRepairTime { get; set; } = true;
-
                 [ToolTip("Only show the HUD when there is actual damage on the car.")]
                 public bool AutoHide { get; set; } = true;
+
+                [ToolTip("Displays the total repair time in the center of the HUD with red colored text.")]
+                public bool TotalRepairTime { get; set; } = true;
             }
         }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayTrackCorners/TrackCornersOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayTrackCorners/TrackCornersOverlay.cs
@@ -125,7 +125,7 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayCornerNames
             if (!(pageGraphics.Status == RaceElement.ACCSharedMemory.AcStatus.AC_PAUSE || pageGraphics.Status == RaceElement.ACCSharedMemory.AcStatus.AC_LIVE))
                 return;
 
-            _currentTrack = NewTracks.FirstOrDefault(x => x.GameName == pageStatic.Track);
+            _currentTrack = Tracks.FirstOrDefault(x => x.GameName == pageStatic.Track);
 
             this.Width = (int)_cornerNumberHeader.Rectangle.Width;
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
@@ -1,0 +1,123 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.OverlayUtil.InfoPanel;
+using RaceElement.HUD.Overlay.Util;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayClock
+{
+    [Overlay(Name = "Clock",
+        Description = "Displays the system time of your operation system.",
+        OverlayType = OverlayType.Debug,
+        OverlayCategory = OverlayCategory.All)]
+    internal sealed class ClockOverlay : AbstractOverlay
+    {
+        private readonly SystemTimeConfig _config = new SystemTimeConfig();
+        private sealed class SystemTimeConfig : OverlayConfiguration
+        {
+            public enum TimeFormat
+            {
+                Full,
+                AmPm
+            }
+
+            [ConfigGrouping("Time", "Change settings that alter the presentation of the time.")]
+            public InfoPanelGrouping InfoPanel { get; set; } = new InfoPanelGrouping();
+            public class InfoPanelGrouping
+            {
+                [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
+                public TimeFormat Format { get; set; } = TimeFormat.Full;
+            }
+
+            public SystemTimeConfig() => this.AllowRescale = true;
+        }
+
+        private Font _font;
+
+        private PanelText _timeHeader;
+        private PanelText _timeValue;
+
+        public ClockOverlay(Rectangle rectangle) : base(rectangle, "Clock")
+        {
+            RefreshRateHz = 1;
+        }
+
+        public override void BeforeStart()
+        {
+            _font = FontUtil.FontSegoeMono(10f * this.Scale);
+
+            int lineHeight = _font.Height;
+
+            int unscaledHeaderWidth = 46;
+            int unscaledValueWidth = 80;
+            if (_config.InfoPanel.Format == SystemTimeConfig.TimeFormat.AmPm)
+                unscaledValueWidth += 24;
+
+            int headerWidth = (int)(unscaledHeaderWidth * this.Scale);
+            int valueWidth = (int)(unscaledValueWidth * this.Scale);
+            int roundingRadius = (int)(6 * this.Scale);
+
+            RectangleF headerRect = new RectangleF(0, 0, headerWidth, lineHeight);
+            RectangleF valueRect = new RectangleF(headerWidth, 0, valueWidth, lineHeight);
+            StringFormat headerFormat = new StringFormat() { Alignment = StringAlignment.Near };
+            StringFormat valueFormat = new StringFormat() { Alignment = StringAlignment.Center, };
+            Color accentColor = Color.FromArgb(25, 255, 0, 0);
+            CachedBitmap headerBackground = new CachedBitmap(headerWidth, lineHeight, g =>
+            {
+                Rectangle panelRect = new Rectangle(0, 0, headerWidth, lineHeight);
+                using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(panelRect, 0, 0, 0, roundingRadius);
+                using LinearGradientBrush brush = new LinearGradientBrush(panelRect, Color.FromArgb(185, 0, 0, 0), Color.FromArgb(255, 10, 10, 10), LinearGradientMode.BackwardDiagonal);
+                g.FillPath(brush, path);
+                g.DrawLine(new Pen(accentColor), 0 + roundingRadius / 2, lineHeight, headerWidth, lineHeight - 1);
+            });
+            CachedBitmap valueBackground = new CachedBitmap(valueWidth, lineHeight, g =>
+            {
+                Rectangle panelRect = new Rectangle(0, 0, valueWidth, lineHeight);
+                using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(panelRect, 0, roundingRadius, 0, 0);
+                using LinearGradientBrush brush = new LinearGradientBrush(panelRect, Color.FromArgb(255, 0, 0, 0), Color.FromArgb(185, 0, 0, 0), LinearGradientMode.ForwardDiagonal);
+                g.FillPath(brush, path);
+                g.DrawLine(new Pen(accentColor), 0, lineHeight - 1, valueWidth, lineHeight - 1);
+            });
+
+            _timeHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+            _timeValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+            headerRect.Offset(0, lineHeight);
+            valueRect.Offset(0, lineHeight);
+
+            this.Width = unscaledHeaderWidth + unscaledValueWidth;
+            this.Height = (int)(headerRect.Top / this.Scale);
+        }
+
+        public override void BeforeStop()
+        {
+            _font?.Dispose();
+
+            _timeHeader?.Dispose();
+            _timeValue?.Dispose();
+        }
+
+        public override void Render(Graphics g)
+        {
+            _timeHeader.Draw(g, "Time", this.Scale);
+            string format = string.Empty;
+            switch (_config.InfoPanel.Format)
+            {
+                case SystemTimeConfig.TimeFormat.Full:
+                    {
+                        format = "HH\\:mm\\:ss";
+                        break;
+                    }
+                case SystemTimeConfig.TimeFormat.AmPm:
+                    {
+                        format = "hh\\:mm\\:ss tt";
+                        break;
+                    }
+            }
+            _timeValue.Draw(g, $"{DateTime.Now.ToString(format)}", this.Scale);
+
+        }
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
@@ -112,7 +112,7 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayClock
 
         public override void Render(Graphics g)
         {
-            _timeHeader.Draw(g, "Time", this.Scale);
+            _timeHeader.Draw(g, "Clock", this.Scale);
             string format = string.Empty;
             switch (_config.InfoPanel.Format)
             {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
@@ -24,12 +24,15 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayClock
                 AmPm
             }
 
-            [ConfigGrouping("Time", "Change settings that alter the presentation of the time.")]
+            [ConfigGrouping("Clock", "Change settings that alter the presentation of the time.")]
             public InfoPanelGrouping InfoPanel { get; set; } = new InfoPanelGrouping();
             public class InfoPanelGrouping
             {
                 [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
                 public TimeFormat Format { get; set; } = TimeFormat.Full;
+
+                [ToolTip("Renders this HUD regardless of the whether the engine is running or not.")]
+                public bool AlwaysShow { get; set; } = true;
             }
 
             public SystemTimeConfig() => this.AllowRescale = true;
@@ -97,6 +100,14 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayClock
 
             _timeHeader?.Dispose();
             _timeValue?.Dispose();
+        }
+
+        public override bool ShouldRender()
+        {
+            if (_config.InfoPanel.AlwaysShow)
+                return true;
+
+            return base.ShouldRender();
         }
 
         public override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
@@ -271,9 +271,9 @@ Description = "(BETA) A table representing a leaderboard.")]
 
                         firstRow[3] = $"L{kv.Value.RealtimeCarUpdate.Laps + 1} | ";
 
-                        if (NewTracks.Any())
+                        if (Tracks.Any())
                         {
-                            var matchingTracks = NewTracks.Where(x => x.GameName == broadCastTrackData.TrackName);
+                            var matchingTracks = Tracks.Where(x => x.GameName == broadCastTrackData.TrackName);
                             if (matchingTracks.Any())
                             {
                                 var currentTrack = matchingTracks.First();

--- a/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
+++ b/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Overlays\Driving\OverlayInputTrace\InputTraceOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayLapTable\LapTimeTableConfiguration.cs" />
     <Compile Include="Overlays\Driving\OverlayLapTable\LapTableOverlay.cs" />
+    <Compile Include="Overlays\Pitwall\OverlayClock\ClockOverlay.cs" />
     <Compile Include="Overlays\System\Overlay3D\3dOverlay.cs" />
     <Compile Include="Overlays\System\OverlayMousePosition\MousePositionOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayOpponent\OpponentOverlay.cs" />

--- a/Race_Element.Util/FileUtil.cs
+++ b/Race_Element.Util/FileUtil.cs
@@ -22,6 +22,7 @@ namespace RaceElement.Util
         public static string CustomsPath => AccPath + "Customs\\";
         public static string CarsPath => CustomsPath + "Cars\\";
         public static string LiveriesPath => CustomsPath + "Liveries\\";
+        public static string SetupsPath = AccPath + "Setups\\";
         public static string AccConfigPath => AccPath + "Config\\";
 
         public static string AppDirectory => StripFileName(System.Reflection.Assembly.GetEntryAssembly().Location);

--- a/Race_Element.Util/Settings/AccManagerSettings.cs
+++ b/Race_Element.Util/Settings/AccManagerSettings.cs
@@ -5,6 +5,7 @@
         public bool MinimizeToSystemTray { get; set; }
         public bool TelemetryRecordDetailed { get; set; }
         public int TelemetryDetailedHerz { get; set; }
+        public bool Generate4kDDS { get; set; }
     }
 
     public class AccManagerSettings : AbstractSettingsJson<AccManagerSettingsJson>
@@ -18,6 +19,7 @@
             MinimizeToSystemTray = false,
             TelemetryRecordDetailed = false,
             TelemetryDetailedHerz = 20,
+            Generate4kDDS = false,
         };
 
     }

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,10 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
-                        "\n- Setup Browser: When opening the tab or refreshing, the current car and track will open in the tree."},
+                        "\n- Setup Browser: When opening the tab or refreshing, the current car and track will open in the tree."+
+                        "\n- Settings Tab:"+
+                        "\n  - Added HUD Settings: Allows you enable or disable settings like the rating widget."+
+                        "\n  - Added Camera Settings: Allows you to modify helicam settings."},
             {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
-            {"0.2.3.2", "- Fixed Lap Delta HUD Activation."+
+            {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},
             {"0.2.3.0", "- Track Corners HUD: Added Circuit Ricardo Tormo Valencia."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,11 +7,11 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
-                        "\n- Setup Browser: When opening the tab or refreshing, the current car and track will open in the tree."+
+                        "\n- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree."+
                         "\n- Added Race Element option to by default generate 4K dds_1 files instead of downsizing them to 2k like the game does."+
-                        "\n- Settings Tab:"+
-                        "\n  - Added HUD Settings: Allows you enable or disable settings like the rating widget."+
-                        "\n  - Added Camera Settings: Allows you to modify helicam settings."},
+                        "\n- Settings Tab: Added ACC Settings only available through json editing."+
+                        "\n  - ACC HUD Settings: Allows you enable or disable settings like the rating widget."+
+                        "\n  - ACC Camera Settings: Allows you to modify helicam settings."},
             {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
-            {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format." },
+            {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
+                        "\n- Setup Browser: When opening the tab or refreshing, the current car and track will open in the tree."},
             {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -8,6 +8,7 @@ namespace RaceElement.Controls
         {
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
                         "\n- Setup Browser: When opening the tab or refreshing, the current car and track will open in the tree."+
+                        "\n- Added Race Element option to by default generate 4K dds_1 files instead of downsizing them to 2k like the game does."+
                         "\n- Settings Tab:"+
                         "\n  - Added HUD Settings: Allows you enable or disable settings like the rating widget."+
                         "\n  - Added Camera Settings: Allows you to modify helicam settings."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
+            {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format." },
             {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -8,10 +8,11 @@ namespace RaceElement.Controls
         {
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
                         "\n- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree."+
-                        "\n- Added Race Element option to by default generate 4K dds_1 files instead of downsizing them to 2k like the game does."+
-                        "\n- Settings Tab: Added ACC Settings only available through json editing."+
-                        "\n  - ACC HUD Settings: Allows you enable or disable settings like the rating widget."+
-                        "\n  - ACC Camera Settings: Allows you to modify helicam settings."},
+                        "\n- Race Element Settings Tab: Added option to by default generate 4K dds_1 files instead of downsizing them to 2K resulution like the game does."+
+                        "\n- ACC Settings Tab: Added ACC Settings only available through json editing."+
+                        "\n  - ACC HUD Settings: Allows you to toggle settings like the rating widget."+
+                        "\n  - ACC Camera Settings: Allows you to modify helicam settings."+
+                        "\n  - ACC Livery Settings: Allows you to toggle settings like texDDS."},
             {"0.2.3.2", "- Fixed Lap Delta Bar HUD Activation."+
                         "\n- Lap Delta Trace HUD: Better data for preview image and more precise adjustment of data collection rate(Herz)."+
                         "\n- Slight rework of Info tab design."},

--- a/Race_Element/Controls/Liveries/DDSutil.cs
+++ b/Race_Element/Controls/Liveries/DDSutil.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using static RaceElement.Controls.LiveryBrowser;
+using RaceElement.Util.Settings;
 
 namespace RaceElement.Controls.Liveries
 {
@@ -22,6 +23,8 @@ namespace RaceElement.Controls.Liveries
 
         public static void GenerateDDS(LiveryTreeCar livery)
         {
+            AccManagerSettingsJson accManagerSettings = new AccManagerSettings().Get(false);
+
             try
             {
                 for (int i = 0; i < pngsToDDS.Count; i++)
@@ -41,10 +44,8 @@ namespace RaceElement.Controls.Liveries
 
                         Bitmap bitmap = new Bitmap(actualFileStream);
 
-                        if (pngsToDDS.ElementAt(i).Key.Contains("_1"))
-                        {
+                        if (!accManagerSettings.Generate4kDDS && pngsToDDS.ElementAt(i).Key.Contains("_1"))
                             bitmap = ResizeBitmap(bitmap, 2048, 2048);
-                        }
 
                         Surface surface = Surface.CopyFromBitmap(bitmap);
 

--- a/Race_Element/Controls/Liveries/LiveryDisplayer.xaml
+++ b/Race_Element/Controls/Liveries/LiveryDisplayer.xaml
@@ -37,7 +37,7 @@
                         <StackPanel x:Name="stackPanelMainInfo" Orientation="Vertical" Grid.Row="0">
                         </StackPanel>
                     </materialDesign:Card>
-                    <Button x:Name="buttonGenerateDDS" Grid.Row="1" Visibility="Hidden" Margin="3" ToolTip="Generate the _0 and _1 dds files so the game doesn't have to do it for you.">Generate DDS Files</Button>
+                    <Button x:Name="buttonGenerateDDS" Grid.Row="1" Visibility="Hidden" Margin="3" ToolTip="Generate the _1 dds files so the game doesn't have to do it for you.">Generate DDS Files</Button>
                 </Grid>
                 <StackPanel x:Name="stackPanelLiveryInfo" Grid.Column="1" HorizontalAlignment="Left" Orientation="Vertical" ScrollViewer.HorizontalScrollBarVisibility="Auto">
                 </StackPanel>

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
@@ -15,6 +15,11 @@
             <Label VerticalAlignment="Center">Minimize Race Element to system tray</Label>
         </StackPanel>
 
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <ToggleButton x:Name="toggleGenerate4kDDS" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+            <Label VerticalAlignment="Center">Generates 4k dds_1 files.</Label>
+        </StackPanel>
+
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <ToggleButton x:Name="toggleRecordLapTelemetry" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand" IsChecked="False"/>

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
@@ -15,9 +15,9 @@
             <Label VerticalAlignment="Center">Minimize Race Element to system tray</Label>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Usually dds_1 files are downscaled to 2K, this forces it to be 4k. Useful if you want to make screenshots of your custom livery whilst driving.">
             <ToggleButton x:Name="toggleGenerate4kDDS" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
-            <Label VerticalAlignment="Center">Generates 4k dds_1 files.</Label>
+            <Label VerticalAlignment="Center">DDS Generator: generate 4k dds_1 files.</Label>
         </StackPanel>
 
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center">

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
@@ -17,7 +17,7 @@
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Usually dds_1 files are downscaled to 2K, this forces it to be 4k. Useful if you want to make screenshots of your custom livery whilst driving.">
             <ToggleButton x:Name="toggleGenerate4kDDS" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
-            <Label VerticalAlignment="Center">DDS Generator: generate 4k dds_1 files.</Label>
+            <Label VerticalAlignment="Center">DDS Generator: generate 4K dds_1 files.</Label>
         </StackPanel>
 
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center">

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml.cs
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml.cs
@@ -23,10 +23,10 @@ namespace RaceElement.Controls
             _settings = new AccManagerSettings();
             Dispatcher.BeginInvoke(new Action(() =>
             {
-                toggleRecordLapTelemetry.IsChecked = _settings.Get().TelemetryRecordDetailed;
-                sliderTelemetryHerz.Value = _settings.Get().TelemetryDetailedHerz;
-                labelTelemetryHerz.Content = $"Telemetry: Extended Data Herz: {_settings.Get().TelemetryDetailedHerz}";
-                toggleMinimizeToSystemTray.IsChecked = _settings.Get().MinimizeToSystemTray;
+                LoadSettings();
+
+                toggleGenerate4kDDS.Checked += (s, e) => SaveSettings();
+                toggleGenerate4kDDS.Unchecked += (s, e) => SaveSettings();
 
                 toggleRecordLapTelemetry.Checked += (s, e) => SaveSettings();
                 toggleRecordLapTelemetry.Unchecked += (s, e) => SaveSettings();
@@ -38,6 +38,15 @@ namespace RaceElement.Controls
 
                 buttonOpenAccManagerFolder.Click += ButtonOpenAccManagerFolder_Click;
             }));
+        }
+
+        private void LoadSettings()
+        {
+            toggleRecordLapTelemetry.IsChecked = _settings.Get().TelemetryRecordDetailed;
+            sliderTelemetryHerz.Value = _settings.Get().TelemetryDetailedHerz;
+            labelTelemetryHerz.Content = $"Telemetry: Extended Data Herz: {_settings.Get().TelemetryDetailedHerz}";
+            toggleMinimizeToSystemTray.IsChecked = _settings.Get().MinimizeToSystemTray;
+            toggleGenerate4kDDS.IsChecked = _settings.Get().Generate4kDDS;
         }
 
         private void ButtonOpenAccManagerFolder_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -54,6 +63,7 @@ namespace RaceElement.Controls
 
             settings.TelemetryRecordDetailed = toggleRecordLapTelemetry.IsChecked.Value;
             settings.TelemetryDetailedHerz = (int)sliderTelemetryHerz.Value;
+            settings.Generate4kDDS = toggleGenerate4kDDS.IsChecked.Value;
 
             labelTelemetryHerz.Content = $"Telemetry: Extended Data Herz: {settings.TelemetryDetailedHerz}";
 

--- a/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="RaceElement.Controls.AccCameraSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:RaceElement.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="400">
+
+            <Button x:Name="buttonResetHelicam">Reset Helicam settings</Button>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam distance.">
+                <Slider x:Name="sliderHelicamDistance" Width="200" Minimum="1000" Maximum="100000" Interval="1000" IsSnapToTickEnabled="True" TickFrequency="1000" 
+                        ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamDistance}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamDistance}" ContentStringFormat="Helicam Distance: {0}"></Label>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam FOV.">
+                <Slider x:Name="sliderHelicamFOV" Width="200" Minimum="10" Maximum="120" Interval="1" IsSnapToTickEnabled="True" TickFrequency="1" 
+               ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamFOV}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamFOV}" ContentStringFormat="Helicam FOV: {0}"></Label>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the amount of cars targeted by the helicam.">
+                <Slider x:Name="sliderHelicamTargetMoreCars" Width="200" Minimum="1" Maximum="10" Interval="1" IsSnapToTickEnabled="True" TickFrequency="1" 
+         ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}" ContentStringFormat="Target More Cars: {0}"></Label>
+            </StackPanel>
+
+
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
@@ -7,27 +7,40 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="400">
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="500">
 
             <Button x:Name="buttonResetHelicam">Reset Helicam settings</Button>
 
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam distance.">
                 <Slider x:Name="sliderHelicamDistance" Width="200" Minimum="1000" Maximum="100000" Interval="1000" IsSnapToTickEnabled="True" TickFrequency="1000" 
-                        ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamDistance}"></Slider>
+                    ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamDistance}"></Slider>
                 <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamDistance}" ContentStringFormat="Helicam Distance: {0}"></Label>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam FOV.">
                 <Slider x:Name="sliderHelicamFOV" Width="200" Minimum="10" Maximum="120" Interval="1" IsSnapToTickEnabled="True" TickFrequency="1" 
-               ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamFOV}"></Slider>
+                    ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamFOV}"></Slider>
                 <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamFOV}" ContentStringFormat="Helicam FOV: {0}"></Label>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the amount of cars targeted by the helicam.">
                 <Slider x:Name="sliderHelicamTargetMoreCars" Width="200" Minimum="1" Maximum="10" Interval="1" IsSnapToTickEnabled="True" TickFrequency="1" 
-         ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}"></Slider>
-                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}" ContentStringFormat="Target More Cars: {0}"></Label>
+                    ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamTargetMoreCars}" ContentStringFormat="Helicam Target More Cars: {0}"></Label>
             </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam target max distance.">
+                <Slider x:Name="sliderHelicamTargetMaxDistance" Width="200" Minimum="200" Maximum="10000" Interval="200" IsSnapToTickEnabled="True" TickFrequency="200" 
+                    ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamTargetMaxDistance}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamTargetMaxDistance}" ContentStringFormat="Helicam Target Max Distance: {0}"></Label>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Stretch" ToolTip="Adjust the helicam target interpolation time.">
+                <Slider x:Name="sliderHelicamInterpolationTime" Width="200" Minimum="1" Maximum="10" Interval="1" IsSnapToTickEnabled="True" TickFrequency="1" 
+                    ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamInterpolationTime}"></Slider>
+                <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamInterpolationTime}" ContentStringFormat="Helicam Target Interpolation Time: {0}"></Label>
+            </StackPanel>
+
 
 
         </StackPanel>

--- a/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml
@@ -40,9 +40,6 @@
                     ToolTipService.InitialShowDelay="0" ToolTipService.BetweenShowDelay="0" ToolTipService.ShowDuration="99999999" ToolTipService.ToolTip="{Binding Path=Value, ElementName=sliderHelicamInterpolationTime}"></Slider>
                 <Label VerticalAlignment="Center" Content="{Binding Path=Value, ElementName=sliderHelicamInterpolationTime}" ContentStringFormat="Helicam Target Interpolation Time: {0}"></Label>
             </StackPanel>
-
-
-
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml.cs
@@ -37,6 +37,8 @@ namespace RaceElement.Controls
             sliderHelicamDistance.ValueChanged += (s, e) => SaveSettings();
             sliderHelicamFOV.ValueChanged += (s, e) => SaveSettings();
             sliderHelicamTargetMoreCars.ValueChanged += (s, e) => SaveSettings();
+            sliderHelicamInterpolationTime.ValueChanged += (s, e) => SaveSettings();
+            sliderHelicamTargetMaxDistance.ValueChanged += (s, e) => SaveSettings();
         }
 
         private void LoadSettings()
@@ -46,6 +48,8 @@ namespace RaceElement.Controls
             sliderHelicamDistance.Value = settings.HelicamDistance;
             sliderHelicamFOV.Value = settings.HelicamFOV;
             sliderHelicamTargetMoreCars.Value = settings.HelicamTargetMoreCars;
+            sliderHelicamInterpolationTime.Value = settings.HelicamTargetInterpTime;
+            sliderHelicamTargetMaxDistance.Value = settings.HelicamTargetCarsMaxDist;
         }
 
         private void SaveSettings()
@@ -55,6 +59,8 @@ namespace RaceElement.Controls
             settings.HelicamDistance = (int)sliderHelicamDistance.Value;
             settings.HelicamFOV = (int)sliderHelicamFOV.Value;
             settings.HelicamTargetMoreCars = (int)sliderHelicamTargetMoreCars.Value;
+            settings.HelicamTargetCarsMaxDist = (int)sliderHelicamTargetMaxDistance.Value;
+            settings.HelicamTargetInterpTime = (int)sliderHelicamInterpolationTime.Value;
 
             camera.Settings().Save(settings);
         }

--- a/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccCameraSettings.xaml.cs
@@ -1,0 +1,62 @@
+﻿using RaceElement.Data.ACC.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace RaceElement.Controls
+{
+    /// <summary>
+    /// Interaction logic for AccCameraSettings.xaml
+    /// </summary>
+    public partial class AccCameraSettings : UserControl
+    {
+        private readonly CameraSettingService camera = new CameraSettingService();
+
+        public AccCameraSettings()
+        {
+            InitializeComponent();
+            this.Loaded += (s, e) => LoadSettings();
+
+            buttonResetHelicam.Click += (s, e) =>
+            {
+                camera.ResetHelicamCamera();
+                LoadSettings();
+            };
+
+            sliderHelicamDistance.ValueChanged += (s, e) => SaveSettings();
+            sliderHelicamFOV.ValueChanged += (s, e) => SaveSettings();
+            sliderHelicamTargetMoreCars.ValueChanged += (s, e) => SaveSettings();
+        }
+
+        private void LoadSettings()
+        {
+            var settings = camera.Settings().Get(false);
+
+            sliderHelicamDistance.Value = settings.HelicamDistance;
+            sliderHelicamFOV.Value = settings.HelicamFOV;
+            sliderHelicamTargetMoreCars.Value = settings.HelicamTargetMoreCars;
+        }
+
+        private void SaveSettings()
+        {
+            var settings = camera.Settings().Get(false);
+
+            settings.HelicamDistance = (int)sliderHelicamDistance.Value;
+            settings.HelicamFOV = (int)sliderHelicamFOV.Value;
+            settings.HelicamTargetMoreCars = (int)sliderHelicamTargetMoreCars.Value;
+
+            camera.Settings().Save(settings);
+        }
+    }
+}

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
@@ -19,6 +19,11 @@
                 <Label VerticalAlignment="Center">Show server stats widget</Label>
             </StackPanel>
 
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Displays or Hides the fps widget in the right bottom of the screen.">
+                <ToggleButton x:Name="toggleFps" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+                <Label VerticalAlignment="Center">Show fps widget</Label>
+            </StackPanel>
+
 
         </StackPanel> 
     </Grid>

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="RaceElement.Controls.AccHudSettingsNS.AccHudSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:RaceElement.Controls.AccHudSettingsNS"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Displays or Hides the rating widget in the right top of the screen.">
+                <ToggleButton x:Name="toggleRatingWidget" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+                <Label VerticalAlignment="Center">Show rating widget</Label>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Displays or Hides the server stats widget in the right bottom of the screen.">
+                <ToggleButton x:Name="toggleServerStats" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+                <Label VerticalAlignment="Center">Show server stats widget</Label>
+            </StackPanel>
+
+
+        </StackPanel> 
+    </Grid>
+</UserControl>

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml
@@ -19,11 +19,10 @@
                 <Label VerticalAlignment="Center">Show server stats widget</Label>
             </StackPanel>
 
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Displays or Hides the fps widget in the right bottom of the screen.">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Displays or Hides the fps widget.">
                 <ToggleButton x:Name="toggleFps" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
                 <Label VerticalAlignment="Center">Show fps widget</Label>
             </StackPanel>
-
 
         </StackPanel> 
     </Grid>

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using RaceElement.Data.ACC.Config;
 using RaceElement.Util;
 using System;
 using System.Collections.Generic;

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
@@ -1,0 +1,219 @@
+﻿using Newtonsoft.Json;
+using RaceElement.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace RaceElement.Controls.AccHudSettingsNS
+{
+    /// <summary>
+    /// Interaction logic for AccHudSettings.xaml
+    /// </summary>
+    public partial class AccHudSettings : UserControl
+    {
+        private AccHud _accHud;
+
+        public AccHudSettings()
+        {
+            InitializeComponent();
+            this.Loaded += (s, e) =>
+            {
+                _accHud = new AccHud();
+                LoadSettings();
+            };
+
+            toggleRatingWidget.Checked += (s, e) => SaveSettings();
+            toggleRatingWidget.Unchecked += (s, e) => SaveSettings();
+            toggleServerStats.Checked += (s, e) => SaveSettings();
+            toggleServerStats.Unchecked += (s, e) => SaveSettings();
+        }
+
+        private void LoadSettings()
+        {
+            var json = _accHud.Get(false);
+            Debug.WriteLine(JsonConvert.SerializeObject(json, Formatting.Indented));
+
+            toggleRatingWidget.IsChecked = json.RatingWidgetVisible == 1;
+            toggleServerStats.IsChecked = json.ServerStatsVisible == 1;
+        }
+
+        private void SaveSettings()
+        {
+            var json = _accHud.Get(false);
+
+            json.RatingWidgetVisible = toggleRatingWidget.IsChecked.Value ? 1 : 0;
+            json.ServerStatsVisible = toggleServerStats.IsChecked.Value ? 1 : 0;
+
+            _accHud.Save(json);
+        }
+
+        private class AccHudSettingsJson : IGenericSettingsJson
+        {
+            [JsonProperty("safezoneLeft")]
+            public int SafezoneLeft { get; set; }
+
+            [JsonProperty("safezoneTop")]
+            public int SafezoneTop { get; set; }
+
+            [JsonProperty("safezoneRight")]
+            public int SafezoneRight { get; set; }
+
+            [JsonProperty("safezoneBottom")]
+            public int SafezoneBottom { get; set; }
+
+            [JsonProperty("defaultHUDPage")]
+            public int DefaultHUDPage { get; set; }
+
+            [JsonProperty("newOverlayHUDPage")]
+            public int NewOverlayHUDPage { get; set; }
+
+            [JsonProperty("raceNotificationsVisible")]
+            public int RaceNotificationsVisible { get; set; }
+
+            [JsonProperty("ratingWidgetVisible")]
+            public int RatingWidgetVisible { get; set; }
+
+            [JsonProperty("ratingWidgetPracticeFocus")]
+            public int RatingWidgetPracticeFocus { get; set; }
+
+            [JsonProperty("ratingSensitiveWidgetVisibility")]
+            public bool RatingSensitiveWidgetVisibility { get; set; }
+
+            [JsonProperty("basicCarInfoVisible")]
+            public int BasicCarInfoVisible { get; set; }
+
+            [JsonProperty("fPSVisible")]
+            public int FPSVisible { get; set; }
+
+            [JsonProperty("electronicsVisible")]
+            public int ElectronicsVisible { get; set; }
+
+            [JsonProperty("hotlapStandingVisible")]
+            public int HotlapStandingVisible { get; set; }
+
+            [JsonProperty("laptimeInfo01Visible")]
+            public int LaptimeInfo01Visible { get; set; }
+
+            [JsonProperty("leaderboardVisible")]
+            public int LeaderboardVisible { get; set; }
+
+            [JsonProperty("trackMapVisible")]
+            public int TrackMapVisible { get; set; }
+
+            [JsonProperty("raceDirectorInvestigationVisible")]
+            public int RaceDirectorInvestigationVisible { get; set; }
+
+            [JsonProperty("raceRealtimeStandingVisible")]
+            public int RaceRealtimeStandingVisible { get; set; }
+
+            [JsonProperty("raceStandingVisible")]
+            public int RaceStandingVisible { get; set; }
+
+            [JsonProperty("radarVisible")]
+            public int RadarVisible { get; set; }
+
+            [JsonProperty("sessionInfoVisible")]
+            public int SessionInfoVisible { get; set; }
+
+            [JsonProperty("tyreTemps01Visible")]
+            public int TyreTemps01Visible { get; set; }
+
+            [JsonProperty("timeLeftWidgetVisible")]
+            public int TimeLeftWidgetVisible { get; set; }
+
+            [JsonProperty("wrongWayVisible")]
+            public int WrongWayVisible { get; set; }
+
+            [JsonProperty("virtualMirrorVisible")]
+            public int VirtualMirrorVisible { get; set; }
+
+            [JsonProperty("serverStatsVisible")]
+            public int ServerStatsVisible { get; set; }
+
+            [JsonProperty("proximityIndicatorsVisible")]
+            public int ProximityIndicatorsVisible { get; set; }
+
+            [JsonProperty("useMPH")]
+            public int UseMPH { get; set; }
+
+            [JsonProperty("greenLightsVisible")]
+            public int GreenLightsVisible { get; set; }
+
+            [JsonProperty("showDriverNamePlates")]
+            public int ShowDriverNamePlates { get; set; }
+
+            [JsonProperty("chatPopupOnMessage")]
+            public int ChatPopupOnMessage { get; set; }
+
+            [JsonProperty("chatMaxMessageCount")]
+            public int ChatMaxMessageCount { get; set; }
+
+            [JsonProperty("chatShowTimestamps")]
+            public int ChatShowTimestamps { get; set; }
+
+            [JsonProperty("chatFadeoutSeconds")]
+            public int ChatFadeoutSeconds { get; set; }
+
+            [JsonProperty("communicationPanelVisible")]
+            public int CommunicationPanelVisible { get; set; }
+
+            [JsonProperty("communicationPanelMinPriority")]
+            public int CommunicationPanelMinPriority { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleTotal")]
+            public int CommunicationPanelMaxVisibleTotal { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleSticky")]
+            public int CommunicationPanelMaxVisibleSticky { get; set; }
+
+            [JsonProperty("communicationPanelMaxVisibleNormal")]
+            public int CommunicationPanelMaxVisibleNormal { get; set; }
+
+            [JsonProperty("communicationPanelInCenter")]
+            public int CommunicationPanelInCenter { get; set; }
+
+            [JsonProperty("overallHUDScale")]
+            public double OverallHUDScale { get; set; }
+
+            [JsonProperty("pitInfoAlwaysVisible")]
+            public int PitInfoAlwaysVisible { get; set; }
+
+            [JsonProperty("lightIndicators")]
+            public int LightIndicators { get; set; }
+
+            [JsonProperty("cameraSetNameLabel")]
+            public int CameraSetNameLabel { get; set; }
+
+            [JsonProperty("lastMfdScreen")]
+            public int LastMfdScreen { get; set; }
+
+            [JsonProperty("autoSwitchPitMFD")]
+            public bool AutoSwitchPitMFD { get; set; }
+
+            [JsonProperty("realtimeStandingPitFilter")]
+            public int RealtimeStandingPitFilter { get; set; }
+
+        }
+
+        private class AccHud : AbstractSettingsJson<AccHudSettingsJson>
+        {
+            public override string Path => FileUtil.AccConfigPath;
+            public override string FileName => "hud.json";
+
+            public override AccHudSettingsJson Default() => new AccHudSettingsJson();
+        }
+    }
+
+}

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
@@ -38,6 +38,8 @@ namespace RaceElement.Controls.AccHudSettingsNS
             toggleRatingWidget.Unchecked += (s, e) => SaveSettings();
             toggleServerStats.Checked += (s, e) => SaveSettings();
             toggleServerStats.Unchecked += (s, e) => SaveSettings();
+            toggleFps.Checked += (s, e) => SaveSettings();
+            toggleFps.Unchecked += (s, e) => SaveSettings();
         }
 
         private void LoadSettings()
@@ -47,6 +49,7 @@ namespace RaceElement.Controls.AccHudSettingsNS
 
             toggleRatingWidget.IsChecked = json.RatingWidgetVisible == 1;
             toggleServerStats.IsChecked = json.ServerStatsVisible == 1;
+            toggleFps.IsChecked = json.FPSVisible == 1;
         }
 
         private void SaveSettings()
@@ -55,6 +58,7 @@ namespace RaceElement.Controls.AccHudSettingsNS
 
             json.RatingWidgetVisible = toggleRatingWidget.IsChecked.Value ? 1 : 0;
             json.ServerStatsVisible = toggleServerStats.IsChecked.Value ? 1 : 0;
+            json.FPSVisible = toggleFps.IsChecked.Value ? 1 : 0;
 
             _accHud.Save(json);
         }

--- a/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccHudSettings.xaml.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -24,29 +25,28 @@ namespace RaceElement.Controls.AccHudSettingsNS
     /// </summary>
     public partial class AccHudSettings : UserControl
     {
-        private AccHud _accHud;
+        private readonly HudSettingsService hudSettings = new HudSettingsService();
+
 
         public AccHudSettings()
         {
             InitializeComponent();
-            this.Loaded += (s, e) =>
-            {
-                _accHud = new AccHud();
-                LoadSettings();
-            };
+            this.Loaded += (s, e) => LoadSettings();
 
-            toggleRatingWidget.Checked += (s, e) => SaveSettings();
-            toggleRatingWidget.Unchecked += (s, e) => SaveSettings();
-            toggleServerStats.Checked += (s, e) => SaveSettings();
-            toggleServerStats.Unchecked += (s, e) => SaveSettings();
-            toggleFps.Checked += (s, e) => SaveSettings();
-            toggleFps.Unchecked += (s, e) => SaveSettings();
+            AddToggleListener(toggleRatingWidget);
+            AddToggleListener(toggleServerStats);
+            AddToggleListener(toggleFps);
+        }
+
+        private void AddToggleListener(ToggleButton button)
+        {
+            button.Checked += (s, e) => SaveSettings();
+            button.Unchecked += (s, e) => SaveSettings();
         }
 
         private void LoadSettings()
         {
-            var json = _accHud.Get(false);
-            Debug.WriteLine(JsonConvert.SerializeObject(json, Formatting.Indented));
+            var json = hudSettings.Settings().Get(false);
 
             toggleRatingWidget.IsChecked = json.RatingWidgetVisible == 1;
             toggleServerStats.IsChecked = json.ServerStatsVisible == 1;
@@ -55,169 +55,13 @@ namespace RaceElement.Controls.AccHudSettingsNS
 
         private void SaveSettings()
         {
-            var json = _accHud.Get(false);
+            var json = hudSettings.Settings().Get(false);
 
             json.RatingWidgetVisible = toggleRatingWidget.IsChecked.Value ? 1 : 0;
             json.ServerStatsVisible = toggleServerStats.IsChecked.Value ? 1 : 0;
             json.FPSVisible = toggleFps.IsChecked.Value ? 1 : 0;
 
-            _accHud.Save(json);
-        }
-
-        private class AccHudSettingsJson : IGenericSettingsJson
-        {
-            [JsonProperty("safezoneLeft")]
-            public int SafezoneLeft { get; set; }
-
-            [JsonProperty("safezoneTop")]
-            public int SafezoneTop { get; set; }
-
-            [JsonProperty("safezoneRight")]
-            public int SafezoneRight { get; set; }
-
-            [JsonProperty("safezoneBottom")]
-            public int SafezoneBottom { get; set; }
-
-            [JsonProperty("defaultHUDPage")]
-            public int DefaultHUDPage { get; set; }
-
-            [JsonProperty("newOverlayHUDPage")]
-            public int NewOverlayHUDPage { get; set; }
-
-            [JsonProperty("raceNotificationsVisible")]
-            public int RaceNotificationsVisible { get; set; }
-
-            [JsonProperty("ratingWidgetVisible")]
-            public int RatingWidgetVisible { get; set; }
-
-            [JsonProperty("ratingWidgetPracticeFocus")]
-            public int RatingWidgetPracticeFocus { get; set; }
-
-            [JsonProperty("ratingSensitiveWidgetVisibility")]
-            public bool RatingSensitiveWidgetVisibility { get; set; }
-
-            [JsonProperty("basicCarInfoVisible")]
-            public int BasicCarInfoVisible { get; set; }
-
-            [JsonProperty("fPSVisible")]
-            public int FPSVisible { get; set; }
-
-            [JsonProperty("electronicsVisible")]
-            public int ElectronicsVisible { get; set; }
-
-            [JsonProperty("hotlapStandingVisible")]
-            public int HotlapStandingVisible { get; set; }
-
-            [JsonProperty("laptimeInfo01Visible")]
-            public int LaptimeInfo01Visible { get; set; }
-
-            [JsonProperty("leaderboardVisible")]
-            public int LeaderboardVisible { get; set; }
-
-            [JsonProperty("trackMapVisible")]
-            public int TrackMapVisible { get; set; }
-
-            [JsonProperty("raceDirectorInvestigationVisible")]
-            public int RaceDirectorInvestigationVisible { get; set; }
-
-            [JsonProperty("raceRealtimeStandingVisible")]
-            public int RaceRealtimeStandingVisible { get; set; }
-
-            [JsonProperty("raceStandingVisible")]
-            public int RaceStandingVisible { get; set; }
-
-            [JsonProperty("radarVisible")]
-            public int RadarVisible { get; set; }
-
-            [JsonProperty("sessionInfoVisible")]
-            public int SessionInfoVisible { get; set; }
-
-            [JsonProperty("tyreTemps01Visible")]
-            public int TyreTemps01Visible { get; set; }
-
-            [JsonProperty("timeLeftWidgetVisible")]
-            public int TimeLeftWidgetVisible { get; set; }
-
-            [JsonProperty("wrongWayVisible")]
-            public int WrongWayVisible { get; set; }
-
-            [JsonProperty("virtualMirrorVisible")]
-            public int VirtualMirrorVisible { get; set; }
-
-            [JsonProperty("serverStatsVisible")]
-            public int ServerStatsVisible { get; set; }
-
-            [JsonProperty("proximityIndicatorsVisible")]
-            public int ProximityIndicatorsVisible { get; set; }
-
-            [JsonProperty("useMPH")]
-            public int UseMPH { get; set; }
-
-            [JsonProperty("greenLightsVisible")]
-            public int GreenLightsVisible { get; set; }
-
-            [JsonProperty("showDriverNamePlates")]
-            public int ShowDriverNamePlates { get; set; }
-
-            [JsonProperty("chatPopupOnMessage")]
-            public int ChatPopupOnMessage { get; set; }
-
-            [JsonProperty("chatMaxMessageCount")]
-            public int ChatMaxMessageCount { get; set; }
-
-            [JsonProperty("chatShowTimestamps")]
-            public int ChatShowTimestamps { get; set; }
-
-            [JsonProperty("chatFadeoutSeconds")]
-            public int ChatFadeoutSeconds { get; set; }
-
-            [JsonProperty("communicationPanelVisible")]
-            public int CommunicationPanelVisible { get; set; }
-
-            [JsonProperty("communicationPanelMinPriority")]
-            public int CommunicationPanelMinPriority { get; set; }
-
-            [JsonProperty("communicationPanelMaxVisibleTotal")]
-            public int CommunicationPanelMaxVisibleTotal { get; set; }
-
-            [JsonProperty("communicationPanelMaxVisibleSticky")]
-            public int CommunicationPanelMaxVisibleSticky { get; set; }
-
-            [JsonProperty("communicationPanelMaxVisibleNormal")]
-            public int CommunicationPanelMaxVisibleNormal { get; set; }
-
-            [JsonProperty("communicationPanelInCenter")]
-            public int CommunicationPanelInCenter { get; set; }
-
-            [JsonProperty("overallHUDScale")]
-            public double OverallHUDScale { get; set; }
-
-            [JsonProperty("pitInfoAlwaysVisible")]
-            public int PitInfoAlwaysVisible { get; set; }
-
-            [JsonProperty("lightIndicators")]
-            public int LightIndicators { get; set; }
-
-            [JsonProperty("cameraSetNameLabel")]
-            public int CameraSetNameLabel { get; set; }
-
-            [JsonProperty("lastMfdScreen")]
-            public int LastMfdScreen { get; set; }
-
-            [JsonProperty("autoSwitchPitMFD")]
-            public bool AutoSwitchPitMFD { get; set; }
-
-            [JsonProperty("realtimeStandingPitFilter")]
-            public int RealtimeStandingPitFilter { get; set; }
-
-        }
-
-        private class AccHud : AbstractSettingsJson<AccHudSettingsJson>
-        {
-            public override string Path => FileUtil.AccConfigPath;
-            public override string FileName => "hud.json";
-
-            public override AccHudSettingsJson Default() => new AccHudSettingsJson();
+            hudSettings.Settings().Save(json);
         }
     }
 

--- a/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml
@@ -9,8 +9,16 @@
     <Grid>
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="500">
             <Button x:Name="buttonResetLiverySettings">Reset Livery Settings</Button>
-            
-            
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="ACC usually when a custom livery doesn't contain the dds files for either showroom or race lobby starts generating them, this option disables it so you can use the showroom to check out your custom livery whilst working on it.">
+                <ToggleButton x:Name="toggleTexDDS" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+                <Label VerticalAlignment="Center">Allow ACC to generate DDS files (Disable when working on custom liveries)</Label>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Recommended is to generate dds _1 files for driving with Race Element in the Liveries tab in the main menu.">
+                <ToggleButton x:Name="toggleTexCap" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+                <Label VerticalAlignment="Center">Allow ACC to generate DDS files with higher quality.</Label>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="RaceElement.Controls.AccLiverySettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:RaceElement.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="500">
+            <Button x:Name="buttonResetLiverySettings">Reset Livery Settings</Button>
+            
+            
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using RaceElement.Data.ACC.Config;
+using RaceElement.Util.Settings;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace RaceElement.Controls
+{
+    /// <summary>
+    /// Interaction logic for AccLiverySettings.xaml
+    /// </summary>
+    public partial class AccLiverySettings : UserControl
+    {
+        private readonly MenuSettingsService menu = new MenuSettingsService();
+
+        public AccLiverySettings()
+        {
+            InitializeComponent();
+            this.Loaded += (s, e) => LoadSettings();
+            buttonResetLiverySettings.Click += (s, e) => menu.ResetLiverySettings();
+        }
+
+        private void LoadSettings()
+        {
+            var settings = menu.Settings().Get(false);
+            if (settings != null)
+                Debug.WriteLine(JsonConvert.SerializeObject(settings, Formatting.Indented));
+
+            int texCap = settings.TexCap;
+            int texDDS = settings.TexDDS;
+        }
+
+        private void SaveSettings()
+        {
+
+        }
+    }
+}

--- a/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -30,22 +31,38 @@ namespace RaceElement.Controls
         {
             InitializeComponent();
             this.Loaded += (s, e) => LoadSettings();
-            buttonResetLiverySettings.Click += (s, e) => menu.ResetLiverySettings();
+            buttonResetLiverySettings.Click += (s, e) =>
+            {
+                menu.ResetLiverySettings();
+                LoadSettings();
+            };
+
+            AddToggleListener(toggleTexDDS);
+            AddToggleListener(toggleTexCap);
+        }
+
+        private void AddToggleListener(ToggleButton button)
+        {
+            button.Checked += (s, e) => SaveSettings();
+            button.Unchecked += (s, e) => SaveSettings();
         }
 
         private void LoadSettings()
         {
             var settings = menu.Settings().Get(false);
-            if (settings != null)
-                Debug.WriteLine(JsonConvert.SerializeObject(settings, Formatting.Indented));
 
-            int texCap = settings.TexCap;
-            int texDDS = settings.TexDDS;
+            toggleTexDDS.IsChecked = settings.TexCap == 1;
+            toggleTexCap.IsChecked = settings.TexDDS == 0;
         }
 
         private void SaveSettings()
         {
+            var settings = menu.Settings().Get(false);
 
+            settings.TexCap = toggleTexDDS.IsChecked.Value ? 1 : 0;
+            settings.TexDDS = toggleTexCap.IsChecked.Value ? 0 : 1;
+
+            menu.Settings().Save(settings);
         }
     }
 }

--- a/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
@@ -11,9 +11,9 @@
     <Grid>
         <TabControl TabStripPlacement="Left">
             
-            <!--<TabItem Height="60">
+            <TabItem Height="60">
                 <TabItem.Header>
-                    <Grid ToolTip="This allows you to save and activate unlisted server ips for lan discovery in the game.">
+                    <Grid ToolTip="This allows you to modify external camera settings for acc.">
                         <Grid.RowDefinitions>
                             <RowDefinition/>
                             <RowDefinition/>
@@ -27,11 +27,11 @@
                             Width="20"
                         Foreground="White"    
                         />
-                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Replays</TextBlock>
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Camera</TextBlock>
                     </Grid>
                 </TabItem.Header>
-                <local:ReplaySettings Margin="2,0,0,0"></local:ReplaySettings>
-            </TabItem>-->
+                <local:AccCameraSettings Margin="2,0,0,0"></local:AccCameraSettings>
+            </TabItem>
 
             <TabItem Height="60">
                 <TabItem.Header>

--- a/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:local="clr-namespace:RaceElement.Controls"
+             xmlns:hudSettings="clr-namespace:RaceElement.Controls.AccHudSettingsNS"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Margin="2,0,2,0">
     <Grid>
@@ -31,6 +32,29 @@
                 </TabItem.Header>
                 <local:ReplaySettings Margin="2,0,0,0"></local:ReplaySettings>
             </TabItem>-->
+
+            <TabItem Height="60">
+                <TabItem.Header>
+                    <Grid ToolTip="Adjust specific settings for the HUD for ACC.">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <materialDesign:PackIcon
+                       Grid.Row="0"
+                       Kind="MonitorDashboard"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Center"
+                       Height="20"
+                       Width="20"
+                       Foreground="White"    
+                       />
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">HUD</TextBlock>
+                    </Grid>
+                </TabItem.Header>
+                <hudSettings:AccHudSettings Margin="2,0,0,0"></hudSettings:AccHudSettings>
+            </TabItem>
+
 
             <TabItem Height="60">
                 <TabItem.Header>

--- a/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
@@ -10,11 +10,32 @@
              d:DesignHeight="450" d:DesignWidth="800" Margin="2,0,2,0">
     <Grid>
         <TabControl TabStripPlacement="Left">
-            
-          
+
             <TabItem Height="60">
                 <TabItem.Header>
-                    <Grid ToolTip="Adjust specific settings for the HUD for ACC.">
+                    <Grid ToolTip="This allows you to modify livery settings for acc.">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <materialDesign:PackIcon
+                            Grid.Row="0"
+                            Kind="PaintbrushOutline"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            Height="20"
+                            Width="20"
+                            Foreground="White"    
+                        />
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Liveries</TextBlock>
+                    </Grid>
+                </TabItem.Header>
+                <local:AccLiverySettings Margin="2,0,0,0"></local:AccLiverySettings>
+            </TabItem>
+
+            <TabItem Height="60">
+                <TabItem.Header>
+                    <Grid ToolTip="Adjust settings for the in-game ACC HUD.">
                         <Grid.RowDefinitions>
                             <RowDefinition/>
                             <RowDefinition/>
@@ -42,40 +63,18 @@
                             <RowDefinition/>
                         </Grid.RowDefinitions>
                         <materialDesign:PackIcon
-                  Grid.Row="0"
-                  Kind="Camcorder"
-                  VerticalAlignment="Center"
-                  HorizontalAlignment="Center"
-                  Height="20"
-                  Width="20"
-              Foreground="White"    
-              />
-                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Camera</TextBlock>
-                    </Grid>
-                </TabItem.Header>
-                <local:AccCameraSettings Margin="2,0,0,0"></local:AccCameraSettings>
-            </TabItem>
-
-            <TabItem Height="60">
-                <TabItem.Header>
-                    <Grid ToolTip="This allows you to modify livery settings for acc.">
-                        <Grid.RowDefinitions>
-                            <RowDefinition/>
-                            <RowDefinition/>
-                        </Grid.RowDefinitions>
-                        <materialDesign:PackIcon
                             Grid.Row="0"
-                            Kind="PaintbrushOutline"
+                            Kind="Camcorder"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Center"
                             Height="20"
                             Width="20"
-                        Foreground="White"    
-                        />  
-                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Liveries</TextBlock>
+                            Foreground="White"    
+                        />
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Camera</TextBlock>
                     </Grid>
                 </TabItem.Header>
-                <local:AccLiverySettings Margin="2,0,0,0"></local:AccLiverySettings>
+                <local:AccCameraSettings Margin="2,0,0,0"></local:AccCameraSettings>
             </TabItem>
 
             <TabItem Height="60">
@@ -92,7 +91,7 @@
                             HorizontalAlignment="Center"
                             Height="20"
                             Width="20"
-                        Foreground="White"    
+                            Foreground="White"    
                         />
                         <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Serverlist</TextBlock>
                     </Grid>

--- a/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccSettings/AccSettingsTab.xaml
@@ -11,28 +11,7 @@
     <Grid>
         <TabControl TabStripPlacement="Left">
             
-            <TabItem Height="60">
-                <TabItem.Header>
-                    <Grid ToolTip="This allows you to modify external camera settings for acc.">
-                        <Grid.RowDefinitions>
-                            <RowDefinition/>
-                            <RowDefinition/>
-                        </Grid.RowDefinitions>
-                        <materialDesign:PackIcon
-                            Grid.Row="0"
-                            Kind="Camcorder"
-                            VerticalAlignment="Center"
-                            HorizontalAlignment="Center"
-                            Height="20"
-                            Width="20"
-                        Foreground="White"    
-                        />
-                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Camera</TextBlock>
-                    </Grid>
-                </TabItem.Header>
-                <local:AccCameraSettings Margin="2,0,0,0"></local:AccCameraSettings>
-            </TabItem>
-
+          
             <TabItem Height="60">
                 <TabItem.Header>
                     <Grid ToolTip="Adjust specific settings for the HUD for ACC.">
@@ -55,6 +34,49 @@
                 <hudSettings:AccHudSettings Margin="2,0,0,0"></hudSettings:AccHudSettings>
             </TabItem>
 
+            <TabItem Height="60">
+                <TabItem.Header>
+                    <Grid ToolTip="This allows you to modify external camera settings for acc.">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <materialDesign:PackIcon
+                  Grid.Row="0"
+                  Kind="Camcorder"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Center"
+                  Height="20"
+                  Width="20"
+              Foreground="White"    
+              />
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Camera</TextBlock>
+                    </Grid>
+                </TabItem.Header>
+                <local:AccCameraSettings Margin="2,0,0,0"></local:AccCameraSettings>
+            </TabItem>
+
+            <TabItem Height="60">
+                <TabItem.Header>
+                    <Grid ToolTip="This allows you to modify livery settings for acc.">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <materialDesign:PackIcon
+                            Grid.Row="0"
+                            Kind="PaintbrushOutline"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            Height="20"
+                            Width="20"
+                        Foreground="White"    
+                        />  
+                        <TextBlock Grid.Row="1" Style="{DynamicResource MaterialDesignButtonTextBlock}">Liveries</TextBlock>
+                    </Grid>
+                </TabItem.Header>
+                <local:AccLiverySettings Margin="2,0,0,0"></local:AccLiverySettings>
+            </TabItem>
 
             <TabItem Height="60">
                 <TabItem.Header>

--- a/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
@@ -40,7 +40,7 @@ namespace RaceElement.Controls
             InitializeComponent();
 
             _setupRenderer = new FlowDocSetupRenderer();
-
+            ThreadPool.QueueUserWorkItem(x => FetchAllSetups());
             setupsTreeView.SelectedItemChanged += SetupsTreeView_SelectedItemChanged;
 
             buttonEditSetup.Click += (o, e) =>
@@ -49,17 +49,10 @@ namespace RaceElement.Controls
                     SetupEditor.Instance.Open(_selectedSetup);
             };
 
-            this.Loaded += (s, e) => ThreadPool.QueueUserWorkItem(x => FetchAllSetups());
-            this.Unloaded += (s, e) =>
-            {
-                setupsTreeView.Items.Clear();
-            };
-
             Instance = this;
         }
 
-
-        private void ExpandCurrentCombination(string track, string carParseName)
+        private void ExpandCombination(string track, string carParseName)
         {
             if (track == string.Empty || carParseName == string.Empty)
                 return;
@@ -70,10 +63,8 @@ namespace RaceElement.Controls
 
             if (!_expandedHeaders.TryGetValue(carName, out List<string> list))
                 _expandedHeaders.Add(carName, new List<string>() { trackData.GameName });
-            else if (!list.Contains(trackData.GameName))
+            else
                 _expandedHeaders[carName].Add(Regex.Replace(trackData.GameName, "^[a-z]", m => m.Value.ToUpper()));
-
-            Debug.WriteLine($"Driving: {carName} at: {trackData.FullName}");
         }
 
         private void SetupsTreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
@@ -105,7 +96,6 @@ namespace RaceElement.Controls
 
         internal void FetchAllSetups()
         {
-
             DirectoryInfo setupsDirectory = new DirectoryInfo(FileUtil.SetupsPath);
 
             if (!setupsDirectory.Exists)
@@ -120,7 +110,7 @@ namespace RaceElement.Controls
                 var staticPage = ACCSharedMemory.Instance.ReadStaticPageFile();
                 string track = staticPage.Track;
                 string carModel = staticPage.CarModel;
-                ExpandCurrentCombination(track, carModel);
+                ExpandCombination(track, carModel);
 
                 // Find car directories
                 foreach (var carDir in setupsDirectory.GetDirectories())

--- a/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
@@ -106,6 +106,7 @@ namespace RaceElement.Controls
                 setupsTreeView.Items.Clear();
 
 
+
                 // Pre-expand the current car and track leafs
                 var staticPage = ACCSharedMemory.Instance.ReadStaticPageFile();
                 string track = staticPage.Track;
@@ -235,6 +236,11 @@ namespace RaceElement.Controls
                             setupsTreeView.Items.Add(carTreeViewItem);
                     }
                 }
+                ThreadPool.QueueUserWorkItem(x =>
+                {
+                    Thread.Sleep(2000);
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, false, true);
+                });
             }));
         }
 

--- a/Race_Element/Controls/Setup/SetupImporter.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupImporter.xaml.cs
@@ -46,7 +46,7 @@ namespace RaceElement.Controls
                     foreach (ListViewItem selectedItem in listViewTracks.SelectedItems)
                     {
                         Import((string)selectedItem.DataContext, false);
-                        var trackData = NewTracks.FirstOrDefault(x => x.GameName == (string)selectedItem.DataContext);
+                        var trackData = Tracks.FirstOrDefault(x => x.GameName == (string)selectedItem.DataContext);
                         sb.Append($", {trackData.FullName}");
                     }
 
@@ -68,7 +68,7 @@ namespace RaceElement.Controls
         private void BuildTrackList()
         {
             this.listViewTracks.Items.Clear();
-            foreach (AbstractTrackData trackData in NewTracks)
+            foreach (AbstractTrackData trackData in Tracks)
             {
                 ListViewItem trackItem = new ListViewItem()
                 {
@@ -117,7 +117,7 @@ namespace RaceElement.Controls
 
                 if (displayMessage)
                 {
-                    AbstractTrackData trackData = NewTracks.FirstOrDefault(x => x.GameName == track);
+                    AbstractTrackData trackData = Tracks.FirstOrDefault(x => x.GameName == track);
                     MainWindow.Instance.EnqueueSnackbarMessage($"Imported setup \"{_setupName}\" for {modelName} at {trackData.FullName}");
                 }
             }

--- a/Race_Element/Controls/Setup/SetupsTab.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupsTab.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MaterialDesignThemes.Wpf;
 using RaceElement.Controls.Util;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -23,18 +24,15 @@ namespace RaceElement.Controls
 
         private void SetupsTab_Loaded(object sender, RoutedEventArgs e)
         {
-            tabSetupTree.ContextMenu = GetBrowseTabContextMenu();
-        }
-
-        private ContextMenu GetBrowseTabContextMenu()
-        {
-            ContextMenu contextMenu = ContextMenuHelper.DefaultContextMenu();
-
-            MenuItem refresh = ContextMenuHelper.DefaultMenuItem("Refresh", PackIconKind.Refresh);
-            refresh.Click += (s, e) => SetupBrowser.Instance.FetchAllSetups();
-            contextMenu.Items.Add(refresh);
-
-            return contextMenu;
+            tabSetupTree.MouseUp += (s, e) =>
+            {
+                if (e.ChangedButton == System.Windows.Input.MouseButton.Right)
+                    ThreadPool.QueueUserWorkItem(x =>
+                    {
+                        SetupBrowser.Instance.FetchAllSetups();
+                        MainWindow.Instance.EnqueueSnackbarMessage("Refreshed Setups");
+                    });
+            };
         }
     }
 }

--- a/Race_Element/Controls/Setup/SetupsTab.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupsTab.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MaterialDesignThemes.Wpf;
 using RaceElement.Controls.Util;
+using System.Diagnostics;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -18,21 +19,21 @@ namespace RaceElement.Controls
         {
             InitializeComponent();
 
-            this.Loaded += SetupsTab_Loaded;
+            tabSetupTree.MouseRightButtonUp += (s, e) =>
+            {
+                ThreadPool.QueueUserWorkItem(x =>
+                {
+                    Debug.WriteLine("Refreshting setups with right click");
+                    MainWindow.Instance.EnqueueSnackbarMessage("Refreshing Setups.... Please wait");
+                    SetupBrowser.Instance.FetchAllSetups();
+                    MainWindow.Instance.ClearSnackbar();
+                    MainWindow.Instance.EnqueueSnackbarMessage("Refreshed Setups");
+                });
+                e.Handled = true;
+            };
+
             Instance = this;
         }
 
-        private void SetupsTab_Loaded(object sender, RoutedEventArgs e)
-        {
-            tabSetupTree.MouseUp += (s, e) =>
-            {
-                if (e.ChangedButton == System.Windows.Input.MouseButton.Right)
-                    ThreadPool.QueueUserWorkItem(x =>
-                    {
-                        SetupBrowser.Instance.FetchAllSetups();
-                        MainWindow.Instance.EnqueueSnackbarMessage("Refreshed Setups");
-                    });
-            };
-        }
     }
 }

--- a/Race_Element/Controls/Telemetry/RaceSessions/RaceSessionBrowser.xaml.cs
+++ b/Race_Element/Controls/Telemetry/RaceSessions/RaceSessionBrowser.xaml.cs
@@ -286,7 +286,7 @@ namespace RaceElement.Controls
                 foreach (DbTrackData track in allTracks)
                 {
                     string trackName;
-                    var trackData = Data.ACC.Tracks.TrackData.NewTracks.FirstOrDefault(x => x.GameName == track.ParseName);
+                    var trackData = Data.ACC.Tracks.TrackData.Tracks.FirstOrDefault(x => x.GameName == track.ParseName);
                     if (trackData == null) trackName = track.ParseName;
                     else trackName = trackData.FullName;
 
@@ -316,7 +316,7 @@ namespace RaceElement.Controls
                     var carModel = ConversionFactory.ParseCarName(carData.ParseName);
                     string carName = ConversionFactory.GetNameFromCarModel(carModel);
                     string trackName = dbTrackData.ParseName;
-                    var trackData = Data.ACC.Tracks.TrackData.NewTracks.FirstOrDefault(x => x.GameName == dbTrackData.ParseName);
+                    var trackData = Data.ACC.Tracks.TrackData.Tracks.FirstOrDefault(x => x.GameName == dbTrackData.ParseName);
                     if (dbTrackData != null) trackName = trackData.FullName;
 
                     session.UtcStart = DateTime.SpecifyKind(session.UtcStart, DateTimeKind.Utc);
@@ -633,7 +633,7 @@ namespace RaceElement.Controls
                 FilterTelemetrySplines(_currentData.ToDictionary(x => x.Key, x => x.Value));
 
 
-                var trackData = Data.ACC.Tracks.TrackData.NewTracks.FirstOrDefault(x => x.Guid == GetSelectedTrack());
+                var trackData = Data.ACC.Tracks.TrackData.Tracks.FirstOrDefault(x => x.Guid == GetSelectedTrack());
                 PlotUtil.trackData = trackData;
                 int fullSteeringLock = SteeringLock.Get(CarDataCollection.GetCarData(CurrentDatabase, GetSelectedCar()).ParseName);
 

--- a/Race_Element/MainWindow.xaml.cs
+++ b/Race_Element/MainWindow.xaml.cs
@@ -248,7 +248,6 @@ namespace RaceElement
             Environment.Exit(0);
         }
 
-
         private System.Windows.Forms.NotifyIcon _notifyIcon;
         private void InitializeSystemTrayIcon()
         {

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.3.2")]
-[assembly: AssemblyFileVersion("0.2.3.2")]
+[assembly: AssemblyVersion("0.2.3.3")]
+[assembly: AssemblyFileVersion("0.2.3.3")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.3.3")]
-[assembly: AssemblyFileVersion("0.2.3.3")]
+[assembly: AssemblyVersion("0.2.3.4")]
+[assembly: AssemblyFileVersion("0.2.3.4")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -297,6 +297,9 @@
     <Compile Include="Controls\Settings\AccManagerSettings\AccManagerSettingsTab.xaml.cs">
       <DependentUpon>AccManagerSettingsTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Settings\AccSettings\AccCameraSettings.xaml.cs">
+      <DependentUpon>AccCameraSettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Settings\AccSettings\AccHudSettings.xaml.cs">
       <DependentUpon>AccHudSettings.xaml</DependentUpon>
     </Compile>
@@ -432,6 +435,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Settings\AccManagerSettings\AccManagerSettingsTab.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Settings\AccSettings\AccCameraSettings.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -303,6 +303,9 @@
     <Compile Include="Controls\Settings\AccSettings\AccHudSettings.xaml.cs">
       <DependentUpon>AccHudSettings.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Settings\AccSettings\AccLiverySettings.xaml.cs">
+      <DependentUpon>AccLiverySettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Settings\AccSettings\AccSettingsTab.xaml.cs">
       <DependentUpon>AccSettingsTab.xaml</DependentUpon>
     </Compile>
@@ -443,6 +446,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Settings\AccSettings\AccHudSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Settings\AccSettings\AccLiverySettings.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -297,6 +297,9 @@
     <Compile Include="Controls\Settings\AccManagerSettings\AccManagerSettingsTab.xaml.cs">
       <DependentUpon>AccManagerSettingsTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Settings\AccSettings\AccHudSettings.xaml.cs">
+      <DependentUpon>AccHudSettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Settings\AccSettings\AccSettingsTab.xaml.cs">
       <DependentUpon>AccSettingsTab.xaml</DependentUpon>
     </Compile>
@@ -429,6 +432,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Settings\AccManagerSettings\AccManagerSettingsTab.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Settings\AccSettings\AccHudSettings.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format.
- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree.
- Race Element Settings Tab: Added option to by default generate 4K dds_1 files instead of downsizing them to 2K resolution like the game does.
- ACC Settings Tab: Added ACC Settings only available through json editing.
  - ACC HUD Settings: Allows you to toggle settings like the rating widget.
  - ACC Camera Settings: Allows you to modify helicam settings.
  - ACC Livery Settings: Allows you to toggle settings like texDDS.