### PR TITLE
0.2.3.8

### DIFF
--- a/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
+++ b/Race_Element.Data.ACC/Race Element.Data.ACC.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.0" />
-    <PackageReference Include="LiteDB" Version="5.0.16" />
+    <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayMapBar/MapBar.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayMapBar/MapBar.cs
@@ -4,11 +4,13 @@ using System.Drawing;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayMapBar
 {
+#if DEBUG
     [Overlay(Name = "Map Bar",
         Description = "A circle showing all drivers on track",
         OverlayType = OverlayType.Release,
         OverlayCategory = OverlayCategory.Track
         )]
+#endif
     internal sealed class MapBar : AbstractOverlay
     {
         private readonly MapBarConfiguration _config = new MapBarConfiguration();

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayMapBar/MapBar.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayMapBar/MapBar.cs
@@ -1,0 +1,31 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using System.Drawing;
+
+namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayMapBar
+{
+    [Overlay(Name = "Map Bar",
+        Description = "A circle showing all drivers on track",
+        OverlayType = OverlayType.Release,
+        OverlayCategory = OverlayCategory.Track
+        )]
+    internal sealed class MapBar : AbstractOverlay
+    {
+        private readonly MapBarConfiguration _config = new MapBarConfiguration();
+        private sealed class MapBarConfiguration : OverlayConfiguration
+        {
+            public MapBarConfiguration() => AllowRescale = true;
+        }
+
+        public MapBar(Rectangle rectangle) : base(rectangle, "Map Bar")
+        {
+            Width = 250;
+            Height = 100;
+        }
+
+        public override void Render(Graphics g)
+        {
+            g.FillRectangle(new SolidBrush(Color.FromArgb(170, 0, 0, 0)), new Rectangle(0, 0, (int)(Width / Scale), (int)(Height / Scale)));
+        }
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Driving/OverlayTrackCorners/TrackCornersOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OverlayTrackCorners/TrackCornersOverlay.cs
@@ -211,17 +211,22 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayCornerNames
 
             if (_currentTrack != null)
             {
-                (int, string) corner = _currentTrack.CornerNames.FirstOrDefault(x => x.Key.IsInRange(carPosition)).Value;
-                if (corner.Item1 > 0)
+                var items = _currentTrack.CornerNames.Where(x => x.Key.IsInRange(carPosition));
+                if (items.Any())
                 {
-                    cornerNumber = $"{corner.Item1}";
 
-                    if (_config.CornerNames.Names)
-                        cornerName = corner.Item2;
+                    (int, string) corner = items.First().Value;
+                    if (corner.Item1 > 0)
+                    {
+                        cornerNumber = $"{corner.Item1}";
+
+                        if (_config.CornerNames.Names)
+                            cornerName = corner.Item2;
+                    }
+                    if (corner.Item1 == -1)
+                        if (_config.CornerNames.Names)
+                            cornerName = corner.Item2;
                 }
-                if (corner.Item1 == -1)
-                    if (_config.CornerNames.Names)
-                        cornerName = corner.Item2;
             }
 
             _cornerNumberHeader?.Draw(g, cornerNumber, Scale);

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
@@ -67,9 +67,9 @@ Description = "(BETA) A table representing a leaderboard.")]
 
             float fontSize = 9;
             var font = FontUtil.FontSegoeMono(fontSize);
-            _table = new InfoTable(fontSize, new int[] { (int)(font.Size * 20), (int)(font.Size * 9), (int)(font.Size * 8), (int)(font.Size * 30) });
+            _table = new InfoTable(fontSize, new int[] { (int)(font.Size * 18), (int)(font.Size * 9), (int)(font.Size * 8), (int)(font.Size * 30) });
 
-            this.Width = 700;
+            this.Width = 650;
             this.Height = 900;
         }
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayEntryList/EntryListOverlay.cs
@@ -271,28 +271,24 @@ Description = "(BETA) A table representing a leaderboard.")]
 
                         firstRow[3] = $"L{kv.Value.RealtimeCarUpdate.Laps + 1} | ";
 
