### PR TITLE
LowFuelMotorsport: Fix crash caused by empty user identifier

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportConfiguration.cs
@@ -14,7 +14,7 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport
 
         public LowFuelMotorsportConfiguration() => GenericConfiguration.AllowRescale = false;
 
-        [ConfigGrouping("Connection", "LFM user information and fetch information interval")]
+        [ConfigGrouping("Connection", "LFM user information and fetch interval")]
         public ConnectionGrouping Connection { get; init; } = new();
         public class ConnectionGrouping
         {
@@ -36,6 +36,14 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport
             [ToolTip("Font size")]
             [IntRange(5, 32, 1)]
             public int Size { get; init; } = 10;
+        }
+
+        [ConfigGrouping("Others", "Other options")]
+        public OtherGrouping Others { get; init; } = new();
+        public class OtherGrouping
+        {
+            [ToolTip("Show always")]
+            public bool ShowAlways { get; init; } = false;
         }
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
@@ -2,6 +2,7 @@ using RaceElement.Core.Jobs.LoopJob;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System;
+using System.Diagnostics;
 using RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport;
@@ -13,14 +14,26 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
 
     public override void RunAction()
     {
-        using HttpClient client = new();
-        string url = string.Format(DRIVER_RACE_API_URL, userId);
+        if (userId.Trim().Length == 0)
+        {
+            return;
+        }
 
-        using HttpResponseMessage response = client.GetAsync(url).Result;
-        using HttpContent content = response.Content;
+        try
+        {
+            using HttpClient client = new();
+            string url = string.Format(DRIVER_RACE_API_URL, userId);
 
-        string json = content.ReadAsStringAsync().Result;
-        ApiObject root = JObject.Parse(json).ToObject<ApiObject>();
-        OnNewApiObject?.Invoke(null, root);
+            using HttpResponseMessage response = client.GetAsync(url).Result;
+            using HttpContent content = response.Content;
+
+            string json = content.ReadAsStringAsync().Result;
+            ApiObject root = JObject.Parse(json).ToObject<ApiObject>();
+            OnNewApiObject?.Invoke(null, root);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+        }
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
@@ -3,6 +3,7 @@ using RaceElement.HUD.Overlay.Internal;
 using System.Drawing.Text;
 using System.Drawing;
 using System;
+using System.Windows.Forms;
 using static RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.LowFuelMotorsportConfiguration;
 using RaceElement.HUD.Overlay.Util;
 using RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
@@ -73,6 +74,12 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
 
         if (IsPreviewing) return;
 
+        if (_config.Connection.User.Trim().Length == 0)
+        {
+            var message = "Missing user identifier (check your configuration)\n(https://lowfuelmotorsport.com/profile/[HERE_IS_THE_ID]";
+            MessageBox.Show(message, "LFM Warning!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
         _lfmJob = new LowFuelMotorsportJob(_config.Connection.User)
         {
             IntervalMillis = _config.Connection.Interval * 1000,
@@ -95,10 +102,10 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
-        if (_config.Connection.User.Trim() == "")
+        if (_config.Connection.User.Trim().Length == 0)
             return false;
 
-        return base.ShouldRender();
+        return _config.Others.ShowAlways || base.ShouldRender();
     }
 
     public override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
@@ -166,7 +166,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
                 race.EventName,
                 race.RaceId,
                 race.Split,
-                race.Sof,
+                _apiObject.Sof,
                 _apiObject.Drivers
             ).Trim();
 


### PR DESCRIPTION
Add user input check. If the user is empty, a warning message will be displayed. The LFM API response is an HTML instead of a JSON if the user is missing, the JSON parser fails and throws an exception.

Extras:
- Add option to show the overlay always
- Fixed incorrect SOF display