### PR TITLE
1.0.3.2

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Driving/Accelerometer/AccelerometerOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Accelerometer/AccelerometerOverlay.cs
@@ -13,7 +13,9 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayAccelerometer;
 
 [Overlay(Name = "Accelerometer", Version = 1.00, OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Physics,
-    Description = "G-meter showing lateral and longitudinal g-forces.")]
+    Description = "G-meter showing lateral and longitudinal g-forces.",
+    Authors = ["Kris Vickers", "Reinier Klarenberg"]
+)]
 internal sealed class AccelerometerOverlay : AbstractOverlay
 {
     private readonly AccelleroConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/AverageLaptime/AverageLaptime.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/AverageLaptime/AverageLaptime.cs
@@ -17,7 +17,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayAverageLapTime;
 Description = "Shows last valid laps and the average lap time.",
 OverlayType = OverlayType.Drive,
 OverlayCategory = OverlayCategory.Lap,
-Version = 1.00)]
+Version = 1.00,
+Authors = ["FG"])]
 internal class AverageLapTimeOverlay : AbstractOverlay
 {
 
@@ -93,7 +94,7 @@ internal class AverageLapTimeOverlay : AbstractOverlay
         {
             _fastestAvgTime = averageLapTime;
         }
-            
+
     }
 
     public override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Driving/BoostGauge/BoostGaugeOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/BoostGauge/BoostGaugeOverlay.cs