-                        if (Tracks.Any())
+                        var matchingTracks = Tracks.Where(x => x.FullName == broadCastTrackData.TrackName).ToList();
+                        if (matchingTracks.Any())
                         {
-                            var matchingTracks = Tracks.Where(x => x.GameName == broadCastTrackData.TrackName);
-                            if (matchingTracks.Any())
+                            var currentTrack = matchingTracks[0];
+                            if (currentTrack.CornerNames.Any())
                             {
-                                var currentTrack = matchingTracks.First();
-                                if (currentTrack.CornerNames.Any())
+                                var items = currentTrack.CornerNames.Where(x => x.Key.IsInRange(kv.Value.RealtimeCarUpdate.SplinePosition));
+                                if (items.Any() && items.First().Value.Item1 != 0)
                                 {
-                                    var items = currentTrack.CornerNames.Where(x => x.Key.IsInRange(kv.Value.RealtimeCarUpdate.SplinePosition));
-                                    if (items.Any())
-                                        if (items.First().Value.Item1 != 0)
-                                        {
-                                            (int, string) corner = items.First().Value;
-                                            if (corner.Item1 != 0)
-                                            {
-                                                StringBuilder builder = new StringBuilder();
-                                                builder.Append("T");
-                                                builder.Append(corner.Item1.ToString().FillEnd(2, ' ') + ' ');
-                                                builder.Append(corner.Item2);
-                                                firstRow[3] += $"{builder}";
-                                            }
-                                        }
+                                    (int, string) corner = items.First().Value;
+                                    if (corner.Item1 != 0)
+                                    {
+                                        StringBuilder builder = new StringBuilder();
+                                        builder.Append("T");
+                                        builder.Append(corner.Item1.ToString().FillEnd(2, ' ') + ' ');
+                                        builder.Append(corner.Item2);
+                                        firstRow[3] += $"{builder}";
+                                    }
                                 }
                             }
                         }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
@@ -28,25 +28,27 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
         public sealed override void BeforeStop() => _panel = null;
 
         public sealed override bool ShouldRender() => true;
-
         public sealed override void Render(Graphics g)
         {
+            // add summary line
             long totalPixels = 0;
             long pixelsPerSecond = 0;
-
             OverlaysACC.ActiveOverlays.ForEach(hud =>
             {
                 long pixels = (long)(hud.Scale * hud.Width * hud.Height);
                 pixelsPerSecond += (long)(pixels * hud.RefreshRateHz);
                 totalPixels += pixels;
             });
+            _panel.AddLine($"  - {OverlaysACC.ActiveOverlays.Count} HUDs -  ", $"Pixels: {totalPixels}, Per Second: {pixelsPerSecond}");
 
-            _panel.AddLine($"{OverlaysACC.ActiveOverlays.Count} activated", $"Pixels Area: {totalPixels}, Per Second: {pixelsPerSecond}");
+            // add details lines for all active huds
             OverlaysACC.ActiveOverlays.ForEach(hud =>
             {
                 long pixels = (long)(hud.Scale * hud.Width * hud.Height);
-                _panel.AddLine(hud.Name, $"X: {hud.X}, Y:{hud.Y}, Scale: {hud.Scale:F3}, Herz: {hud.RefreshRateHz}, Visible: {hud.ShouldRender()}, Pixels: {pixels:F0}, PPS: {hud.RefreshRateHz * pixels:F0}");
+                _panel.AddLine(hud.Name, $"({hud.X}, {hud.Y}, {hud.Width}, {hud.Height}, scale: {hud.Scale:F3}), herz: {hud.RefreshRateHz}, vis: {hud.ShouldRender()}, pix: {pixels:F0}, PPS: {hud.RefreshRateHz * pixels:F0}");
             });
+
+            // draw the panel
             _panel.Draw(g);
         }
     }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
