### PR TITLE
1.0.6.8

### DIFF
--- a/Race_Element.Data.ACC/SetupParser/Cars/GTC/LamborghiniHuracanSTEvo2.cs
+++ b/Race_Element.Data.ACC/SetupParser/Cars/GTC/LamborghiniHuracanSTEvo2.cs
@@ -19,8 +19,8 @@ internal class LamborghiniHuracanSTEvo22021 : ICarSetupConversion
         {
             switch (GetPosition(wheel))
             {
-                case Position.Front: return Math.Round(-3.0 + 0.1 * rawValue[(int)wheel], 2);
-                case Position.Rear: return Math.Round(-3.5 + 0.1 * rawValue[(int)wheel], 2);
+                case Position.Front: return Math.Round(-3.5 + 0.1 * rawValue[(int)wheel], 2);
+                case Position.Rear: return Math.Round(-3.0 + 0.1 * rawValue[(int)wheel], 2);
                 default: return -1;
             }
         }

--- a/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -93,7 +93,14 @@ internal sealed class FuelInfoOverlay : AbstractOverlay
     {
         // Some global variants
         double lapBufferVar = pageGraphics.FuelXLap * this._config.InfoPanel.FuelBufferLaps;
-        double bestLapTime = pageGraphics.BestTimeMs; if (bestLapTime > TimeSpan.FromMinutes(12).TotalMilliseconds) bestLapTime = new TimeSpan(0, 8, 10).TotalMilliseconds;
+        double bestLapTime = pageGraphics.BestTimeMs;
+        if (bestLapTime > TimeSpan.FromMinutes(12).TotalMilliseconds)
+        {
+            if (pageGraphics.LastTimeMs < TimeSpan.FromMinutes(12).TotalMilliseconds)
+                bestLapTime = pageGraphics.LastTimeMs;
+            else
+                bestLapTime = new TimeSpan(0, 8, 10).TotalMilliseconds;
+        }
         double fuelTimeLeft = pageGraphics.FuelEstimatedLaps * bestLapTime;
         double stintDebug = pageGraphics.DriverStintTimeLeft; stintDebug.ClipMin(-1);
         //**********************

--- a/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -104,8 +104,9 @@ internal sealed class FuelInfoOverlay : AbstractOverlay
                 bestLapTime = pageGraphics.LastTimeMs;
             else
             {
-                //bestLapTime = new TimeSpan(0, 8, 10).TotalMilliseconds;
-                _infoPanel.AddLine("Notice", "No best/last lap set");
+                string header = "No";
+                header = header.FillStart(10, ' ');
+                _infoPanel.AddLine(header, "Best/Last Lap");
                 goto drawPanel;
             }
         }

--- a/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -8,7 +8,8 @@ using System.Drawing;
 namespace RaceElement.HUD.ACC.Overlays.OverlayFuelInfo;
 
 [Overlay(Name = "Fuel Info",
-    Description = "A panel showing information about the fuel: laps left, fuel to end of race. Optionally showing stint information.",
+    Description = "A panel showing information about the fuel: laps left, fuel to end of race. Optionally showing stint information." +
+    "\nBest to be used in a race, Do not use this before you start it as the game doesn't provide accurate data at that point.",
     Version = 1.00,
     OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Car,

--- a/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -93,7 +93,7 @@ internal sealed class FuelInfoOverlay : AbstractOverlay
     {
         // Some global variants
         double lapBufferVar = pageGraphics.FuelXLap * this._config.InfoPanel.FuelBufferLaps;
-        double bestLapTime = pageGraphics.BestTimeMs; bestLapTime.ClipMax(180000);
+        double bestLapTime = pageGraphics.BestTimeMs; if (bestLapTime > TimeSpan.FromMinutes(12).TotalMilliseconds) bestLapTime = new TimeSpan(0, 8, 10).TotalMilliseconds;
         double fuelTimeLeft = pageGraphics.FuelEstimatedLaps * bestLapTime;
         double stintDebug = pageGraphics.DriverStintTimeLeft; stintDebug.ClipMin(-1);
         //**********************

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,9 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.6.8", "- Fuel Info HUD: Now calculates laptimes above 3 minutes. It will also use your last lap as laptime if you don't haven't set a valid best lap yet."+
+        {"1.0.6.8", "- Fuel Info HUD:" +
+                    "\n  - Now calculates laptimes above 3 minutes. It will also use your last lap as laptime if you don't haven't set a valid best lap yet." +
+                    "\n  - No data will be shown if there are no known laptimes(best or last)."+
                     "\n- Setup Viewer: Fix Camber value for Lambo Huracan ST Evo 2."},
         {"1.0.6.6", "- Twitch Chat Bot:"+
                     "\n  - Added Fuel Calculator: +fuel [minutes] [liters/lap] [laptime]. Use like +fuel 60 3 2:16."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,8 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.0.6.8", "- Fuel Info HUD: Now calculates laptimes above 3 minutes, (we never expected Nordschleife DLC)."+
+                    "\n- Setup Viewer: Fix Camber value for Lambo Huracan ST Evo 2."},
         {"1.0.6.6", "- Twitch Chat Bot:"+
                     "\n  - Added Fuel Calculator: +fuel [minutes] [liters/lap] [laptime]. Use like +fuel 60 3 2:16."+
                     "\n  - Car info commands now also show whether a car is in the pitlane."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.0.6.8", "- Fuel Info HUD: Now calculates laptimes above 3 minutes, (we never expected Nordschleife DLC)."+
+        {"1.0.6.8", "- Fuel Info HUD: Now calculates laptimes above 3 minutes. It will also use your last lap as laptime if you don't haven't set a valid best lap yet."+
                     "\n- Setup Viewer: Fix Camber value for Lambo Huracan ST Evo 2."},
         {"1.0.6.6", "- Twitch Chat Bot:"+
                     "\n  - Added Fuel Calculator: +fuel [minutes] [liters/lap] [laptime]. Use like +fuel 60 3 2:16."+

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.6.7</ApplicationVersion>
-        <AssemblyVersion>1.0.6.7</AssemblyVersion>
-        <Version>1.0.6.7</Version>
+        <ApplicationVersion>1.0.6.8</ApplicationVersion>
+        <AssemblyVersion>1.0.6.8</AssemblyVersion>
+        <Version>1.0.6.8</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.0.6.6</ApplicationVersion>
-        <AssemblyVersion>1.0.6.6</AssemblyVersion>
-        <Version>1.0.6.6</Version>
+        <ApplicationVersion>1.0.6.7</ApplicationVersion>
+        <AssemblyVersion>1.0.6.7</AssemblyVersion>
+        <Version>1.0.6.7</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
- Fuel Info HUD:
  - Now calculates laptimes above 3 minutes. It will also use your last lap as laptime if you don't haven't set a valid best lap yet.
  - No data will be shown if there are no known laptimes(best or last).
- Setup Viewer: Fix Camber value for Lambo Huracan ST Evo 2.