@@ -8,7 +8,8 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayBoostGauge;
 
 [Overlay(Name = "Boost Gauge", Version = 1.00, OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Driving,
-  Description = "Progress bar showing boost percentage.")]
+  Description = "Progress bar showing boost percentage.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class BoostGaugeOverlay : AbstractOverlay
 {
     private readonly BoostConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/BoostGauge/BoostGaugeOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/BoostGauge/BoostGaugeOverlay.cs
@@ -14,10 +14,7 @@ internal sealed class BoostGaugeOverlay : AbstractOverlay
     private readonly BoostConfiguration _config = new();
     private sealed class BoostConfiguration : OverlayConfiguration
     {
-        public BoostConfiguration()
-        {
-            GenericConfiguration.AllowRescale = true;
-        }
+        public BoostConfiguration() => GenericConfiguration.AllowRescale = true;
     }
 
     private readonly InfoPanel _panel;

--- a/Race_Element.HUD.ACC/Overlays/Driving/CarInfo/CarInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/CarInfo/CarInfoOverlay.cs
@@ -14,7 +14,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayCarInfo;
 
 [Overlay(Name = "Car Info", Version = 1.00, OverlayType = OverlayType.Drive,
     Description = "A panel showing the damage time. Optionally showing current tyre set, fuel per lap, exhaust temp and water temp.",
-    OverlayCategory = OverlayCategory.Car)]
+    OverlayCategory = OverlayCategory.Car,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class CarInfoOverlay : AbstractOverlay
 {
     private readonly CarInfoConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/CornerData/CornerDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/CornerData/CornerDataOverlay.cs
@@ -18,7 +18,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayCornerData;
 [Overlay(Name = "Corner Data",
         Description = "(early access/alpha)\nShows Corner Delta and other data like speeds for each corner.",
         OverlayCategory = OverlayCategory.Lap,
-        OverlayType = OverlayType.Drive)]
+        OverlayType = OverlayType.Drive,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class CornerDataOverlay : AbstractOverlay
 {
     internal readonly CornerDataConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/CurrentGear/CurrentGearOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/CurrentGear/CurrentGearOverlay.cs
@@ -16,7 +16,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayCurrentGear;
 
 [Overlay(Name = "Current Gear", Version = 1.00, OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Driving,
-Description = "Shows the selected gear.")]
+Description = "Shows the selected gear.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class CurrentGearOverlay : AbstractOverlay
 {
     private readonly CurrentGearConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/EcuMapInfo/EcuMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/EcuMapInfo/EcuMapOverlay.cs
@@ -6,7 +6,8 @@ using System.Drawing;
 namespace RaceElement.HUD.ACC.Overlays.OverlayEcuMapInfo;
 
 [Overlay(Name = "ECU Maps", Version = 1.00, OverlayType = OverlayType.Drive,
-    Description = "A panel showing information about the current ECU Map.")]
+    Description = "A panel showing information about the current ECU Map.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class EcuMapOverlay : AbstractOverlay
 {
     private const int PanelWidth = 270;

--- a/Race_Element.HUD.ACC/Overlays/Driving/Electronics/ElectronicsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Electronics/ElectronicsOverlay.cs
@@ -36,7 +36,7 @@ internal sealed class ElectronicsOverlay : AbstractOverlay
 
     public ElectronicsOverlay(Rectangle rectangle) : base(rectangle, "Electronics")
     {
-        RefreshRateHz = 2;
+        RefreshRateHz = 5;
     }
 
     public override void BeforeStart()

--- a/Race_Element.HUD.ACC/Overlays/Driving/Electronics/ElectronicsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Electronics/ElectronicsOverlay.cs
@@ -12,7 +12,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayElectronics;
 [Overlay(Name = "Electronics",
     Description = "Shows current Brake Bias, ABS, TC1, TC2 and engine map setting.",
     OverlayCategory = OverlayCategory.Car,
-    OverlayType = OverlayType.Drive)]
+    OverlayType = OverlayType.Drive,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class ElectronicsOverlay : AbstractOverlay
 {
     private readonly ElectronicsConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -11,7 +11,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayFuelInfo;
     Description = "A panel showing information about the fuel: laps left, fuel to end of race. Optionally showing stint information.",
     Version = 1.00,
     OverlayType = OverlayType.Drive,
-    OverlayCategory = OverlayCategory.Car)]
+    OverlayCategory = OverlayCategory.Car,
+Authors = ["Kris Vickers", "Reinier Klarenberg"])]
 internal sealed class FuelInfoOverlay : AbstractOverlay
 {
     private readonly InfoPanel _infoPanel;

--- a/Race_Element.HUD.ACC/Overlays/Driving/InputBars/InputBarsOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/InputBars/InputBarsOverlay.cs
@@ -8,7 +8,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayInputBars;
 
 [Overlay(Name = "Input Bars", Version = 1.00, OverlayType = OverlayType.Drive,
   Description = "Live input bars of throttle and brake.",
-  OverlayCategory = OverlayCategory.Inputs)]
+  OverlayCategory = OverlayCategory.Inputs,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class InputBarsOverlay : AbstractOverlay
 {
     private readonly InputBarsConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/InputTrace/InputTraceOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/InputTrace/InputTraceOverlay.cs
@@ -6,7 +6,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayInputTrace;
 
 [Overlay(Name = "Input Trace", Version = 1.00, OverlayType = OverlayType.Drive,
     Description = "Live graph of steering, throttle and brake inputs.",
-    OverlayCategory = OverlayCategory.Inputs)]
+    OverlayCategory = OverlayCategory.Inputs,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class InputTraceOverlay : AbstractOverlay
 {
     private readonly InputTraceConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/InputValues/InputValuesOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/InputValues/InputValuesOverlay.cs
@@ -11,7 +11,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayInputValues;
 [Overlay(Name = "Input Values",
     Description = "Shows raw Throttle and Brake data.",
     OverlayCategory = OverlayCategory.Inputs,
-    OverlayType = OverlayType.Drive
+    OverlayType = OverlayType.Drive,
+Authors = ["Reinier Klarenberg"]
     )]
 internal class InputValuesOverlay : AbstractOverlay
 {

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapDeltaBar/LapDeltaOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapDeltaBar/LapDeltaOverlay.cs
@@ -14,7 +14,8 @@ using System.Linq;
 namespace RaceElement.HUD.ACC.Overlays.OverlayLapDeltaBar;
 
 [Overlay(Name = "Lap Delta Bar", Description = "A customizable Laptime Delta Bar", OverlayType = OverlayType.Drive, Version = 1,
-    OverlayCategory = OverlayCategory.Lap)]
+    OverlayCategory = OverlayCategory.Lap,
+Authors = ["Reinier Klarenberg"])]
 internal class LapDeltaOverlay : AbstractOverlay
 {
     private readonly LapTimeDeltaConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapDeltaTrace/LapDeltaTraceOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapDeltaTrace/LapDeltaTraceOverlay.cs
@@ -13,7 +13,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayLapDeltaTrace;
     Description = "Shows a graph of the lap delta.",
     OverlayCategory = OverlayCategory.Lap,
     OverlayType = OverlayType.Drive,
-    Version = 1)]
+    Version = 1,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class LapDeltaTraceOverlay : AbstractOverlay
 {
     private readonly LapDeltaTraceConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapInfo/LapInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapInfo/LapInfoOverlay.cs
@@ -11,7 +11,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayLapDeltaInfo;
 
 [Overlay(Name = "Lap Info", Version = 1.00, OverlayType = OverlayType.Drive,
     Description = "A panel with a bar showing the current delta.\nOptionally showing the sector times, last lap, best lap and the potential best.",
-    OverlayCategory = OverlayCategory.Lap)]
+    OverlayCategory = OverlayCategory.Lap,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class LapInfoOverlay : AbstractOverlay
 {
     private readonly LapInfoConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTableOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTableOverlay.cs
@@ -13,8 +13,11 @@ using System.Linq;
 
 namespace RaceElement.HUD.ACC.Overlays.OverlayLapTimeTable;
 
-[Overlay(Name = "Lap Table", Description = "A table showing time for each lap and optionally sectors.", OverlayType = OverlayType.Drive, Version = 1.00,
-    OverlayCategory = OverlayCategory.Lap)]
+[Overlay(Name = "Lap Table",
+Description = "A table showing time for each lap and optionally sectors.",
+OverlayType = OverlayType.Drive, Version = 1.00,
+OverlayCategory = OverlayCategory.Lap,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class LapTableOverlay : AbstractOverlay
 {
     private readonly LapTimeTableConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/OversteerTrace/OversteerTraceOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/OversteerTrace/OversteerTraceOverlay.cs
@@ -7,7 +7,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlaySlipAngle;
 [Overlay(Name = "Oversteer Trace", Version = 1.00,
     Description = "Live graph of oversteer in red and understeer in blue.",
     OverlayType = OverlayType.Drive,
-    OverlayCategory = OverlayCategory.Physics)]
+    OverlayCategory = OverlayCategory.Physics,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class OversteerTraceOverlay : AbstractOverlay
 {
     private readonly OversteerTraceConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/PressureHelper/PressureHelperOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/PressureHelper/PressureHelperOverlay.cs
@@ -14,7 +14,8 @@ using System.Threading.Tasks;
 namespace RaceElement.HUD.ACC.Overlays.Driving.PressureHelper
 {
     [Overlay(Name = "Pressure Helper",
-Description = "Helps you with setting up tyre pressures.\n(Alpha version, in progress but could be tested to verify data, options won't do anything for now.)")]
+Description = "Helps you with setting up tyre pressures.\n(Alpha version, in progress but could be tested to verify data, options won't do anything for now.)",
+Authors = ["Reinier Klarenberg"])]
     internal class PressureHelperOverlay : AbstractOverlay
     {
         private readonly PressureHelperConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/PressureTrace/PressureTraceOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/PressureTrace/PressureTraceOverlay.cs
@@ -9,7 +9,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayPressureTrace;
     Version = 1.00,
     OverlayType = OverlayType.Drive,
     Description = "Live graphs of the tyre pressures, green is within range, red is too high, blue is too low.",
-    OverlayCategory = OverlayCategory.Physics)]
+    OverlayCategory = OverlayCategory.Physics,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class PressureTraceOverlay : AbstractOverlay
 {
     private readonly PressureTraceOverlayConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/RaceInfo/RaceInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/RaceInfo/RaceInfoOverlay.cs
@@ -6,7 +6,8 @@ using System.Drawing;
 
 namespace RaceElement.HUD.ACC.Overlays.OverlayRaceInfo;
 
-[Overlay(Name = "Race Info", Description = "(BETA) Provides information for the current race session.", OverlayType = OverlayType.Drive, Version = 1.00)]
+[Overlay(Name = "Race Info", Description = "(BETA) Provides information for the current race session.", OverlayType = OverlayType.Drive, Version = 1.00,
+Authors = ["Reinier Klarenberg"])]
 internal class RaceInfoOverlay : AbstractOverlay
 {
     private readonly RaceInfoConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/Radar/OverlayRadar.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Radar/OverlayRadar.cs
@@ -18,7 +18,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlaySpotter;
     Description = "Beta",
     Version = 1.00,
     OverlayType = OverlayType.Drive,
-    OverlayCategory = OverlayCategory.Driving
+    OverlayCategory = OverlayCategory.Driving,
+    Authors = ["Reinier Klarenberg"]
 )]
 internal sealed class RadarOverlay : AbstractOverlay
 {

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataConfiguration.cs
@@ -10,5 +10,18 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData
     internal sealed class SectorDataConfiguration : OverlayConfiguration
     {
         public SectorDataConfiguration() => GenericConfiguration.AllowRescale = true;
+
+        [ConfigGrouping("Table", "Adjust settings for the sector data table")]
+        public TableGrouping Table { get; init; } = new();
+        public class TableGrouping
+        {
+            [ToolTip("Sets the amount of previous sectors visible, in general settings it to more than 3 will also show you the data from previous laps.")]
+            [IntRange(1, 13, 1)]
+            public int Rows { get; set; } = 4;
+
+            [ToolTip("Changed the amount of corner roundering for each cell in the table.")]
+            [IntRange(0, 12, 2)]
+            public int Roundness { get; init; } = 2;
+        }
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData
+{
+    internal sealed class SectorDataConfiguration : OverlayConfiguration
+    {
+        public SectorDataConfiguration() => GenericConfiguration.AllowRescale = true;
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataJob.cs
@@ -5,12 +5,12 @@ using System;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData
 {
-    internal class SectorDataModel
+    internal record SectorDataModel
     {
         /// <summary>
         /// 0 indexed
         /// </summary>
-        public required int SectorIndex { get; set; }
+        public required int SectorIndex { get; init; }
 
         public required float VelocityMin { get; set; }
         public required float VelocityMax { get; set; }

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataJob.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData
 {
-    internal record SectorDataModel
+    internal sealed record SectorDataModel
     {
         /// <summary>
         /// 0 indexed
@@ -16,7 +16,7 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData
         public required float VelocityMax { get; set; }
     }
 
-    internal class SectorDataJob : AbstractLoopJob
+    internal sealed class SectorDataJob : AbstractLoopJob
     {
         private int _lastSectorIndex = -1;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -158,7 +158,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
     {
         for (int i = 0; i < _config.Table.Rows; i++)
         {
-            if (i > _Sectors.Count)
+            if (i >= _Sectors.Count)
                 break;
 
             DrawableTextCell sectorCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][0];

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -20,17 +20,6 @@ internal sealed class SectorDataOverlay : AbstractOverlay
 {
     private readonly SectorDataConfiguration _config = new();
 
-
-    /*
-
-        | Sector | vMin   | vMax   |
-        | 3      | 110.99 | 236.29 |
-        | 2      | 60.97  | 246.56 |
-        | 1      | 96.59  | 245.33 |
-
-     */
-
-
     /// <summary>
     /// New sector at 0 index;
     /// </summary>
@@ -49,7 +38,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         RefreshRateHz = 0.5f;
     }
 
-    public override void SetupPreviewData()
+    public sealed override void SetupPreviewData()
     {
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 0, VelocityMin = 101, VelocityMax = 140 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 1, VelocityMin = 56, VelocityMax = 160 });
@@ -68,7 +57,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.3f });
     }
 
-    public override void BeforeStart()
+    public sealed override void BeforeStart()
     {
         float scale = this.Scale;
         if (IsPreviewing) scale = 1f;
@@ -152,7 +141,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         Debug.WriteLine($"Sector {e.SectorIndex + 1} completed:\n{JsonConvert.SerializeObject(e)}");
     }
 
-    public override void BeforeStop()
+    public sealed override void BeforeStop()
     {
         _graphicsGrid?.Dispose();
         _font?.Dispose();
@@ -166,23 +155,21 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         RaceSessionTracker.Instance.OnNewSessionStarted -= Instance_OnNewSessionStarted;
     }
 
-    public override void Render(Graphics g)
+    public sealed override void Render(Graphics g)
     {
-
-
         for (int i = 0; i < _config.Table.Rows; i++)
         {
             if (i > _Sectors.Count)
                 break;
 
             DrawableTextCell sectorCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][0];
-            sectorCell.UpdateText($"{_Sectors[i].SectorIndex + 1}");
+            sectorCell?.UpdateText($"{_Sectors[i].SectorIndex + 1}");
 
             DrawableTextCell vMinCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][1];
-            vMinCell.UpdateText($"{_Sectors[i].VelocityMin:F2}");
+            vMinCell?.UpdateText($"{_Sectors[i].VelocityMin:F2}");
 
             DrawableTextCell vMaxCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][2];
-            vMaxCell.UpdateText($"{_Sectors[i].VelocityMax:F2}");
+            vMaxCell?.UpdateText($"{_Sectors[i].VelocityMax:F2}");
         }
 
         _graphicsGrid?.Draw(g);

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -71,7 +71,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
 
         float fontHeight = (int)(_font.GetHeight(120));
         int columnHeight = (int)(Math.Ceiling(fontHeight) + 1 * scale);
-        int[] columnWidths = [(int)(70f * scale), (int)(100f * scale), (int)(100f * scale)];
+        int[] columnWidths = [(int)(70f * scale), (int)(75 * scale), (int)(75 * scale)];
         int totalWidth = columnWidths[0] + columnWidths[1] + columnWidths[2];
 
         // set up backgrounds of each cell
@@ -106,6 +106,8 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         this.Width = totalWidth + 1;
         this.Height = columnHeight * (_config.Table.Rows + 1) + 1; // +1 for header
 
+
+        StringFormat sf = new() { Alignment = StringAlignment.Far };
         // config data rows
         for (int row = 1; row <= _config.Table.Rows; row++)
         {
@@ -116,6 +118,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
                 int width = columnWidths[column];
                 RectangleF rect = new(x, y, width, columnHeight);
                 DrawableTextCell cell = new(rect, _font);
+                if (column > 0) cell.StringFormat = sf;
                 cell.CachedBackground = _columnBackgrounds[column];
                 _graphicsGrid.Grid[row][column] = cell;
                 cell.UpdateText("");
@@ -132,7 +135,11 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         RaceSessionTracker.Instance.OnNewSessionStarted += Instance_OnNewSessionStarted;
     }
 
-    private void Instance_OnNewSessionStarted(object sender, RaceElement.Data.ACC.Database.SessionData.DbRaceSession e) => _Sectors.Clear();
+    private void Instance_OnNewSessionStarted(object sender, RaceElement.Data.ACC.Database.SessionData.DbRaceSession e)
+    {
+        _Sectors.Clear();
+        ClearData();
+    }
 
     private void SectorCompleted(object sender, SectorDataModel e)
     {
@@ -173,5 +180,20 @@ internal sealed class SectorDataOverlay : AbstractOverlay
 
         _graphicsGrid?.Draw(g);
 
+    }
+
+    private void ClearData()
+    {
+        for (int i = 0; i < _config.Table.Rows; i++)
+        {
+            DrawableTextCell sectorCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][0];
+            sectorCell?.UpdateText($"");
+
+            DrawableTextCell vMinCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][1];
+            vMinCell?.UpdateText($"");
+
+            DrawableTextCell vMaxCell = (DrawableTextCell)_graphicsGrid.Grid[1 + i][2];
+            vMaxCell?.UpdateText($"");
+        }
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -7,11 +7,33 @@ using System.Drawing;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData;
 
-#if DEBUG
-[Overlay(Name = "Sector Data", Description = "Shows data from previous sectors")]
-#endif
-internal class SectorDataOverlay : AbstractOverlay
+[Overlay(Name = "Sector Data",
+Description = "Shows data from previous sectors",
+Authors = ["Reinier Klarenberg"])]
+internal sealed class SectorDataOverlay : AbstractOverlay
 {
+    private readonly SectorDataConfiguration _config = new();
+
+
+    /*
+
+                L2     L3     Best
+         S1
+         S2
+         S3  
+
+
+        | Sector | vMin   | vMax   |
+        | 3      | 110.99 | 236.29 |
+        | 2      | 60.97  | 246.56 |
+        | 1      | 96.59  | 245.33 |
+
+
+
+     */
+
+
+
     private readonly List<SectorDataModel> _Sectors = [];
     private SectorDataJob _datajob;
 
@@ -20,6 +42,13 @@ internal class SectorDataOverlay : AbstractOverlay
         Width = 300;
         Height = 50;
         RefreshRateHz = 0.5f;
+    }
+
+    public override void SetupPreviewData()
+    {
+        _Sectors.Add(new SectorDataModel() { SectorIndex = 1, VelocityMin = 0, VelocityMax = 0 });
+        _Sectors.Add(new SectorDataModel() { SectorIndex = 2, VelocityMin = 0, VelocityMax = 0 });
+        _Sectors.Add(new SectorDataModel() { SectorIndex = 0, VelocityMin = 0, VelocityMax = 0 });
     }
 
     public override void BeforeStart()

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -17,17 +17,10 @@ internal sealed class SectorDataOverlay : AbstractOverlay
 
     /*
 
-                L2     L3     Best
-         S1
-         S2
-         S3  
-
-
         | Sector | vMin   | vMax   |
         | 3      | 110.99 | 236.29 |
         | 2      | 60.97  | 246.56 |
         | 1      | 96.59  | 245.33 |
-
 
 
      */

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -14,7 +14,7 @@ using System.Linq;
 namespace RaceElement.HUD.ACC.Overlays.Driving.SectorData;
 
 [Overlay(Name = "Sector Data",
-Description = "Shows data from previous sectors",
+Description = "Shows data from previous sectors. New driven sectors appear at the top",
 Authors = ["Reinier Klarenberg"])]
 internal sealed class SectorDataOverlay : AbstractOverlay
 {

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -74,7 +74,7 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         int[] columnWidths = [(int)(70f * scale), (int)(100f * scale), (int)(100f * scale)];
         int totalWidth = columnWidths[0] + columnWidths[1] + columnWidths[2];
 
-        // set up backgrounds and invalid ones
+        // set up backgrounds of each cell
         Color colorDefault = Color.FromArgb(190, Color.Black);
         using HatchBrush columnBrushDefault = new(HatchStyle.LightUpwardDiagonal, colorDefault, Color.FromArgb(colorDefault.A - 25, colorDefault));
         _columnBackgrounds = new CachedBitmap[columns];
@@ -106,7 +106,6 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         this.Width = totalWidth + 1;
         this.Height = columnHeight * (_config.Table.Rows + 1) + 1; // +1 for header
 
-
         // config data rows
         for (int row = 1; row <= _config.Table.Rows; row++)
         {
@@ -118,8 +117,8 @@ internal sealed class SectorDataOverlay : AbstractOverlay
                 RectangleF rect = new(x, y, width, columnHeight);
                 DrawableTextCell cell = new(rect, _font);
                 cell.CachedBackground = _columnBackgrounds[column];
-                cell.UpdateText("");
                 _graphicsGrid.Grid[row][column] = cell;
+                cell.UpdateText("");
             }
         }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/SectorData/SectorDataOverlay.cs
@@ -45,16 +45,16 @@ internal sealed class SectorDataOverlay : AbstractOverlay
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 0, VelocityMin = 101, VelocityMax = 140 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 1, VelocityMin = 56, VelocityMax = 160 });
-        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.3f });
+        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.37f });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 0, VelocityMin = 101, VelocityMax = 140 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 1, VelocityMin = 56, VelocityMax = 160 });
-        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.3f });
+        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 178.31f });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 0, VelocityMin = 101, VelocityMax = 140 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 1, VelocityMin = 56, VelocityMax = 160 });
-        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.3f });
+        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 189.33f });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 0, VelocityMin = 101, VelocityMax = 140 });
         _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 1, VelocityMin = 56, VelocityMax = 160 });