@@ -19,8 +19,8 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
         private InfoPanel _panel;
         public HUDsOverlay(Rectangle rectangle) : base(rectangle, "HUDs")
         {
-            Width = 700;
-            Height = 170;
+            Width = 1000;
+            Height = 300;
             RefreshRateHz = 10;
         }
 
@@ -31,7 +31,22 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
 
         public sealed override void Render(Graphics g)
         {
-            OverlaysACC.ActiveOverlays.ForEach(hud => _panel.AddLine(hud.Name, $"X: {hud.X}, Y:{hud.Y}, Scale: {hud.Scale:F3}, Herz: {hud.RefreshRateHz}, Visible: {hud.ShouldRender()}"));
+            long totalPixels = 0;
+            long pixelsPerSecond = 0;
+
+            OverlaysACC.ActiveOverlays.ForEach(hud =>
+            {
+                long pixels = (long)(hud.Scale * hud.Width * hud.Height);
+                pixelsPerSecond += (long)(pixels * hud.RefreshRateHz);
+                totalPixels += pixels;
+            });
+
+            _panel.AddLine($"{OverlaysACC.ActiveOverlays.Count} activated", $"Pixels Area: {totalPixels}, Per Second: {pixelsPerSecond}");
+            OverlaysACC.ActiveOverlays.ForEach(hud =>
+            {
+                long pixels = (long)(hud.Scale * hud.Width * hud.Height);
+                _panel.AddLine(hud.Name, $"X: {hud.X}, Y:{hud.Y}, Scale: {hud.Scale:F3}, Herz: {hud.RefreshRateHz}, Visible: {hud.ShouldRender()}, Pixels: {pixels:F0}, PPS: {hud.RefreshRateHz * pixels:F0}");
+            });
             _panel.Draw(g);
         }
     }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
@@ -1,12 +1,7 @@
 ﻿using RaceElement.HUD.Overlay.Configuration;
 using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.Util;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
 {
@@ -28,17 +23,15 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
             Height = 170;
             RefreshRateHz = 10;
         }
-        public sealed override void BeforeStart()
-        {
-            _panel = new InfoPanel(11, Width);
-        }
-        public override bool ShouldRender() => true;
 
-        public override void Render(Graphics g)
-        {
-            foreach (var item in OverlaysACC.ActiveOverlays)
-                _panel.AddLine(item.Name, $"X: {item.X}, Y:{item.Y}, Scale: {item.Scale:F3}, Herz: {item.RefreshRateHz}, Visible: {item.ShouldRender()}");
+        public sealed override void BeforeStart() => _panel = new InfoPanel(11, Width);
+        public sealed override void BeforeStop() => _panel = null;
 
+        public sealed override bool ShouldRender() => true;
+
+        public sealed override void Render(Graphics g)
+        {
+            OverlaysACC.ActiveOverlays.ForEach(hud => _panel.AddLine(hud.Name, $"X: {hud.X}, Y:{hud.Y}, Scale: {hud.Scale:F3}, Herz: {hud.RefreshRateHz}, Visible: {hud.ShouldRender()}"));
             _panel.Draw(g);
         }
     }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayHUDs/HUDsOverlay.cs
@@ -1,0 +1,45 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.Util;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayHUDs
+{
+    [Overlay(Name = "HUDs",
+        Description = "Shows info about active HUDs",
+        OverlayType = OverlayType.Debug)]
+    internal sealed class HUDsOverlay : AbstractOverlay
+    {
+        private readonly HUDsConfiguration _config = new HUDsConfiguration();
+        private sealed class HUDsConfiguration : OverlayConfiguration
+        {
+            public HUDsConfiguration() => this.AllowRescale = true;
+        }
+
+        private InfoPanel _panel;
+        public HUDsOverlay(Rectangle rectangle) : base(rectangle, "HUDs")
+        {
+            Width = 700;
+            Height = 170;
+            RefreshRateHz = 10;
+        }
+        public sealed override void BeforeStart()
+        {
+            _panel = new InfoPanel(11, Width);
+        }
+        public override bool ShouldRender() => true;
+
+        public override void Render(Graphics g)
+        {
+            foreach (var item in OverlaysACC.ActiveOverlays)
+                _panel.AddLine(item.Name, $"X: {item.X}, Y:{item.Y}, Scale: {item.Scale:F3}, Herz: {item.RefreshRateHz}, Visible: {item.ShouldRender()}");
+
+            _panel.Draw(g);
+        }
+    }
+}

