### PR TITLE
1.0.5.6

### DIFF
--- a/Race_Element.Data.ACC/Tracks/Data/Nordschleife.cs
+++ b/Race_Element.Data.ACC/Tracks/Data/Nordschleife.cs
@@ -3,20 +3,19 @@ using System;
 using System.Collections.Generic;
 using static RaceElement.Data.ACC.Tracks.TrackData;
 
-namespace RaceElement.Data.ACC.Tracks.Data
+namespace RaceElement.Data.ACC.Tracks.Data;
+
+internal class Nordschleife : AbstractTrackData
 {
-    internal class Nordschleife : AbstractTrackData
-    {
-        public override Guid Guid => new("fae08ea8-03fb-429b-be59-c56c7cd18ef1");
+    public override Guid Guid => new("fae08ea8-03fb-429b-be59-c56c7cd18ef1");
 
-        public override string GameName => "nurburgring_24h";
+    public override string GameName => "nurburgring_24h";
 
-        public override string FullName => "Nurburgring Nordschleife";
+    public override string FullName => "Nurburgring 24h";
 
-        public override int TrackLength => 25378;
+    public override int TrackLength => 25378;
 
-        public override Dictionary<FloatRangeStruct, (int, string)> CornerNames => [];
+    public override Dictionary<FloatRangeStruct, (int, string)> CornerNames => [];
 
-        public override List<float> Sectors => [];
-    }
+    public override List<float> Sectors => [];
 }

--- a/Race_Element.Data.ACC/Tracks/Data/Nordschleife.cs
+++ b/Race_Element.Data.ACC/Tracks/Data/Nordschleife.cs
@@ -1,0 +1,22 @@
+﻿using RaceElement.Util.DataTypes;
+using System;
+using System.Collections.Generic;
+using static RaceElement.Data.ACC.Tracks.TrackData;
+
+namespace RaceElement.Data.ACC.Tracks.Data
+{
+    internal class Nordschleife : AbstractTrackData
+    {
+        public override Guid Guid => new("fae08ea8-03fb-429b-be59-c56c7cd18ef1");
+
+        public override string GameName => "nurburgring_24h";
+
+        public override string FullName => "Nurburgring Nordschleife";
+
+        public override int TrackLength => 25378;
+
+        public override Dictionary<FloatRangeStruct, (int, string)> CornerNames => [];
+
+        public override List<float> Sectors => [];
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Driving/CornerData/CornerDataOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/CornerData/CornerDataOverlay.cs
@@ -102,14 +102,14 @@ internal sealed class CornerDataOverlay : AbstractOverlay
         {
             columnWidths.Add(80);
             if (_config.Data.DeltaSource != CornerDataConfiguration.DeltaSource.Off)
-                columnWidths.Add(50);
+                columnWidths.Add(68);
         }
 
         if (_config.Data.AverageSpeed)
         {
             columnWidths.Add(80);
             if (_config.Data.DeltaSource != CornerDataConfiguration.DeltaSource.Off)
-                columnWidths.Add(50);
+                columnWidths.Add(68);
         }
 
         if (_config.Data.MaxLatG)

--- a/Race_Element.SharedMemory/ACCSharedMemory.cs
+++ b/Race_Element.SharedMemory/ACCSharedMemory.cs
@@ -59,24 +59,20 @@ public unsafe class ACCSharedMemory
     }
 
 
-    public static string SessionTypeToString(AcSessionType sessionType)
+    public static string SessionTypeToString(AcSessionType sessionType) => sessionType switch
     {
-        switch (sessionType)
-        {
-            case AcSessionType.AC_UNKNOWN: return "Unknown";
-            case AcSessionType.AC_PRACTICE: return "Practice";
-            case AcSessionType.AC_QUALIFY: return "Qualify";
-            case AcSessionType.AC_RACE: return "Race";
-            case AcSessionType.AC_HOTLAP: return "Hotlap";
-            case AcSessionType.AC_TIME_ATTACK: return "Time attack";
-            case AcSessionType.AC_DRIFT: return "Drift";
-            case AcSessionType.AC_DRAG: return "Drag";
-            case AcSessionType.AC_HOTSTINT: return "Hotstint";
-            case AcSessionType.AC_HOTLAPSUPERPOLE: return "Hotlap superpole";
-
-            default: return sessionType.ToString();
-        }
-    }
+        AcSessionType.AC_UNKNOWN => "Unknown",
+        AcSessionType.AC_PRACTICE => "Practice",
+        AcSessionType.AC_QUALIFY => "Qualify",
+        AcSessionType.AC_RACE => "Race",
+        AcSessionType.AC_HOTLAP => "Hotlap",
+        AcSessionType.AC_TIME_ATTACK => "Time attack",
+        AcSessionType.AC_DRIFT => "Drift",
+        AcSessionType.AC_DRAG => "Drag",
+        AcSessionType.AC_HOTSTINT => "Hotstint",
+        AcSessionType.AC_HOTLAPSUPERPOLE => "Hotlap superpole",
+        _ => sessionType.ToString(),
+    };
 
     public enum AcFlagType : int
     {
@@ -92,23 +88,19 @@ public unsafe class ACCSharedMemory
 
     }
 