-        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 188.3f });
+        _Sectors.Insert(0, new SectorDataModel() { SectorIndex = 2, VelocityMin = 88, VelocityMax = 187.34f });
     }
 
     public sealed override void BeforeStart()

--- a/Race_Element.HUD.ACC/Overlays/Driving/ShiftIndicator/ShiftIndicatorOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/ShiftIndicator/ShiftIndicatorOverlay.cs
@@ -16,7 +16,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayShiftIndicator;
     Description = "Shift Bar with RPM Text. Adjustable colors and percentages.",
     Version = 1.00,
     OverlayType = OverlayType.Drive,
-    OverlayCategory = OverlayCategory.Driving)]
+    OverlayCategory = OverlayCategory.Driving,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class ShiftIndicatorOverlay : AbstractOverlay
 {
     private readonly ShiftIndicatorConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/Speedometer/SpeedometerOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Speedometer/SpeedometerOverlay.cs
@@ -12,7 +12,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlaySpeedometer;
 [Overlay(Name = "Speedometer",
     Description = "Displays a circular gauge with the current speed in km/h.",
     OverlayCategory = OverlayCategory.Driving,
-    OverlayType = OverlayType.Drive)]
+    OverlayType = OverlayType.Drive,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class SpeedometerOverlay(Rectangle rectangle) : AbstractOverlay(rectangle, "Speedometer")
 {
     private readonly SpeedometerConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/Steering/SteeringOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Steering/SteeringOverlay.cs
@@ -12,7 +12,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayInputs;
 
 [Overlay(Name = "Steering", Version = 1.00, OverlayType = OverlayType.Drive,
     Description = "Displays the Steering Input.",
-    OverlayCategory = OverlayCategory.Inputs)]
+    OverlayCategory = OverlayCategory.Inputs,
+Authors = ["FG", "Reinier Klarenberg"])]
 internal sealed class SteeringOverlay : AbstractOverlay
 {
     private readonly SteeringConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackBar/TrackBarOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackBar/TrackBarOverlay.cs
@@ -13,7 +13,8 @@ using static RaceElement.Data.ACC.Tracks.TrackData;
 namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayTrackBar;
 
 [Overlay(Name = "Track Bar",
-         Description = "A bar displaying a flat and zoomed in version of the Track Circle HUD.")]
+         Description = "A bar displaying a flat and zoomed in version of the Track Circle HUD.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class TrackBarOverlay : AbstractOverlay
 {
     private readonly TrackBarConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackCircle/TrackCircleOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackCircle/TrackCircleOverlay.cs
@@ -13,7 +13,8 @@ using static RaceElement.Data.ACC.Tracks.TrackData;
 namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayTrackCircle;
 
 [Overlay(Name = "Track Circle",
-        Description = "Shows the progression of all cars on track in a track circle.")]
+        Description = "Shows the progression of all cars on track in a track circle.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class TrackCircleOverlay : AbstractOverlay
 {
     private readonly TrackCircleConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackCorners/TrackCornersOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackCorners/TrackCornersOverlay.cs
@@ -19,7 +19,8 @@ namespace ACCManager.HUD.ACC.Overlays.OverlayCornerNames;
     Description = "Shows corner/sector names for each track.",
     OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Track,
-    Version = 1.00)]
+    Version = 1.00,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class TrackCornersOverlay : AbstractOverlay
 {
     private readonly CornerNamesConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
@@ -11,7 +11,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayTrackInfo;
 
 [Overlay(Name = "Track Info", Version = 1.00, OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Track,
-    Description = "A panel showing information about the track state: grip, temperatures and wind.\nOptionally showing the global flag, session type and time of day.")]
+    Description = "A panel showing information about the track state: grip, temperatures and wind.\nOptionally showing the global flag, session type and time of day.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class TrackInfoOverlay : AbstractOverlay
 {
     private readonly TrackInfoConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoOverlay.cs
@@ -13,7 +13,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayTyreInfo;
 
 [Overlay(Name = "Tyre Info", Version = 1.00, OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Car,
-    Description = "Shows tyre temperatures and more. Put it on top of vanilla in-game tyre hud.")]
+    Description = "Shows tyre temperatures and more. Put it on top of vanilla in-game tyre hud.",
+Authors = ["Reinier Klarenberg"])]
 internal sealed class TyreInfoOverlay : AbstractOverlay
 {
     private readonly TyreInfoConfig _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/WheelSlip/WheelSlipOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/WheelSlip/WheelSlipOverlay.cs
@@ -12,7 +12,8 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.OverlayWheelSlip;
 [Overlay(Name = "Wheel Slip",
     Description = "Shows wheel slip angle and ratio of each tyre.",
     OverlayCategory = OverlayCategory.Physics,
-    OverlayType = OverlayType.Drive)]
+    OverlayType = OverlayType.Drive,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class WheelSlipOverlay : AbstractOverlay
 {
     private readonly WheelSlipConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/Wind/WindOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/Wind/WindOverlay.cs
@@ -12,7 +12,8 @@ namespace RaceElement.HUD.ACC.Overlays.OverlayWind;
 [Overlay(Name = "Wind Direction", Description = "Shows wind direction relative to car heading.",
     OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Track,
-    Version = 1.00)]
+    Version = 1.00,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class WindDirectionOverlay : AbstractOverlay
 {
     private readonly WindDirectionConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/DualSenseXOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/DualSenseXOverlay.cs
@@ -13,7 +13,8 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayDualSenseX;
 [Overlay(Name = "DualSense X",
     Description = "Adds active triggers for the DualSense 5 controller using DSX on steam.\n See Guide in the Discord of Race Element for instructions.",
     OverlayCategory = OverlayCategory.Inputs,
-    OverlayType = OverlayType.Pitwall)]
+    OverlayType = OverlayType.Pitwall,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class DualSenseXOverlay : AbstractOverlay
 {
     private readonly DualSenseXConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/DualSenseXOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/DualSenseXOverlay.cs
@@ -52,7 +52,7 @@ internal sealed class DualSenseXOverlay : AbstractOverlay
             SetLighting();
         }
 
-        Packet tcPacket = TriggerHaptics.HandleAcceleration(pagePhysics, _config.ThrottleHaptics);
+        Packet tcPacket = TriggerHaptics.HandleAcceleration(ref pagePhysics, _config.ThrottleHaptics);
         if (tcPacket != null)
         {
             Send(tcPacket);
@@ -60,7 +60,7 @@ internal sealed class DualSenseXOverlay : AbstractOverlay
             //HandleResponse(response);
         }
 
-        Packet absPacket = TriggerHaptics.HandleBraking(pagePhysics, _config.BrakeHaptics);
+        Packet absPacket = TriggerHaptics.HandleBraking(ref pagePhysics, _config.BrakeHaptics);
         if (absPacket != null)
         {
             Send(absPacket);
@@ -117,8 +117,7 @@ internal sealed class DualSenseXOverlay : AbstractOverlay
             Debug.WriteLine("===================================================================");
 
             Debug.WriteLine($"Status: {response.Status}");
-            DateTime CurrentTime = DateTime.Now;
-            TimeSpan Timespan = CurrentTime - _timeSent;
+            TimeSpan Timespan = DateTime.Now - _timeSent;
             // First send shows high Milliseconds response time for some reason
             Debug.WriteLine($"Time Received: {response.TimeReceived}, took: {Timespan.TotalMilliseconds} to receive response from DSX");
             Debug.WriteLine($"isControllerConnected: {response.isControllerConnected}");

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/TriggerHaptics.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseX/TriggerHaptics.cs
@@ -15,7 +15,7 @@ internal static class TriggerHaptics
         return null;
     }
 
-    public static Packet HandleBraking(SPageFilePhysics pagePhysics, BrakeHapticsConfig brakeConfig)
+    public static Packet HandleBraking(ref SPageFilePhysics pagePhysics, BrakeHapticsConfig brakeConfig)
     {
         Packet p = new();
         List<Instruction> instructions = [];
@@ -71,7 +71,7 @@ internal static class TriggerHaptics
         return p;
     }
 
-    public static Packet HandleAcceleration(SPageFilePhysics pagePhysics, ThrottleHapticsConfig throttleConfig)
+    public static Packet HandleAcceleration(ref SPageFilePhysics pagePhysics, ThrottleHapticsConfig throttleConfig)
     {
         Packet p = new();
         List<Instruction> instructions = [];

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseXFree/DualSenseXFreeOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseXFree/DualSenseXFreeOverlay.cs
@@ -3,6 +3,7 @@ using RaceElement.HUD.Overlay.Internal;
 using RaceElement.Util;
 using RaceElement.Util.SystemExtensions;
 using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Reflection;
@@ -43,7 +44,8 @@ internal sealed class DualSenseXFreeOverlay : AbstractOverlay
 
     public override void BeforeStart()
     {
-        _textFile = new FileInfo($"{FileUtil.AppDirectory}{Path.DirectorySeparatorChar}DualSenseXTriggerStates.txt");
+        _textFile = new FileInfo($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}DualSenseXTriggerStates.txt");
+        Debug.WriteLine(_textFile.FullName);
         if (!_textFile.Exists)
             _textFile.Create();
     }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseXFree/DualSenseXFreeOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayDualSenseXFree/DualSenseXFreeOverlay.cs
@@ -16,7 +16,8 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayDualSenseXFree;
 [Overlay(Name = "DualSense X Free",
     Description = "Adds variable trigger haptics and feedback for the DualSense 5 controller using DualSense X 1.4.9.\n See Guide in the Discord of Race Element for instructions.",
     OverlayCategory = OverlayCategory.Inputs,
-    OverlayType = OverlayType.Pitwall)]
+    OverlayType = OverlayType.Pitwall,
+Authors = ["Reinier Klarenberg"])]
 internal sealed class DualSenseXFreeOverlay : AbstractOverlay
 {
     private readonly DualSenseXConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayNamePlate/NamePlateOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayNamePlate/NamePlateOverlay.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayNamePlate;
 
 #if DEBUG
-[Overlay(Name = "Name plate", Description = "A plate/bar")]
+[Overlay(Name = "Name plate", Description = "A plate/bar", OverlayType = OverlayType.Pitwall)]
 #endif
 internal sealed class NamePlateOverlay : AbstractOverlay
 {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatConfiguration.cs
@@ -38,14 +38,11 @@ internal sealed class TwitchChatConfiguration : OverlayConfiguration
         public bool AlwaysVisible { get; init; } = true;
     }
 
-    [ConfigGrouping("Bot", "Adjust the twitch chat bot.")]
+    [ConfigGrouping("Bot", "If you've enabled the twitch Chat Bot HUD, this will allow you to also show the responses of the bot in the twitch chat hud.")]
     public BotGrouping Bot { get; init; } = new();
     public class BotGrouping
     {
-        [ToolTip("Enable or disable the chat bot")]
-        public bool IsEnabled { get; init; } = true;
-
-        [ToolTip("When enabled the bot responses will also be displayed in the Twitch Chat HUD.")]
+        [ToolTip("When enabled responses from the Twitch Chat Bot will also be displayed in the Twitch Chat HUD.")]
         public bool DisplayBotResponses { get; init; } = true;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -14,7 +14,7 @@ using TwitchLib.Communication.Models;
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat;
 
 [Overlay(Name = "Twitch Chat",
-Description = "Shows twitch chat, newest messages appear at the top. (type +commands in chat for all available ones)\nTo allow Race Element to connect to the twitch api create the O Auth token at twitchapps.com/tmi",
+Description = "Shows twitch chat, newest messages appear at the top.\nTo allow Race Element to connect to the twitch api create the O Auth token at twitchapps.com/tmi",
 OverlayType = OverlayType.Pitwall,
 Authors = ["Reinier Klarenberg"])]
 internal sealed class TwitchChatOverlay : AbstractOverlay

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -90,6 +90,9 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         _twitchClient.Initialize(credentials, _config.Credentials.TwitchUser);
         _twitchClient.OnMessageReceived += (s, e) =>
         {
+            if (e.ChatMessage.DisplayName.ToLower() == $"{_config.Credentials.TwitchUser.ToLower()}")
+                return;
+
             if (e.ChatMessage.Bits > 0)
                 Messages.Add(new(MessageType.Bits, $"{DateTime.Now:HH:mm} {e.ChatMessage.DisplayName} cheered {e.ChatMessage.Bits} bits: {e.ChatMessage.Message}"));
             else
@@ -102,7 +105,7 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         _twitchClient.OnPrimePaidSubscriber += (s, e) => Messages.Add(new(MessageType.Subscriber, $"{e.PrimePaidSubscriber.DisplayName} Subscribed with Prime!"));
         _twitchClient.OnGiftedSubscription += (s, e) => Messages.Add(new(MessageType.Subscriber, $"{e.GiftedSubscription.DisplayName} gifted a subscription ({e.GiftedSubscription.MsgParamSubPlanName}) to {e.GiftedSubscription.MsgParamRecipientDisplayName}"));
 
-        _twitchClient.OnConnected += (s, e) => Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Connected"));
+        _twitchClient.OnConnected += (s, e) => Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Chat HUD - Connected"));
         _twitchClient.OnConnectionError += TwitchClient_OnConnectionError;
 
         if (!_config.Shape.AlwaysVisible)
@@ -148,8 +151,8 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
 
         if (!_twitchClient.IsConnected)
         {
-            _twitchClient.Reconnect();
-            Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} chat hud Reconnecting..."));
+            _twitchClient.Connect();
+            //Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} chat hud Reconnecting..."));
         }
 
         g.CompositingQuality = CompositingQuality.HighQuality;

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChat/TwitchChatOverlay.cs
@@ -90,7 +90,7 @@ internal sealed class TwitchChatOverlay : AbstractOverlay
         _twitchClient.Initialize(credentials, _config.Credentials.TwitchUser);
         _twitchClient.OnMessageReceived += (s, e) =>
         {
-            if (e.ChatMessage.DisplayName.ToLower() == $"{_config.Credentials.TwitchUser.ToLower()}")
+            if (e.ChatMessage.IsBroadcaster && e.ChatMessage.ChatReply != null)
                 return;
 
             if (e.ChatMessage.Bits > 0)

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChatBot
+{
+    internal sealed class TwitchChatBotConfiguration : OverlayConfiguration
+    {
+        public TwitchChatBotConfiguration() => GenericConfiguration.AllowRescale = false;
+
+        [ConfigGrouping("Connection", "Set up the username and O Auth token")]
+        public CredentialsGrouping Credentials { get; init; } = new();
+        public class CredentialsGrouping
+        {
+            [ToolTip("Your channel name")]
+            public string TwitchUser { get; init; } = "";
+
+            [ToolTip("Create an O Auth token at twitchapps.com/tmi, click connect and connect and copy -> paste the entire result in here." +
+                "\n(This is required for Race Element to connect to your chat using the twitch api.)")]
+            [StringOptions(isPassword: true)]
+            public string OAuthToken { get; init; } = "";
+        }
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotOverlay.cs
@@ -10,7 +10,7 @@ using TwitchLib.Communication.Clients;
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChatBot;
 
 [Overlay(Name = "Twitch Chat Bot",
-Description = "+commands in chat for all commands\nTo allow Race Element to connect to the twitch api create the O Auth token at twitchapps.com/tmi",
+Description = "(type +commands in chat for all available ones)\nTo allow Race Element to connect to the twitch api create the O Auth token at twitchapps.com/tmi",
 OverlayType = OverlayType.Pitwall,
 Authors = ["Reinier Klarenberg"])]
 internal sealed class TwitchChatBotOverlay : AbstractOverlay
@@ -53,7 +53,7 @@ internal sealed class TwitchChatBotOverlay : AbstractOverlay
         _twitchClient.OnConnected += (s, e) => Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Chat Bot - Connected"));
         _twitchClient.OnDisconnected += (s, e) => Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Chat Bot - Disconnected"));
         _twitchClient.OnConnectionError += TwitchClient_OnConnectionError;
-      
+
     }
     private void TwitchClient_OnConnectionError(object sender, TwitchLib.Client.Events.OnConnectionErrorArgs e)
     {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatBotOverlay.cs
@@ -1,0 +1,88 @@
+﻿using RaceElement.HUD.Overlay.Internal;
+using System;
+using System.Drawing;
+using TwitchLib.Client;
+using static RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat.TwitchChatOverlay;
+using TwitchLib.Communication.Models;
+using RaceElement.Util;
+using TwitchLib.Communication.Clients;
+
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChatBot;
+
+[Overlay(Name = "Twitch Chat Bot",
+Description = "+commands in chat for all commands\nTo allow Race Element to connect to the twitch api create the O Auth token at twitchapps.com/tmi",
+OverlayType = OverlayType.Pitwall,
+Authors = ["Reinier Klarenberg"])]
+internal sealed class TwitchChatBotOverlay : AbstractOverlay
+{
+    private TwitchChatBotConfiguration _config = new();
+
+    private TwitchClient _twitchClient = null;
+    private TwitchChatBotCommandHandler _chatCommandHandler;
+
+    public TwitchChatBotOverlay(Rectangle rectangle) : base(rectangle, "Twitch Chat Bot")
+    {
+        Width = 1;
+        Height = 1;
+        RequestsDrawItself = true;
+    }
+
+    public sealed override void BeforeStart()
+    {
+        base.BeforeStart();
+    }
+
+    private void SetupTwitchClient()
+    {
+        if (IsPreviewing) return;
+
+        var credentials = new TwitchLib.Client.Models.ConnectionCredentials(_config.Credentials.TwitchUser, _config.Credentials.OAuthToken);
+        var clientOptions = new ClientOptions
+        {
+            MessagesAllowedInPeriod = 750,
+            ThrottlingPeriod = TimeSpan.FromSeconds(30),
+        };
+        WebSocketClient customClient = new(clientOptions);
+        _twitchClient = new(customClient);
+
+        _twitchClient.Initialize(credentials, _config.Credentials.TwitchUser);
+
+        _chatCommandHandler = new(this, _twitchClient);
+        _twitchClient.AddChatCommandIdentifier(TwitchChatBotCommandHandler.ChatCommandCharacter);
+
+
+        _twitchClient.OnConnected += (s, e) => Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} Race Element - Connected"));
+        _twitchClient.OnConnectionError += TwitchClient_OnConnectionError;
+
+
+        if (!_twitchClient.IsConnected)
+            _twitchClient.Connect();
+    }
+    private void TwitchClient_OnConnectionError(object sender, TwitchLib.Client.Events.OnConnectionErrorArgs e)
+    {
+        LogWriter.WriteToLog($"Twitch chat bot error: {e.Error}");
+    }
+
+    public sealed override bool ShouldRender() => true;
+
+    public sealed override void BeforeStop()
+    {
+        _twitchClient.RemoveChatCommandIdentifier(TwitchChatBotCommandHandler.ChatCommandCharacter);
+        _twitchClient.OnChatCommandReceived -= _chatCommandHandler.OnChatCommandReceived;
+        _twitchClient.OnConnectionError -= TwitchClient_OnConnectionError;
+
+        _twitchClient.Disconnect();
+    }
+
+    public sealed override void Render(Graphics g)
+    {
+        if (IsPreviewing) return;
+
+        if (!_twitchClient.IsConnected)
+        {
+            _twitchClient.Reconnect();
+            Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} chat hud Reconnecting..."));
+        }
+    }
+}
+

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatCommandHandler.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayTwitchChatBot/TwitchChatCommandHandler.cs
@@ -6,6 +6,7 @@ using RaceElement.Data.ACC.Cars;
 using RaceElement.Data.ACC.Database.LapDataDB;
 using RaceElement.Data.ACC.EntryList;
 using RaceElement.Data.ACC.Tracker.Laps;
+using RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat;
 using RaceElement.Util;
 using System;
 using System.Diagnostics;
@@ -18,11 +19,11 @@ using WebSocketSharp;
 using static RaceElement.Data.ACC.EntryList.EntryListTracker;
 using static RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat.TwitchChatOverlay;
 
-namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChat;
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.OverlayTwitchChatBot;
 
-internal class TwitchChatCommandHandler
+internal class TwitchChatBotCommandHandler
 {
-    private readonly TwitchChatOverlay _overlay;
+    private readonly TwitchChatBotOverlay _overlay;
 
     private readonly TwitchClient _client;
 
@@ -39,7 +40,7 @@ internal class TwitchChatCommandHandler
     }
     private readonly ChatResponse[] Responses;
 
-    public TwitchChatCommandHandler(TwitchChatOverlay overlay, TwitchClient client)
+    public TwitchChatBotCommandHandler(TwitchChatBotOverlay overlay, TwitchClient client)
     {
         _overlay = overlay;
         _client = client;
@@ -88,8 +89,8 @@ internal class TwitchChatCommandHandler
 
             _client.SendReply(_client.JoinedChannels[0], e.Command.ChatMessage.Id, replyMessage);
 
-            if (_overlay._config.Bot.DisplayBotResponses && !command.Equals("commands"))
-                _overlay._messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} - {replyMessage}"));
+            if (!command.Equals("commands"))
+                TwitchChatOverlay.Messages.Add(new(MessageType.Bot, $"{DateTime.Now:HH:mm} - {replyMessage}"));
         }
         catch (Exception ex)
         {

--- a/Race_Element.HUD/Overlay/Configuration/OverlayConfiguration.cs
+++ b/Race_Element.HUD/Overlay/Configuration/OverlayConfiguration.cs
@@ -74,7 +74,7 @@ public abstract class OverlayConfiguration
 
         foreach (var field in configFields)
         {
-            bool isGrouped = field.Name.Contains(".");
+            bool isGrouped = field.Name.Contains('.');
             if (isGrouped)
             {
                 string[] groupSplit = field.Name.Split('.');

--- a/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
@@ -46,7 +46,7 @@ public abstract class AbstractOverlay : FloatingWindow
 
     public bool IsRepositioning { get; internal set; }
 
-    public bool IsPreviewing { get; set; }
+    public bool IsPreviewing { get; set; } = false;
 
     public double RefreshRateHz = 30;
 

--- a/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
@@ -46,6 +46,8 @@ public abstract class AbstractOverlay : FloatingWindow
 
     public bool IsRepositioning { get; internal set; }
 
+    public bool IsPreviewing { get; set; }
+
     public double RefreshRateHz = 30;
 
     public SPageFilePhysics pagePhysics;

--- a/Race_Element.Util/FileUtil.cs
+++ b/Race_Element.Util/FileUtil.cs
@@ -24,6 +24,7 @@ public class FileUtil
     public static string SetupsPath = AccPath + "Setups\\";
     public static string AccConfigPath => AccPath + "Config\\";
 
+    [Obsolete("Use AppContext.BaseDirectory instead: .NET 8 broke the Assembly.GetEntryAssembly().Location implementation.")]
     public static string AppDirectory => StripFileName(System.Reflection.Assembly.GetEntryAssembly().Location);
     public static string AppFullName => AppDomain.CurrentDomain.BaseDirectory + AppDomain.CurrentDomain.FriendlyName;
 

--- a/Race_Element/Controls/HUD/HudOptions.xaml.cs
+++ b/Race_Element/Controls/HUD/HudOptions.xaml.cs
@@ -161,6 +161,7 @@ public partial class HudOptions : UserControl
                     LogWriter.WriteToLog(ex);
                 }
         }));
+
         Instance = this;
     }
 
@@ -509,7 +510,7 @@ public partial class HudOptions : UserControl
             m_GlobalHook.Dispose();
     }
 
-    private MousePositionOverlay mousePositionOverlay;
+    internal MousePositionOverlay mousePositionOverlay;
     private void SetRepositionMode(bool enabled)
     {
         gridOverlays.IsEnabled = !enabled;

--- a/Race_Element/Controls/HUD/HudOptions.xaml.cs
+++ b/Race_Element/Controls/HUD/HudOptions.xaml.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -599,7 +600,20 @@ public partial class HudOptions : UserControl
             };
             if (overlayAttribute.Description != string.Empty)
             {
-                listViewItem.ToolTip = overlayAttribute.Description;
+                StringBuilder tooltipBuilder = new StringBuilder(overlayAttribute.Description);
+                string toolTip = overlayAttribute.Description;
+                if (overlayAttribute.Authors.Length > 0)
+                {
+                    tooltipBuilder.Append("\n\nAuthors: ");
+                    for (int i = 0; i < overlayAttribute.Authors.Length; i++)
+                    {
+                        tooltipBuilder.Append(overlayAttribute.Authors[i]);
+
+                        tooltipBuilder.Append($"{(i < overlayAttribute.Authors.Length - 1 ? ", " : ".")}");
+                    }
+                }
+
+                listViewItem.ToolTip = tooltipBuilder.ToString();
                 ToolTipService.SetPlacement(listViewItem, PlacementMode.Right);
                 ToolTipService.SetInitialShowDelay(listViewItem, 0);
             }

--- a/Race_Element/Controls/HUD/PreviewCache.cs
+++ b/Race_Element/Controls/HUD/PreviewCache.cs
@@ -121,6 +121,7 @@ internal class PreviewCache
         overlay.pageStatic.CarModel = "porsche_991ii_gt3_r";
 
         overlay.SetupPreviewData();
+        overlay.IsPreviewing = true;
 
         try
         {

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,8 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.0.3.2", "- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active."+
+                    "- Fix DualSenseX Free, now places the trigger states text file in correct directory."},
         {"1.0.3.0", "- Decrease shutdown time of app."+
                     "\n- HUD Tab:"+
                     "\n  - Added buttons to reset the position or the configuration for a HUD."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,7 @@ public static class ReleaseNotes
     internal readonly static Dictionary<string, string> Notes = new()
     {
         {"1.0.3.2", "- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active."+
-                    "- Fix DualSenseX Free, now places the trigger states text file in correct directory."},
+                    "\n- Fix DualSenseX Free, now places the trigger states text file in correct directory."},
         {"1.0.3.0", "- Decrease shutdown time of app."+
                     "\n- HUD Tab:"+
                     "\n  - Added buttons to reset the position or the configuration for a HUD."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.3.2", "- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active."+
+        {"1.0.3.2", "- Add Sector Data HUD: Shows you the Min and Max velocity after each sector."+
+                    "\n- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active."+
                     "\n- Fix DualSenseX Free, now places the trigger states text file in correct directory."},
         {"1.0.3.0", "- Decrease shutdown time of app."+
                     "\n- HUD Tab:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,6 +7,8 @@ public static class ReleaseNotes
     internal readonly static Dictionary<string, string> Notes = new()
     {
         {"1.0.3.2", "- Add Sector Data HUD: Shows you the Min and Max velocity after each sector."+
+                    "\n- Add Twitch Chat Bot: Removed it from the chat HUD itself, this way you can only enable the bot without using the twitch chat HUD. There is still an option to display the bot commands in the chat hud itself." +
+                    " You can use the same credentials as you have used in the twitch chat hud."+
                     "\n- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active."+
                     "\n- Fix DualSenseX Free, now places the trigger states text file in correct directory."},
         {"1.0.3.0", "- Decrease shutdown time of app."+

--- a/Race_Element/MainWindow.xaml.cs
+++ b/Race_Element/MainWindow.xaml.cs
@@ -277,6 +277,8 @@ public partial class MainWindow : Window
         HudTrackers.StopAll();
         ACCTrackerDispose.Dispose();
         HudOptions.Instance.DisposeKeyboardHooks();
+        HudOptions.Instance.mousePositionOverlay?.Stop();
+        HudOptions.Instance.mousePositionOverlay?.Dispose();
         SteeringLockTracker.Stop();
         FileUtil.CleanDownloadCache();
 
@@ -295,6 +297,8 @@ public partial class MainWindow : Window
         HudTrackers.StopAll();
         ACCTrackerDispose.Dispose();
         HudOptions.Instance.DisposeKeyboardHooks();
+        HudOptions.Instance.mousePositionOverlay?.Stop();
+        HudOptions.Instance.mousePositionOverlay?.Dispose();
         SteeringLockTracker.Stop();
         FileUtil.CleanDownloadCache();
 

--- a/Race_Element/MainWindow.xaml.cs
+++ b/Race_Element/MainWindow.xaml.cs
@@ -447,7 +447,7 @@ public partial class MainWindow : Window
 
     private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        DecreaseOpacity(0.850, 0.025);
+        DecreaseOpacity(0.825, 0.025);
         DragMove();
         e.Handled = true;
     }

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,7 +12,7 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.3.0</ApplicationVersion>
+        <ApplicationVersion>1.0.3.1</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -27,6 +27,17 @@
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
         <RunCodeAnalysis>false</RunCodeAnalysis>
+    </PropertyGroup>
+    <PropertyGroup>
+        <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
+        <PlatformTarget>x64</PlatformTarget>
+        <AssemblyVersion>1.0.3.1</AssemblyVersion>
+        <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+        <Title>Race Element</Title>
+        <PackageIcon>race element icon 2.png</PackageIcon>
+        <Authors>Element Future</Authors>
+        <Version>1.0.3.1</Version>
+        <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup>
         <StartupObject>RaceElement.App</StartupObject>
@@ -55,17 +66,7 @@
     <PropertyGroup>
         <TargetZone>Custom</TargetZone>
     </PropertyGroup>
-    <PropertyGroup>
-        <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
-        <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.3.0</AssemblyVersion>
-        <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
-        <Title>Race Element</Title>
-        <PackageIcon>race element icon 2.png</PackageIcon>
-        <Authors>Element Future</Authors>
-        <Version>1.0.3.0</Version>
-        <Product>Race Element</Product>
-    </PropertyGroup>
+
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Minimized|AnyCPU'">
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\Debug Minimized\</OutputPath>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,7 +12,7 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.3.1</ApplicationVersion>
+        <ApplicationVersion>1.0.3.2</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -31,12 +31,12 @@
     <PropertyGroup>
         <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
         <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.3.1</AssemblyVersion>
+        <AssemblyVersion>1.0.3.2</AssemblyVersion>
         <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
         <Title>Race Element</Title>
         <PackageIcon>race element icon 2.png</PackageIcon>
         <Authors>Element Future</Authors>
-        <Version>1.0.3.1</Version>
+        <Version>1.0.3.2</Version>
         <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
- Add Sector Data HUD: Shows you the Min and Max velocity after each sector.
- Add Twitch Chat Bot: Removed it from the chat HUD itself, this way you can only enable the bot without using the twitch chat HUD. There is still an option to display the bot commands in the chat hud itself. You can use the same credentials as you have used in the twitch chat hud.
- Fix Mouse Position HUD disposal at shutdown of app when movement mode was still active.
- Fix DualSenseX Free, now places the trigger states text file in correct directory.