--- a/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
+++ b/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Overlays\Driving\OverlayDamage\DamageOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayWheelSlip\WheelSlipOverlay.cs" />
     <Compile Include="Overlays\Pitwall\DebugInfoHelper.cs" />
+    <Compile Include="Overlays\Pitwall\OverlayHUDs\HUDsOverlay.cs" />
     <Compile Include="Overlays\Pitwall\OverlayRenderTest\RenderTestOverlay.cs" />
     <Compile Include="Overlays\Pitwall\OverlayACC\AccOverlay.cs" />
     <Compile Include="Overlays\Pitwall\OverlayBroadcastRealtime\BroadcastRealtimeOverlay.cs" />

--- a/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
+++ b/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
@@ -47,7 +47,7 @@
     </PackageReference>
     <PackageReference Include="MouseKeyHook" Version="5.7.1" />
     <PackageReference Include="ScottPlot">
-      <Version>4.1.67</Version>
+      <Version>4.1.68</Version>
     </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
+++ b/Race_Element.HUD.ACC/Race Element.HUD.ACC.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Overlays\Driving\OverlayLapDeltaTrace\LapDeltaTraceOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayLapDeltaTrace\LapDeltaDataCollector.cs" />
     <Compile Include="Overlays\Driving\OverlayLapDeltaTrace\LapDeltaGraph.cs" />
+    <Compile Include="Overlays\Driving\OverlayMapBar\MapBar.cs" />
     <Compile Include="Overlays\Driving\OverlayTrackCorners\TrackCornersOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayCurrentGear\CurrentGearOverlay.cs" />
     <Compile Include="Overlays\Driving\OverlayDamage\DamageOverlay.cs" />

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,8 @@ namespace RaceElement.Controls
     {
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
+            {"0.2.3.8", "- App hotkeys: Added Ctrl + (F4/W) to shut down the app when the gui is open."+
+                        "\n- ?"},
             {"0.2.3.6", "- Fix Setup browser from intercepting right clicks." },
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
                         "\n- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,8 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.2.3.8", "- App hotkeys: Added Ctrl + (F4/W) to shut down the app when the gui is open."+
-                        "\n- Adaptive text scaling by windows is now permanently disabled for the app."},
+                        "\n- Adaptive text scaling by windows is now permanently disabled for the app."+
+                        "\n- Add HUDs hud in pitwall tab to display all active huds and some extra information about them."},
             {"0.2.3.6", "- Fix Setup browser from intercepting right clicks." },
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
                         "\n- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,7 @@ namespace RaceElement.Controls
         internal readonly static Dictionary<string, string> Notes = new Dictionary<string, string>()
         {
             {"0.2.3.8", "- App hotkeys: Added Ctrl + (F4/W) to shut down the app when the gui is open."+
-                        "\n- ?"},
+                        "\n- Adaptive text scaling by windows is now permanently disabled for the app."},
             {"0.2.3.6", "- Fix Setup browser from intercepting right clicks." },
             {"0.2.3.4", "- Added Clock HUD to Pitwall Tab: Displays your system time in either 24h or am/pm format."+
                         "\n- Setup Browser: When refreshing the livery browser, the current car and track combo will open in the tree."+

--- a/Race_Element/Controls/Setup/SetupImporter.xaml
+++ b/Race_Element/Controls/Setup/SetupImporter.xaml
@@ -32,7 +32,7 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0" Orientation="Vertical">
-                <ListView x:Name="listViewTracks" HorizontalContentAlignment="Center"
+                <ListView x:Name="listViewTracks" HorizontalContentAlignment="Center" FontSize="12"
                   ToolTip="Click the correct track and the setup will automatically be copied in the correct folder." Cursor="Hand">
                 </ListView>
             </StackPanel>

--- a/Race_Element/Controls/TitleBar.xaml.cs
+++ b/Race_Element/Controls/TitleBar.xaml.cs
@@ -147,6 +147,7 @@ namespace RaceElement.Controls
 
         private void ButtonExit_Click(object sender, RoutedEventArgs e)
         {
+            MainWindow.Instance.EnqueueSnackbarMessage("Shutting down Race Element");
             MainWindow.Instance.SaveLocation();
             Environment.Exit(0);
         }

--- a/Race_Element/MainWindow.xaml.cs
+++ b/Race_Element/MainWindow.xaml.cs
@@ -61,6 +61,18 @@ namespace RaceElement
             _uiSettings = new UiSettings();
             _accManagerSettings = new AccManagerSettings();
 
+            this.KeyUp += (s, e) =>
+            {
+                if (Keyboard.Modifiers == ModifierKeys.Control && (e.Key == Key.F4 || e.Key == Key.W))
+                {
+                    EnqueueSnackbarMessage("Shutting down Race Element");
+                    MainWindow.Instance.SaveLocation();
+                    Environment.Exit(0);
+                }
+            };
+
+
+            // titlebar mouse actions
             this.titleBar.MouseLeftButtonDown += TitleBar_MouseLeftButtonDown;
             this.titleBar.MouseLeftButtonUp += TitleBar_MouseLeftButtonUp;
             this.titleBar.MouseLeave += (s, e) => { _stopDecreaseOpacty = true; e.Handled = true; this.Opacity = MaxOpacity; };

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.3.6")]
-[assembly: AssemblyFileVersion("0.2.3.6")]
+[assembly: AssemblyVersion("0.2.3.7")]
+[assembly: AssemblyFileVersion("0.2.3.7")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Properties/AssemblyInfo.cs
+++ b/Race_Element/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Windows;
 )]
 
 //      Major Version, Minor Version, Build Number, Revision
