### PR TITLE
1.0.1.4

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
@@ -74,7 +74,7 @@ internal class TwitchChatCommandHandler
 
             _client.SendReply(_client.JoinedChannels[0], e.Command.ChatMessage.Id, replyMessage);
 
-            if (_overlay._config.Bot.DisplayBotAnswers && !command.Equals("commands"))
+            if (_overlay._config.Bot.DisplayBotResponses && !command.Equals("commands"))
                 _overlay._messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} - {replyMessage}"));
         }
         catch (Exception ex)

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
@@ -53,6 +53,7 @@ internal class TwitchChatCommandHandler
 
     internal void OnChatCommandReceived(object sender, OnChatCommandReceivedArgs e)
     {
+        if (e.Command.CommandIdentifier != ChatCommandCharacter) return;
         try
         {
             string command = e.Command.CommandText.ToLower();

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
@@ -37,9 +37,9 @@ internal class TwitchChatCommandHandler
 
         Responses = [
             new("commands", GetCommandsList),
-            new("hud", () => "These are Race Element HUDs, it's free to use: https://race.elementfuture.com"),
+            new("bot", () => "Race Element, it's free to use: https://race.elementfuture.com"),
             new("damage", () => $"{TimeSpan.FromSeconds(Damage.GetTotalRepairTime(_overlay.pagePhysics)):mm\\:ss\\.fff}"),
-            new("temps", () => $"Air {_overlay.pagePhysics.AirTemp:F2}°, Track {_overlay.pagePhysics.RoadTemp:F2}°, Wind {_overlay.pageGraphics.WindSpeed:F1} km/h, Grip: {_overlay.pageGraphics.trackGripStatus}"),
+            new("temps", GetTemperaturesResponse),
             new("track", GetCurrentTrackResponse),
             new("car", GetCurrentCarResponse),
             new("steering", GetSteeringLockResponse),
@@ -89,6 +89,20 @@ internal class TwitchChatCommandHandler
         Span<ChatResponse> responses = Responses.AsSpan();
         for (int i = 1; i < responses.Length; i++) sb.Append($"{responses[i].Command}{(i < responses.Length - 1 ? ", " : string.Empty)}");
         _ = sb.Append('.');
+        return sb.ToString();
+    }
+
+    private string GetTemperaturesResponse()
+    {
+        StringBuilder sb = new();
+        if (_overlay.pagePhysics.AirTemp > 0)
+        {
+            sb.Append($"Air {_overlay.pagePhysics.AirTemp:F2}°, Track {_overlay.pagePhysics.RoadTemp:F2}°, Wind {_overlay.pageGraphics.WindSpeed:F1} km/h, Grip: {_overlay.pageGraphics.trackGripStatus}");
+        }
+        else
+        {
+            sb.Append($"Air {_overlay.broadCastRealTime.AmbientTemp}° ,Track {_overlay.broadCastRealTime.TrackTemp}°");
+        }
         return sb.ToString();
     }
     private string GetCarAheadResponse()

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatCommandHandler.cs
@@ -2,7 +2,6 @@
 using RaceElement.Data;
 using RaceElement.Data.ACC.Cars;
 using RaceElement.Data.ACC.EntryList;
-using RaceElement.HUD.Overlay.Internal;
 using RaceElement.Util;
 using System;
 using System.Diagnostics;
@@ -12,12 +11,13 @@ using TwitchLib.Client;
 using TwitchLib.Client.Events;
 using WebSocketSharp;
 using static RaceElement.Data.ACC.EntryList.EntryListTracker;
+using static RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat.TwitchChatOverlay;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat;
 
 internal class TwitchChatCommandHandler
 {
-    private readonly AbstractOverlay _overlay;
+    private readonly TwitchChatOverlay _overlay;
 
     private readonly TwitchClient _client;
 
@@ -30,7 +30,7 @@ internal class TwitchChatCommandHandler
     }
     private readonly ChatResponse[] Responses;
 
-    public TwitchChatCommandHandler(AbstractOverlay overlay, TwitchClient client)
+    public TwitchChatCommandHandler(TwitchChatOverlay overlay, TwitchClient client)
     {
         _overlay = overlay;
         _client = client;
@@ -73,6 +73,9 @@ internal class TwitchChatCommandHandler
                 return;
 
             _client.SendReply(_client.JoinedChannels[0], e.Command.ChatMessage.Id, replyMessage);
+
+            if (_overlay._config.Bot.DisplayBotAnswers && !command.Equals("commands"))
+                _overlay._messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} - {replyMessage}"));
         }
         catch (Exception ex)
         {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -43,7 +43,7 @@ internal class TwitchChatConfiguration : OverlayConfiguration
         public bool IsEnabled { get; init; } = true;
 
         [ToolTip("When enabled the bot responses will also be displayed in the Twitch Chat HUD.")]
-        public bool DisplayBotResponses { get; init; } = false;
+        public bool DisplayBotResponses { get; init; } = true;
     }
 
     [ConfigGrouping("Colors", "Adjust the colors of the text and the background")]

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -35,6 +35,17 @@ internal class TwitchChatConfiguration : OverlayConfiguration
         public int Height { get; init; } = 150;
     }
 