-    public static string FlagTypeToString(AcFlagType flagType)
+    public static string FlagTypeToString(AcFlagType flagType) => flagType switch
     {
-        switch (flagType)
-        {
-            case AcFlagType.AC_NO_FLAG: return "Green";
-            case AcFlagType.AC_BLUE_FLAG: return "Blue";
-            case AcFlagType.AC_YELLOW_FLAG: return "Yellow";
-            case AcFlagType.AC_BLACK_FLAG: return "Black";
-            case AcFlagType.AC_WHITE_FLAG: return "White";
-            case AcFlagType.AC_CHECKERED_FLAG: return "Checkered";
-            case AcFlagType.AC_PENALTY_FLAG: return "Penalty";
-            case AcFlagType.AC_GREEN_FLAG: return "Green";
-            case AcFlagType.AC_BLACK_FLAG_WITH_ORANGE_CIRCLE: return "Orange";
-
-            default: return flagType.ToString();
-        }
-    }
+        AcFlagType.AC_NO_FLAG => "Green",
+        AcFlagType.AC_BLUE_FLAG => "Blue",
+        AcFlagType.AC_YELLOW_FLAG => "Yellow",
+        AcFlagType.AC_BLACK_FLAG => "Black",
+        AcFlagType.AC_WHITE_FLAG => "White",
+        AcFlagType.AC_CHECKERED_FLAG => "Checkered",
+        AcFlagType.AC_PENALTY_FLAG => "Penalty",
+        AcFlagType.AC_GREEN_FLAG => "Green",
+        AcFlagType.AC_BLACK_FLAG_WITH_ORANGE_CIRCLE => "Orange",
+        _ => flagType.ToString(),
+    };
 
     public enum PenaltyShortcut : int
     {

--- a/Race_Element.SharedMemory/ACCSharedMemory.cs
+++ b/Race_Element.SharedMemory/ACCSharedMemory.cs
@@ -166,10 +166,10 @@ public unsafe class ACCSharedMemory
     {
         AcRainIntensity.No_Rain => "Dry",
         AcRainIntensity.Drizzle => "Drizzle",
-        AcRainIntensity.Light_Rain => "Light Rain",
-        AcRainIntensity.Medium_Rain => "Medium Rain",
-        AcRainIntensity.Heavy_Rain => "Heavy Rain",
-        AcRainIntensity.Thunderstorm => "Thunderstorm",
+        AcRainIntensity.Light_Rain => "Light",
+        AcRainIntensity.Medium_Rain => "Medium",
+        AcRainIntensity.Heavy_Rain => "Heavy",
+        AcRainIntensity.Thunderstorm => "Thunder",
         _ => string.Empty,
     };
 

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.5.6", "Added preliminary support for Nordschle 24h dlc, expect an update for corner names and sector data." },
+        {"1.0.5.6", "- Added preliminary support for Nordschle 24h dlc, expect an update for corner names and sector data." },
         {"1.0.5.4", "- Add Rain Prediction HUD: Shows predicted rain intensity and counts down." },
         {"1.0.5.2", "- Dual Sense X: Improved responsiveness by increasing ffb rate from 70 to 100 Herz." },
         {"1.0.5.0", "- Rework of several Live Trace HUDs:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.5.6", "- Added preliminary support for ACC Nordschleife 24H DLC, expect an update for corner names and sector data." },
+        {"1.0.5.6", "- Added preliminary support for ACC Nordschleife 24H DLC, expect an update for corner names and sector data."+
+                    "\n- Corner Data HUD: Increased width of speed delta columns."},
         {"1.0.5.4", "- Add Rain Prediction HUD: Shows predicted rain intensity and counts down." },
         {"1.0.5.2", "- Dual Sense X: Improved responsiveness by increasing ffb rate from 70 to 100 Herz." },
         {"1.0.5.0", "- Rework of several Live Trace HUDs:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.5.6", "- Added preliminary support for Nordschle 24h dlc, expect an update for corner names and sector data." },
+        {"1.0.5.6", "- Added preliminary support for ACC Nordschleife 24H DLC, expect an update for corner names and sector data." },
         {"1.0.5.4", "- Add Rain Prediction HUD: Shows predicted rain intensity and counts down." },
         {"1.0.5.2", "- Dual Sense X: Improved responsiveness by increasing ffb rate from 70 to 100 Herz." },
         {"1.0.5.0", "- Rework of several Live Trace HUDs:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,8 @@ public static class ReleaseNotes
     internal readonly static Dictionary<string, string> Notes = new()
     {
         {"1.0.5.6", "- Added preliminary support for ACC Nordschleife 24H DLC, expect an update for corner names and sector data."+
-                    "\n- Corner Data HUD: Increased width of speed delta columns."},
+                    "\n- Corner Data HUD: Increased width of speed delta columns."+
+                    "\n- Rain Prediction HUD: \"Heavy Rain\" will now show as \"Heavy\"."},
         {"1.0.5.4", "- Add Rain Prediction HUD: Shows predicted rain intensity and counts down." },
         {"1.0.5.2", "- Dual Sense X: Improved responsiveness by increasing ffb rate from 70 to 100 Herz." },
         {"1.0.5.0", "- Rework of several Live Trace HUDs:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.0.5.6", "Added preliminary support for Nordschle 24h dlc, expect an update for corner names and sector data." },
         {"1.0.5.4", "- Add Rain Prediction HUD: Shows predicted rain intensity and counts down." },
         {"1.0.5.2", "- Dual Sense X: Improved responsiveness by increasing ffb rate from 70 to 100 Herz." },
         {"1.0.5.0", "- Rework of several Live Trace HUDs:"+

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,7 +12,7 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.5.5</ApplicationVersion>
+        <ApplicationVersion>1.0.5.6</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -31,12 +31,12 @@
     <PropertyGroup>
         <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
         <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.5.5</AssemblyVersion>
+        <AssemblyVersion>1.0.5.6</AssemblyVersion>
         <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
         <Title>Race Element</Title>
         <PackageIcon>race element icon 2.png</PackageIcon>
         <Authors>Element Future</Authors>
-        <Version>1.0.5.5</Version>
+        <Version>1.0.5.6</Version>
         <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,7 +12,7 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.5.4</ApplicationVersion>
+        <ApplicationVersion>1.0.5.5</ApplicationVersion>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -31,12 +31,12 @@
     <PropertyGroup>
         <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
         <PlatformTarget>x64</PlatformTarget>
-        <AssemblyVersion>1.0.5.4</AssemblyVersion>
+        <AssemblyVersion>1.0.5.5</AssemblyVersion>
         <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
         <Title>Race Element</Title>
         <PackageIcon>race element icon 2.png</PackageIcon>
         <Authors>Element Future</Authors>
-        <Version>1.0.5.4</Version>
+        <Version>1.0.5.5</Version>
         <Product>Race Element</Product>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
- Added preliminary support for ACC Nordschleife 24H DLC, expect an update for corner names and sector data.
- Corner Data HUD: Increased width of speed delta columns.
- Rain Prediction HUD: "Heavy Rain" will now show as "Heavy".