-[assembly: AssemblyVersion("0.2.3.7")]
-[assembly: AssemblyFileVersion("0.2.3.7")]
+[assembly: AssemblyVersion("0.2.3.8")]
+[assembly: AssemblyFileVersion("0.2.3.8")]
 [assembly: NeutralResourcesLanguage("")]

--- a/Race_Element/Properties/app.manifest
+++ b/Race_Element/Properties/app.manifest
@@ -41,13 +41,13 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
+ 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</dpiAware>
     </windowsSettings>
   </application>
-  -->
+ 
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -115,7 +115,7 @@
     <PackageReference Include="Costura.Fody" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="DdsFileTypePlusHack" Version="1.0.4" />
     <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="all" />
-    <PackageReference Include="LiteDB" Version="5.0.16" />
+    <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
@@ -150,13 +150,13 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="obs-websocket-dotnet" Version="5.0.0.3" />
-    <PackageReference Include="Octokit" Version="7.0.1" />
+    <PackageReference Include="Octokit" Version="8.0.1" />
     <PackageReference Include="Quartz" Version="3.6.3" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.3" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.3" />
-    <PackageReference Include="ScottPlot" Version="4.1.65" />
-    <PackageReference Include="ScottPlot.WPF" Version="4.1.65" />
-    <PackageReference Include="SharpCompress" Version="0.33.0" />
+    <PackageReference Include="ScottPlot" Version="4.1.68" />
+    <PackageReference Include="ScottPlot.WPF" Version="4.1.68" />
+    <PackageReference Include="SharpCompress" Version="0.34.1" />
     <PackageReference Include="SLOBSharp" Version="1.1.4" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />


### PR DESCRIPTION
- App hotkeys: Added Ctrl + (F4/W) to shut down the app when the gui is open.
- Adaptive text scaling by windows is now permanently disabled for the app.
- Add HUDs hud in pitwall tab to display all active huds and some extra information about them.