+    [ConfigGrouping("Bot", "Adjust the twitch chat bot.")]
+    public BotGrouping Bot { get; init; } = new();
+    public class BotGrouping
+    {
+        [ToolTip("Enable or disable the chat bot")]
+        public bool IsEnabled { get; init; } = true;
+
+        [ToolTip("When enabled the bot answers will also be displayed in the Twitch Chat HUD.")]
+        public bool DisplayBotAnswers { get; init; } = false;
+    }
+
     [ConfigGrouping("Colors", "Adjust the colors of the text and the background")]
     public ColorGrouping Colors { get; init; } = new();
     public class ColorGrouping
@@ -57,5 +68,8 @@ internal class TwitchChatConfiguration : OverlayConfiguration
 
         [ToolTip("Adjust the text color when someone subscribes.")]
         public Color SubscriptionColor { get; init; } = Color.FromArgb(255, 255, 215, 0);
+
+        [ToolTip("Adjust the text color when Display Bot Answers is enabled.")]
+        public Color BotColor { get; init; } = Color.FromArgb(255, 255, 69, 0);
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -42,8 +42,8 @@ internal class TwitchChatConfiguration : OverlayConfiguration
         [ToolTip("Enable or disable the chat bot")]
         public bool IsEnabled { get; init; } = true;
 
-        [ToolTip("When enabled the bot answers will also be displayed in the Twitch Chat HUD.")]
-        public bool DisplayBotAnswers { get; init; } = false;
+        [ToolTip("When enabled the bot responses will also be displayed in the Twitch Chat HUD.")]
+        public bool DisplayBotResponses { get; init; } = false;
     }
 
     [ConfigGrouping("Colors", "Adjust the colors of the text and the background")]

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -70,6 +70,6 @@ internal class TwitchChatConfiguration : OverlayConfiguration
         public Color SubscriptionColor { get; init; } = Color.FromArgb(255, 255, 215, 0);
 
         [ToolTip("Adjust the text color when Display Bot Answers is enabled.")]
-        public Color BotColor { get; init; } = Color.FromArgb(255, 255, 69, 0);
+        public Color BotColor { get; init; } = Color.FromArgb(255, 0, 255, 255);
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -26,13 +26,16 @@ internal class TwitchChatConfiguration : OverlayConfiguration
     public class ShapeGrouping
     {
         [ToolTip("Either new text will come from the top or it will come from the bottom of the hud.")]
-        public Direction Direction { get; set; } = Direction.TopToBottom;
+        public Direction Direction { get; init; } = Direction.TopToBottom;
 
         [IntRange(100, 500, 2)]
         public int Width { get; init; } = 400;
 
         [IntRange(100, 500, 2)]
         public int Height { get; init; } = 150;
+
+        [ToolTip("When disabled the hud will only appear when the engine is running.\nWhen disabled and spectating the twitch chat HUD will dissapear.")]
+        public bool AlwaysVisible { get; init; } = true;
     }
 
     [ConfigGrouping("Bot", "Adjust the twitch chat bot.")]

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
-using System.Threading.Tasks;
 using TwitchLib.Client;
 using TwitchLib.Communication.Clients;
 using TwitchLib.Communication.Models;

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -110,6 +110,12 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         }
 
         _twitchClient.OnConnected += (s, e) => _messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Connected"));
+
+        if (!_config.Shape.AlwaysVisible)
+        {
+            if (!_twitchClient.IsConnected)
+                _twitchClient.Connect();
+        }
     }
 
     public sealed override void BeforeStop()
@@ -137,7 +143,13 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         _dividerPen?.Dispose();
     }
 
-    public sealed override bool ShouldRender() => true;
+    public sealed override bool ShouldRender()
+    {
+        if (_config.Shape.AlwaysVisible)
+            return true;
+
+        return base.ShouldRender();
+    }
     public sealed override void Render(Graphics g)
     {
         if (_isPreviewing) return;

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -67,7 +67,7 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         _textBrushRaid = new SolidBrush(Color.FromArgb(255, _config.Colors.RaidColor));
         _textBrushBits = new SolidBrush(Color.FromArgb(255, _config.Colors.BitsColor));
         _textBrushSubscription = new SolidBrush(Color.FromArgb(255, _config.Colors.SubscriptionColor));
-        if (_config.Bot.DisplayBotAnswers) _textBrushBot = new SolidBrush(Color.FromArgb(255, _config.Colors.BotColor));
+        _textBrushBot = new SolidBrush(Color.FromArgb(255, _config.Colors.BotColor));
 
         _dividerPen = new(new SolidBrush(Color.FromArgb(25, _config.Colors.TextColor)), 0.5f);
         _font = FontUtil.FontRoboto(11);
@@ -110,7 +110,7 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
             _twitchClient.OnChatCommandReceived += _chatCommandHandler.OnChatCommandReceived;
         }
 
-        _twitchClient.OnConnected += (s, e) => _messages.Add(new(MessageType.Chat, $"{DateTime.Now:HH:mm} Race Element - Connected"));
+        _twitchClient.OnConnected += (s, e) => _messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Connected"));
     }
 
     public sealed override void BeforeStop()

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,9 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.0.1.4", "- Twitch Chat HUD:"+
+                    "\n  - Add option to enable or disable chat bot."+
+                    "\n  - Add option to display bot responses in hud."},
         {"1.0.1.2", "- Twitch Chat HUD:"+
                     "\n  - Connected message is now only visible to you."+
                     "\n  - Added option to make new messages appear at the bottom of the hud."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,9 +7,10 @@ public static class ReleaseNotes
     internal readonly static Dictionary<string, string> Notes = new()
     {
         {"1.0.1.4", "- Twitch Chat HUD:"+
-                    "\n  - Add option to enable or disable chat bot."+
-                    "\n  - Add option to display bot responses in hud."+
-                    "\n  - ahead and behind commands now have a parameter called 'best', instead of showing the last lap it will show the best lap."},
+                    "\n  - Added option to enable or disable chat bot."+
+                    "\n  - Added option to only display the hud when the engine is running, disabling this option also hides the HUD during spectator."+
+                    "\n  - Added option to display bot responses in hud."+
+                    "\n  - ahead and behind commands now have a parameter called 'best', instead of showing the last lap it will show the best lap.(for example: +behind best)"},
         {"1.0.1.2", "- Twitch Chat HUD:"+
                     "\n  - Connected message is now only visible to you."+
                     "\n  - Added option to make new messages appear at the bottom of the hud."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -8,7 +8,8 @@ public static class ReleaseNotes
     {
         {"1.0.1.4", "- Twitch Chat HUD:"+
                     "\n  - Add option to enable or disable chat bot."+
-                    "\n  - Add option to display bot responses in hud."},
+                    "\n  - Add option to display bot responses in hud."+
+                    "\n  - ahead and behind commands now have a parameter called 'best', instead of showing the last lap it will show the best lap."},
         {"1.0.1.2", "- Twitch Chat HUD:"+
                     "\n  - Connected message is now only visible to you."+
                     "\n  - Added option to make new messages appear at the bottom of the hud."+

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -21,7 +21,7 @@
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
         <ApplicationRevision>1</ApplicationRevision>
-        <ApplicationVersion>1.0.1.3</ApplicationVersion>
+        <ApplicationVersion>1.0.1.4</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -67,12 +67,12 @@
     <PropertyGroup>
         <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
         <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.1.3</AssemblyVersion>
+        <AssemblyVersion>1.0.1.4</AssemblyVersion>
         <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
         <Title>Race Element</Title>
         <PackageIcon>race element icon 2.png</PackageIcon>
         <Authors>Element Future</Authors>
-        <Version>1.0.1.3</Version>
+        <Version>1.0.1.4</Version>
         <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Minimized|AnyCPU'">

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -21,7 +21,7 @@
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
         <ApplicationRevision>1</ApplicationRevision>
-        <ApplicationVersion>1.0.1.2</ApplicationVersion>
+        <ApplicationVersion>1.0.1.3</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -67,12 +67,12 @@
     <PropertyGroup>
         <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
         <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.1.2</AssemblyVersion>
+        <AssemblyVersion>1.0.1.3</AssemblyVersion>
         <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
         <Title>Race Element</Title>
         <PackageIcon>race element icon 2.png</PackageIcon>
         <Authors>Element Future</Authors>
-        <Version>1.0.1.2</Version>
+        <Version>1.0.1.3</Version>
         <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Minimized|AnyCPU'">


### PR DESCRIPTION
- Twitch Chat HUD:
  - Added option to enable or disable chat bot.
  - Added option to only display the hud when the engine is running, disabling this option also hides the HUD during spectator.
  - Added option to display bot responses in hud.
  - ahead and behind commands now have a parameter called 'best', instead of showing the last lap it will show the best lap.(for example: +behind best)