### PR TITLE
Position prediction for pit stop exit and lapped cars logic

### DIFF
--- a/Race_Element.Broadcast/Structs/LapInfo.cs
+++ b/Race_Element.Broadcast/Structs/LapInfo.cs
@@ -4,20 +4,48 @@ namespace RaceElement.Broadcast.Structs;
 
 public class LapInfo
 {
+    /// <summary>
+    /// Lap time in milliseconds. Use "GetLapTimeMS()"
+    /// as this value sometime is reported wrong by
+    /// the server.
+    /// </summary>
     public int? LaptimeMS { get; internal set; }
+
+    /// <summary>
+    /// Sector time in milliseconds.
+    /// </summary>
     public List<int?> Splits { get; } = [];
+
+    /// <summary>
+    /// Internal server identifier assigned to the car.
+    /// </summary>
     public ushort CarIndex { get; internal set; }
+
+    /// <summary>
+    ///  TODO
+    /// </summary>
     public ushort DriverIndex { get; internal set; }
+
+    /// <summary>
+    /// Lap is not valid due corner cut, out of track, etc.
+    /// </summary>
     public bool IsInvalid { get; internal set; }
+
+    /// <summary>
+    /// Improving its own the best time.
+    /// </summary>
     public bool IsValidForBest { get; internal set; }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
     public LapType Type { get; internal set; }
 
     /// <summary>
-    /// Prefered to use this method instead of LapTimeMS property.
-    /// The LapTimeMS Property sometimes doesn't return the correct laptime.
+    /// Preferred to use this method instead of LapTimeMS property.
+    /// The LapTimeMS Property sometimes doesn't return the correct
+    /// laptime.
     /// </summary>
-    /// <param name="splits"></param>
-    /// <returns></returns>
     public int GetLapTimeMS()
     {
         int lapTimeMs = 0;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -52,31 +52,31 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
     public sealed class ColorGrouping
     {
         [ToolTip("Map color")]
-        public Color Map { get; init; } = Color.WhiteSmoke;
+        public Color Map { get; init; } = Color.FromArgb(255, 245, 245, 245);
 
         [ToolTip("Player car color")]
-        public Color Player { get; init; } = Color.Red;
+        public Color Player { get; init; } = Color.FromArgb(255, 255, 0, 0);
 
         [ToolTip("Default car color (no player / no lapped)")]
-        public Color Default { get; init; } = Color.LightGray;
+        public Color Default { get; init; } = Color.FromArgb(255, 211, 211, 211);
 
         [ToolTip("Leader car color (no player)")]
-        public Color Leader { get; init; } = Color.SeaGreen;
+        public Color Leader { get; init; } = Color.FromArgb(255, 46, 139, 87);
 
         [ToolTip("Cars lapped by player color")]
-        public Color PlayerLappedOthers { get; init; } = Color.SteelBlue;
+        public Color PlayerLappedOthers { get; init; } = Color.FromArgb(255, 70, 130, 180);
 
         [ToolTip("Other lapped by player color")]
-        public Color OthersLappedPlayer { get; init; } = Color.DarkOrange;
+        public Color OthersLappedPlayer { get; init; } = Color.FromArgb(255, 255, 140, 0);
 
         [ToolTip("Improving lap car color (no player)")]
-        public Color ImprovingLap { get; init; } = Color.SeaGreen;
+        public Color ImprovingLap { get; init; } = Color.FromArgb(255, 46, 139, 87);
 
         [ToolTip("Pit stop color")]
-        public Color PitStop { get; init; } = Color.MediumOrchid;
+        public Color PitStop { get; init; } = Color.FromArgb(255, 186, 85, 211);
 
         [ToolTip("Pit stop with damage color")]
-        public Color PitStopWithDamage { get; init; } = Color.MediumPurple;
+        public Color PitStopWithDamage { get; init; } = Color.FromArgb(255, 147, 112, 219);
     }
 
     public TrackMapConfiguration() => this.GenericConfiguration.AllowRescale = false;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -35,11 +35,20 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
         [ToolTip("Show Cars number")]
         public bool ShowCarNumber { get; init; } = false;
 
+        [ToolTip("Show pit stop on map")]
+        public bool ShowPitStop { get; init; } = false;
+
         [ToolTip("Player car color")]
         public Color PlayerColor { get; init; } = Color.Red;
 
         [ToolTip("Default car color (no player / no lapped)")]
         public Color DefaultColor { get; init; } = Color.DarkGray;
+
+        [ToolTip("Pit stop color")]
+        public Color PitStopColor { get; init; } = Color.Yellow;
+
+        [ToolTip("Pit stop with damage color")]
+        public Color PitStopWithDamageColor { get; init; } = Color.MediumPurple;
     }
 
     [ConfigGrouping("Other", "Other options")]

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -71,8 +71,8 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
         public float FontSize { get; init; } = 10;
 
         [ToolTip("Lapped distance threshold in meters")]
-        [FloatRange(0, 200, 1.0f, 1)]
-        public float LappedThreshold { get; init; } = 75;
+        [FloatRange(0, 500, 1.0f, 1)]
+        public float LappedThreshold { get; init; } = 150;
 
         [ToolTip("Cars lapped by player color")]
         public Color PlayerLappedOthersColor { get; init; } = Color.SteelBlue;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -5,63 +5,22 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
 
 internal sealed class TrackMapConfiguration : OverlayConfiguration
 {
-    [ConfigGrouping("Map", "Map options")]
-    public MapGrouping Map { get; init; } = new();
-    public sealed class MapGrouping
+    [ConfigGrouping("General", "General options")]
+    public GeneralGrouping General { get; init; } = new();
+    public sealed class GeneralGrouping
     {
         [ToolTip("Minimap max width")]
-        [FloatRange(200.0f, 300.0f, 1.0f, 1)]
-        public float MaxWidth { get; init; } = 300f;
+        [FloatRange(200.0f, 500.0f, 1.0f, 1)]
+        public float MaxWidth { get; init; } = 350f;
 
         [ToolTip("Map lines thickness")]
         [FloatRange(1.0f, 10.0f, 0.1f, 1)]
-        public float Thickness { get; init; } = 4.0f;
+        public float Thickness { get; init; } = 2.0f;
 
         [ToolTip("Rotation in degrees")]
         [FloatRange(-360.0f, 360.0f, 1.0f, 1)]
         public float Rotation { get; init; } = -90.0f;
 
-        [ToolTip("Save map preview (Race Element directory -> Tracks)")]
-        public bool SavePreview { get; init; } = false;
-
-        [ToolTip("Map color")]
-        public Color Color { get; init; } = Color.WhiteSmoke;
-    }
-
-    [ConfigGrouping("Car", "Car options")]
-    public CarGrouping Car { get; init; } = new();
-    public sealed class CarGrouping
-    {
-        [ToolTip("Show Cars number")]
-        public bool ShowCarNumber { get; init; } = true;
-
-        [ToolTip("Show pit stop on map")]
-        public bool ShowPitStop { get; init; } = true;
-
-        [ToolTip("Player car color")]
-        public Color PlayerColor { get; init; } = Color.Red;
-
-        [ToolTip("Default car color (no player / no lapped)")]
-        public Color DefaultColor { get; init; } = Color.LightGray;
-
-        [ToolTip("Leader car color (no player)")]
-        public Color LeaderColor { get; init; } = Color.SeaGreen;
-
-        [ToolTip("Improving lap car color (no player)")]
-        public Color ImprovingLapColor { get; init; } = Color.SeaGreen;
-
-
-        [ToolTip("Pit stop color")]
-        public Color PitStopColor { get; init; } = Color.MediumOrchid;
-
-        [ToolTip("Pit stop with damage color")]
-        public Color PitStopWithDamageColor { get; init; } = Color.MediumPurple;
-    }
-
-    [ConfigGrouping("Other", "Other options")]
-    public OtherGrouping Other { get; init; } = new();
-    public sealed class OtherGrouping
-    {
         [ToolTip("Car size on the map")]
         [FloatRange(5.0f, 32.0f, 1.0f, 1)]
         public float CarSize { get; init; } = 15;
@@ -74,11 +33,50 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
         [FloatRange(0, 500, 1.0f, 1)]
         public float LappedThreshold { get; init; } = 150;
 
+        [ToolTip("Refresh interval (times per second)")]
+        [IntRange(8, 24, 1)]
+        public int RefreshInterval { get; init; } = 18;
+
+        [ToolTip("Save map preview (Race Element directory -> Tracks)")]
+        public bool SavePreview { get; init; } = false;
+
+        [ToolTip("Show Cars number")]
+        public bool ShowCarNumber { get; init; } = true;
+
+        [ToolTip("Show pit stop on map")]
+        public bool ShowPitStop { get; init; } = true;
+    }
+
+    [ConfigGrouping("Colors", "Colors options")]
+    public ColorGrouping Color { get; init; } = new();
+    public sealed class ColorGrouping
+    {
+        [ToolTip("Map color")]
+        public Color Map { get; init; } = global::System.Drawing.Color.WhiteSmoke;
+
+        [ToolTip("Player car color")]
+        public Color Player { get; init; } = global::System.Drawing.Color.Red;
+
+        [ToolTip("Default car color (no player / no lapped)")]
+        public Color Default { get; init; } = global::System.Drawing.Color.LightGray;
+
+        [ToolTip("Leader car color (no player)")]
+        public Color Leader { get; init; } = global::System.Drawing.Color.SeaGreen;
+
         [ToolTip("Cars lapped by player color")]
-        public Color PlayerLappedOthersColor { get; init; } = Color.SteelBlue;
+        public Color PlayerLappedOthers { get; init; } = global::System.Drawing.Color.SteelBlue;
 
         [ToolTip("Other lapped by player color")]
-        public Color OthersLappedPlayerColor { get; init; } = Color.DarkOrange;
+        public Color OthersLappedPlayer { get; init; } = global::System.Drawing.Color.DarkOrange;
+
+        [ToolTip("Improving lap car color (no player)")]
+        public Color ImprovingLap { get; init; } = global::System.Drawing.Color.SeaGreen;
+
+        [ToolTip("Pit stop color")]
+        public Color PitStop { get; init; } = global::System.Drawing.Color.MediumOrchid;
+
+        [ToolTip("Pit stop with damage color")]
+        public Color PitStopWithDamage { get; init; } = global::System.Drawing.Color.MediumPurple;
     }
 
     public TrackMapConfiguration() => this.GenericConfiguration.AllowRescale = false;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -42,10 +42,17 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
         public Color PlayerColor { get; init; } = Color.Red;
 
         [ToolTip("Default car color (no player / no lapped)")]
-        public Color DefaultColor { get; init; } = Color.DarkGray;
+        public Color DefaultColor { get; init; } = Color.LightGray;
+
+        [ToolTip("Leader car color (no player)")]
+        public Color LeaderColor { get; init; } = Color.SeaGreen;
+
+        [ToolTip("Improving lap car color (no player)")]
+        public Color ImprovingLapColor { get; init; } = Color.SeaGreen;
+
 
         [ToolTip("Pit stop color")]
-        public Color PitStopColor { get; init; } = Color.Yellow;
+        public Color PitStopColor { get; init; } = Color.MediumOrchid;
 
         [ToolTip("Pit stop with damage color")]
         public Color PitStopWithDamageColor { get; init; } = Color.MediumPurple;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -48,35 +48,35 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
     }
 
     [ConfigGrouping("Colors", "Colors options")]
-    public ColorGrouping Color { get; init; } = new();
+    public ColorGrouping Colors { get; init; } = new();
     public sealed class ColorGrouping
     {
         [ToolTip("Map color")]
-        public Color Map { get; init; } = global::System.Drawing.Color.WhiteSmoke;
+        public Color Map { get; init; } = Color.WhiteSmoke;
 
         [ToolTip("Player car color")]
-        public Color Player { get; init; } = global::System.Drawing.Color.Red;
+        public Color Player { get; init; } = Color.Red;
 
         [ToolTip("Default car color (no player / no lapped)")]
-        public Color Default { get; init; } = global::System.Drawing.Color.LightGray;
+        public Color Default { get; init; } = Color.LightGray;
 
         [ToolTip("Leader car color (no player)")]
-        public Color Leader { get; init; } = global::System.Drawing.Color.SeaGreen;
+        public Color Leader { get; init; } = Color.SeaGreen;
 
         [ToolTip("Cars lapped by player color")]
-        public Color PlayerLappedOthers { get; init; } = global::System.Drawing.Color.SteelBlue;
+        public Color PlayerLappedOthers { get; init; } = Color.SteelBlue;
 
         [ToolTip("Other lapped by player color")]
-        public Color OthersLappedPlayer { get; init; } = global::System.Drawing.Color.DarkOrange;
+        public Color OthersLappedPlayer { get; init; } = Color.DarkOrange;
 
         [ToolTip("Improving lap car color (no player)")]
-        public Color ImprovingLap { get; init; } = global::System.Drawing.Color.SeaGreen;
+        public Color ImprovingLap { get; init; } = Color.SeaGreen;
 
         [ToolTip("Pit stop color")]
-        public Color PitStop { get; init; } = global::System.Drawing.Color.MediumOrchid;
+        public Color PitStop { get; init; } = Color.MediumOrchid;
 
         [ToolTip("Pit stop with damage color")]
-        public Color PitStopWithDamage { get; init; } = global::System.Drawing.Color.MediumPurple;
+        public Color PitStopWithDamage { get; init; } = Color.MediumPurple;
     }
 
     public TrackMapConfiguration() => this.GenericConfiguration.AllowRescale = false;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapConfiguration.cs
@@ -33,10 +33,10 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
     public sealed class CarGrouping
     {
         [ToolTip("Show Cars number")]
-        public bool ShowCarNumber { get; init; } = false;
+        public bool ShowCarNumber { get; init; } = true;
 
         [ToolTip("Show pit stop on map")]
-        public bool ShowPitStop { get; init; } = false;
+        public bool ShowPitStop { get; init; } = true;
 
         [ToolTip("Player car color")]
         public Color PlayerColor { get; init; } = Color.Red;
@@ -62,5 +62,17 @@ internal sealed class TrackMapConfiguration : OverlayConfiguration
         [ToolTip("Font size for car number")]
         [FloatRange(5.0f, 32.0f, 1.0f, 1)]
         public float FontSize { get; init; } = 10;
+
+        [ToolTip("Lapped distance threshold in meters")]
+        [FloatRange(0, 200, 1.0f, 1)]
+        public float LappedThreshold { get; init; } = 75;
+
+        [ToolTip("Cars lapped by player color")]
+        public Color PlayerLappedOthersColor { get; init; } = Color.SteelBlue;
+
+        [ToolTip("Other lapped by player color")]
+        public Color OthersLappedPlayerColor { get; init; } = Color.DarkOrange;
     }
+
+    public TrackMapConfiguration() => this.GenericConfiguration.AllowRescale = false;
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapCreationJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapCreationJob.cs
@@ -135,7 +135,7 @@ public class TrackMapCreationJob : AbstractLoopJob
 
     private CreationState LoadMapFromFile()
     {
-        var trackName = ACCSharedMemory.Instance.PageFileStatic.Track;
+        var trackName = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
         string path = FileUtil.RaceElementTracks + trackName + ".bin";
 
         using FileStream fileStream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -163,7 +163,7 @@ public class TrackMapCreationJob : AbstractLoopJob
         DirectoryInfo directory = new(FileUtil.RaceElementTracks);
         if (!directory.Exists) directory.Create();
 
-        var trackName = ACCSharedMemory.Instance.PageFileStatic.Track;
+        var trackName = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
         string path = FileUtil.RaceElementTracks + trackName + ".bin";
 
         using FileStream fileStream = new(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -17,10 +17,12 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
 class TrackMapDrawing
 {
     private readonly SolidBrush _borderColor = new(Color.Black);
-    private Bitmap _bitmap = null;
 
-    private bool _showCarNumber = false;
-    private bool _showPitStop = false;
+    private Bitmap _bitmap;
+    private float _lappedDistanceThreshold = 100.0f;
+
+    private bool _showCarNumber;
+    private bool _showPitStop;
 
     private float _fontSize = 10;
     private float _dotSize = 15;
@@ -46,6 +48,12 @@ class TrackMapDrawing
     public TrackMapDrawing SetFontSize(float size)
     {
         _fontSize = size;
+        return this;
+    }
+
+    public TrackMapDrawing SetLappedThreshold(float threshold)
+    {
+        _lappedDistanceThreshold = threshold;
         return this;
     }
 
@@ -172,11 +180,11 @@ class TrackMapDrawing
                 var otherTrackMeters = otherLaps * trackMeters + currentCarData.RealtimeCarUpdate.SplinePosition * trackMeters;
                 var playerTrackMeters = playerLaps * trackMeters + playerCarData.RealtimeCarUpdate.SplinePosition * trackMeters;
 
-                if (playerLaps > otherLaps && (playerTrackMeters - otherTrackMeters) >= trackMeters)
+                if (playerLaps >= otherLaps && (playerTrackMeters - otherTrackMeters) >= (trackMeters - _lappedDistanceThreshold))
                 {
                     color = _colorCarPlayerLapperOthers;
                 }
-                else if (otherLaps > playerLaps && (otherTrackMeters - playerTrackMeters) >= trackMeters)
+                else if (otherLaps >= playerLaps && (otherTrackMeters - playerTrackMeters) >= (trackMeters - _lappedDistanceThreshold))
                 {
                     color = _colorCarOthersLappedPlayer;
                 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 
 using System.Collections.Generic;
 using System.Diagnostics;
+
 using RaceElement.Data.ACC.EntryList;
 using RaceElement.Broadcast.Structs;
 
@@ -237,12 +238,11 @@ class TrackMapDrawing
         g.FillEllipse(_borderColor, car.X - outBorder * 0.5f, car.Y - outBorder * 0.5f, _dotSize, _dotSize);
         g.FillEllipse(color, car.X, car.Y, _dotSize - outBorder, _dotSize - outBorder);
 
-        string simbol = pitStop.Laps > 0 ? "+" : "P";
-        g.DrawStringWithShadow(simbol, font, new SolidBrush(Color.WhiteSmoke), car);
+        string symbol = pitStop.Laps > 0 ? "+" : "P";
+        g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.WhiteSmoke), car);
 
         if (pitStop.Laps > 0)
         {
-            g.DrawStringWithShadow("+", font, new SolidBrush(Color.WhiteSmoke), car);
             using SolidBrush pen = new (Color.FromArgb(100, Color.Black));
 
             var laps = pitStop.Laps.ToString();

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -75,7 +75,7 @@ class TrackMapDrawer
         return bitmap;
     }
 
-    public static Bitmap CreateLineOfPoints(Color color, float thickness, float margin, List<PointF> points, BoundingBox boundaries)
+    public static Bitmap CreateLineFromPoints(Color color, float thickness, float margin, List<PointF> points, BoundingBox boundaries)
     {
         var w = Math.Sqrt(Math.Pow(boundaries.Right - boundaries.Left, 2)) + margin + 1.5;
         var h = Math.Sqrt(Math.Pow(boundaries.Bottom - boundaries.Top, 2)) + margin + 1.5;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -35,7 +35,7 @@ class TrackMapDrawing
     private SolidBrush _colorCarDefault = new(Color.DarkGray);
 
     private SolidBrush _colorPitStop = new(Color.Yellow);
-    private SolidBrush _colorPitStopWithDamange = new(Color.MediumPurple);
+    private SolidBrush _colorPitStopWithDamage = new(Color.MediumPurple);
 
     public TrackMapDrawing SetDotSize(float size)
     {
@@ -103,9 +103,9 @@ class TrackMapDrawing
         return this;
     }
 
-    public TrackMapDrawing SetColorPitStopWithDamange(Color color)
+    public TrackMapDrawing SetColorPitStopWithDamage(Color color)
     {
-        _colorPitStopWithDamange = new(color);
+        _colorPitStopWithDamage = new(color);
         return this;
     }
 
@@ -140,6 +140,11 @@ class TrackMapDrawing
 
     private Bitmap DrawCars(List<PointF> cars, List<int> ids, List<PointF> track, Graphics g, TrackData broadCastTrackData)
     {
+        if (ids.Count != cars.Count)
+        {
+            return null;
+        }
+
         int playerIdx = 0;
         using Font font = FontUtil.FontSegoeMono(_fontSize);
 
@@ -156,9 +161,7 @@ class TrackMapDrawing
 
             var car = cars[i];
             var color = _colorCarDefault;
-
-            var idx = pageFileGraphic.CarIds[i];
-            var currentCarData = EntryListTracker.Instance.GetCarData(idx);
+            var currentCarData = EntryListTracker.Instance.GetCarData(ids[i]);
 
             if (playerCarData != null && currentCarData != null)
             {
@@ -189,7 +192,7 @@ class TrackMapDrawing
             if (_showPitStop)
             {
                 DrawPitStopOnMap(font, g, _colorPitStop, TrackMapPitPrediction.GetPitStop(track));
-                DrawPitStopOnMap(font, g, _colorPitStopWithDamange, TrackMapPitPrediction.GetPitStopWithDamage(track));
+                DrawPitStopOnMap(font, g, _colorPitStopWithDamage, TrackMapPitPrediction.GetPitStopWithDamage(track));
             }
         }
 
@@ -239,7 +242,7 @@ class TrackMapDrawing
         g.FillEllipse(color, car.X, car.Y, _dotSize - outBorder, _dotSize - outBorder);
 
         string symbol = pitStop.Laps > 0 ? "+" : "P";
-        g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.WhiteSmoke), car);
+        g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.Black), car);
 
         if (pitStop.Laps > 0)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -220,11 +220,11 @@ class TrackMapDrawing
         return _bitmap;
     }
 
-    private void DrawCarOnMap(CarOnTrack carOnTrack, Graphics g, SolidBrush color, Font font)
+    private void DrawCarOnMap(CarOnTrack car, Graphics g, SolidBrush color, Font font)
     {
         {
             var outBorder = 3.0f;
-            PointF pos = carOnTrack.Coord;
+            PointF pos = car.Coord;
 
             pos.X -= _dotSize * 0.5f;
             pos.Y -= _dotSize * 0.5f;
@@ -233,17 +233,17 @@ class TrackMapDrawing
             g.FillEllipse(color, pos.X, pos.Y, _dotSize - outBorder, _dotSize - outBorder);
         }
 
-        if (_showCarNumber && carOnTrack.RaceNumber != null)
+        if (_showCarNumber && car.RaceNumber != null)
         {
             using SolidBrush pen = new (Color.FromArgb(100, Color.Black));
-            var size = g.MeasureString(carOnTrack.RaceNumber, font);
-            PointF pos = carOnTrack.Coord;
+            var size = g.MeasureString(car.RaceNumber, font);
+            PointF pos = car.Coord;
 
             pos.Y -= _dotSize * 0.5f + size.Height;
             pos.X -= _dotSize * 0.5f;
 
             g.FillRectangle(pen, pos.X, pos.Y, size.Width, size.Height);
-            g.DrawStringWithShadow(carOnTrack.RaceNumber, font, new SolidBrush(Color.WhiteSmoke), pos);
+            g.DrawStringWithShadow(car.RaceNumber, font, new SolidBrush(Color.WhiteSmoke), pos);
         }
     }
 
@@ -286,23 +286,23 @@ class TrackMapDrawing
         }
     }
 
-    private SolidBrush GetRaceCarColor(CarOnTrack playerCarData, CarOnTrack otherCarData)
+    private SolidBrush GetRaceCarColor(CarOnTrack player, CarOnTrack other)
     {
-        if (playerCarData == null || otherCarData == null)
+        if (player == null || other == null)
         {
             return _colorCarDefault;
         }
 
-        if (otherCarData.Position == 1)
+        if (other.Position == 1)
         {
             return _colorCarLeader;
         }
 
-        var playerLaps = playerCarData.Laps;
-        var otherLaps = otherCarData.Laps;
+        var playerLaps = player.Laps;
+        var otherLaps = other.Laps;
 
-        var playerTrackMeters = playerLaps * _trackMeters + playerCarData.Spline * _trackMeters;
-        var otherTrackMeters = otherLaps * _trackMeters + otherCarData.Spline * _trackMeters;
+        var playerTrackMeters = playerLaps * _trackMeters + player.Spline * _trackMeters;
+        var otherTrackMeters = otherLaps * _trackMeters + other.Spline * _trackMeters;
 
         if (playerLaps == otherLaps && otherLaps == 0)
         {
@@ -334,19 +334,19 @@ class TrackMapDrawing
         return _colorCarDefault;
     }
 
-    private SolidBrush GetOtherSessionCarColor(CarOnTrack otherCarData)
+    private SolidBrush GetOtherSessionCarColor(CarOnTrack car)
     {
-        if (otherCarData.Location != CarLocationEnum.Track)
+        if (car.Location != CarLocationEnum.Track)
         {
             return _colorCarDefault;
         }
 
-        if (!otherCarData.IsValid)
+        if (!car.IsValid)
         {
             return _colorCarPlayerLapperOthers;
         }
 
-        if (otherCarData.Delta < 0 && otherCarData.IsValidForBest)
+        if (car.Delta < 0 && car.IsValidForBest)
         {
             return _colorValidForBest;
         }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -238,6 +238,9 @@ class TrackMapDrawing
             return;
         }
 
+        string symbol = pitStop.Laps > 0 ? "+" : "P";
+        SizeF textSize = g.MeasureString(symbol, font);
+
         var car = pitStop.Position;
         var outBorder = 3.0f;
 
@@ -247,7 +250,9 @@ class TrackMapDrawing
         g.FillEllipse(_borderColor, car.X - outBorder * 0.5f, car.Y - outBorder * 0.5f, _dotSize, _dotSize);
         g.FillEllipse(color, car.X, car.Y, _dotSize - outBorder, _dotSize - outBorder);
 
-        string symbol = pitStop.Laps > 0 ? "+" : "P";
+        car.Y += Math.Abs(_dotSize - textSize.Height) * 0.5f;
+        car.X += Math.Abs(_dotSize - textSize.Width) * 0.5f;
+
         g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.Black), car);
 
         if (pitStop.Laps > 0)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -2,9 +2,9 @@
 using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.Drawing;
+using System;
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using RaceElement.Data.ACC.EntryList;
 using RaceElement.Broadcast;
@@ -16,11 +16,11 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
 
 class TrackMapDrawing
 {
-    private readonly SolidBrush _colorValidForBest = new(Color.Purple);
-    private readonly SolidBrush _colorCarLeader = new(Color.DarkGreen);
     private readonly SolidBrush _borderColor = new(Color.Black);
-
     private Bitmap _bitmap;
+
+    private SolidBrush _colorValidForBest = new(Color.SeaGreen);
+    private SolidBrush _colorCarLeader = new(Color.SeaGreen);
 
     private float _lappedDistanceThreshold = 100.0f;
     private float _trackMeters = 0.0f;
@@ -40,7 +40,7 @@ class TrackMapDrawing
     private SolidBrush _colorCarPlayer = new(Color.Red);
     private SolidBrush _colorCarDefault = new(Color.DarkGray);
 
-    private SolidBrush _colorPitStop = new(Color.Yellow);
+    private SolidBrush _colorPitStop = new(Color.MediumOrchid);
     private SolidBrush _colorPitStopWithDamage = new(Color.MediumPurple);
 
     public TrackMapDrawing SetDotSize(float size)
@@ -61,6 +61,12 @@ class TrackMapDrawing
         return this;
     }
 
+    public TrackMapDrawing SetMapThickness(float thickness)
+    {
+        _mapThickness = thickness;
+        return this;
+    }
+
     public TrackMapDrawing SetTrackMeter(float meters)
     {
         _trackMeters = meters;
@@ -70,6 +76,12 @@ class TrackMapDrawing
     public TrackMapDrawing SetShowCarNumber(bool show)
     {
         _showCarNumber = show;
+        return this;
+    }
+
+    public TrackMapDrawing SetShowPitStop(bool show)
+    {
+        _showPitStop = show;
         return this;
     }
 
@@ -91,12 +103,6 @@ class TrackMapDrawing
         return this;
     }
 
-    public TrackMapDrawing SetMapThickness(float thickness)
-    {
-        _mapThickness = thickness;
-        return this;
-    }
-
     public TrackMapDrawing SetColorPlayerLappedOthers(Color color)
     {
         _colorCarPlayerLapperOthers = new(color);
@@ -109,12 +115,6 @@ class TrackMapDrawing
         return this;
     }
 
-    public TrackMapDrawing SetShowPitStop(bool show)
-    {
-        _showPitStop = show;
-        return this;
-    }
-
     public TrackMapDrawing SetColorPitStop(Color color)
     {
         _colorPitStop = new(color);
@@ -124,6 +124,18 @@ class TrackMapDrawing
     public TrackMapDrawing SetColorPitStopWithDamage(Color color)
     {
         _colorPitStopWithDamage = new(color);
+        return this;
+    }
+
+    public TrackMapDrawing SetColorLeader(Color color)
+    {
+        _colorCarLeader = new(color);
+        return this;
+    }
+
+    public TrackMapDrawing SetColorImprovingLap(Color color)
+    {
+        _colorValidForBest = new(color);
         return this;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -57,8 +57,8 @@ class TrackMapDrawer
 {
     public static Bitmap CreateCircleWithOutline(Color color, float diameter, float outLineSize)
     {
-        var w = diameter + outLineSize + 0.5f;
-        var h = diameter + outLineSize + 0.5f;
+        var w = diameter + outLineSize + 1.5f;
+        var h = diameter + outLineSize + 1.5f;
 
         var bitmap = new Bitmap((int)w, (int)h, PixelFormat.Format32bppPArgb);
         bitmap.MakeTransparent();
@@ -70,15 +70,15 @@ class TrackMapDrawer
         g.CompositingQuality = CompositingQuality.HighQuality;
 
         g.FillEllipse(new SolidBrush(color), outLineSize * 0.5f, outLineSize * 0.5f, diameter, diameter);
-        g.DrawEllipse(new Pen(new SolidBrush(Color.Black), outLineSize), outLineSize * 0.5f, outLineSize * 0.5f, diameter, diameter);
+        g.DrawEllipse(new Pen(new SolidBrush(Color.FromArgb(200, 0, 0, 0)), outLineSize), outLineSize * 0.5f, outLineSize * 0.5f, diameter, diameter);
 
         return bitmap;
     }
 
     public static Bitmap CreateLineOfPoints(Color color, float thickness, float margin, List<PointF> points, BoundingBox boundaries)
     {
-        var w = Math.Sqrt(Math.Pow(boundaries.Right - boundaries.Left, 2)) + margin + 0.5;
-        var h = Math.Sqrt(Math.Pow(boundaries.Bottom - boundaries.Top, 2)) + margin + 0.5;
+        var w = Math.Sqrt(Math.Pow(boundaries.Right - boundaries.Left, 2)) + margin + 1.5;
+        var h = Math.Sqrt(Math.Pow(boundaries.Bottom - boundaries.Top, 2)) + margin + 1.5;
 
         var bitmap = new Bitmap((int)w, (int)h, PixelFormat.Format32bppPArgb);
         bitmap.MakeTransparent();
@@ -105,7 +105,7 @@ class TrackMapDrawer
         g.CompositingQuality = CompositingQuality.HighQuality;
 
         var sessionType = ACCSharedMemory.Instance.PageFileGraphic.SessionType;
-        using var font = FontUtil.FontSegoeMono(conf.Other.FontSize);
+        using var font = FontUtil.FontSegoeMono(conf.General.FontSize);
 
         foreach (var it in cars.Cars)
         {
@@ -123,7 +123,7 @@ class TrackMapDrawer
             DrawCarOnMap(it, bitmap, conf, g, font);
         }
 
-        if (conf.Car.ShowPitStop)
+        if (conf.General.ShowPitStop)
         {
             DrawPitStopOnMap(font, g, cache.PitStop, TrackMapPitPrediction.GetPitStop(track));
             DrawPitStopOnMap(font, g, cache.PitStopWithDamage, TrackMapPitPrediction.GetPitStopWithDamage(track));
@@ -149,7 +149,7 @@ class TrackMapDrawer
             g.DrawImage(bitmap, pos);
         }
 
-        if (conf.Car.ShowCarNumber && car.RaceNumber != null)
+        if (conf.General.ShowCarNumber && car.RaceNumber != null)
         {
             using SolidBrush pen = new (Color.FromArgb(100, Color.Black));
             var size = g.MeasureString(car.RaceNumber, font);
@@ -242,11 +242,11 @@ class TrackMapDrawer
                 return cache.OthersLappedPlayer;
             }
         }
-        else if (playerLaps >= otherLaps && (playerTrackMeters - otherTrackMeters) >= (trackMeters - conf.Other.LappedThreshold))
+        else if (playerLaps >= otherLaps && (playerTrackMeters - otherTrackMeters) >= (trackMeters - conf.General.LappedThreshold))
         {
             return cache.PlayerLapperOthers;
         }
-        else if (otherLaps >= playerLaps && (otherTrackMeters - playerTrackMeters) >= (trackMeters - conf.Other.LappedThreshold))
+        else if (otherLaps >= playerLaps && (otherTrackMeters - playerTrackMeters) >= (trackMeters - conf.General.LappedThreshold))
         {
             return cache.OthersLappedPlayer;
         }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -36,273 +36,193 @@ class CarRenderData
     public CarOnTrack Player;
 }
 
-class TrackMapDrawing
+class TrackMapCache
 {
-    private readonly SolidBrush _borderColor = new(Color.Black);
-    private Bitmap _bitmap;
+    public Bitmap OthersLappedPlayer;
+    public Bitmap PlayerLapperOthers;
 
-    private SolidBrush _colorValidForBest = new(Color.SeaGreen);
-    private SolidBrush _colorCarLeader = new(Color.SeaGreen);
+    public Bitmap CarDefault;
+    public Bitmap CarPlayer;
 
-    private float _lappedDistanceThreshold = 100.0f;
-    private float _trackMeters = 0.0f;
+    public Bitmap PitStopWithDamage;
+    public Bitmap PitStop;
 
-    private bool _showCarNumber;
-    private bool _showPitStop;
+    public Bitmap ValidForBest;
+    public Bitmap Leader;
 
-    private float _fontSize = 10;
-    private float _dotSize = 15;
+    public Bitmap Map;
+}
 
-    private Color _mapColor = Color.WhiteSmoke;
-    private float _mapThickness = 4;
-
-    private SolidBrush _colorCarOthersLappedPlayer = new(Color.DarkOrange);
-    private SolidBrush _colorCarPlayerLapperOthers = new(Color.SteelBlue);
-
-    private SolidBrush _colorCarPlayer = new(Color.Red);
-    private SolidBrush _colorCarDefault = new(Color.DarkGray);
-
-    private SolidBrush _colorPitStop = new(Color.MediumOrchid);
-    private SolidBrush _colorPitStopWithDamage = new(Color.MediumPurple);
-
-    public TrackMapDrawing SetDotSize(float size)
+class TrackMapDrawer
+{
+    public static Bitmap CreateCircleWithOutline(Color color, float diameter, float outLineSize)
     {
-        _dotSize = size;
-        return this;
-    }
+        var w = diameter + outLineSize + 0.5f;
+        var h = diameter + outLineSize + 0.5f;
 
-    public TrackMapDrawing SetFontSize(float size)
-    {
-        _fontSize = size;
-        return this;
-    }
+        var bitmap = new Bitmap((int)w, (int)h, PixelFormat.Format32bppPArgb);
+        bitmap.MakeTransparent();
 
-    public TrackMapDrawing SetLappedThreshold(float threshold)
-    {
-        _lappedDistanceThreshold = threshold;
-        return this;
-    }
-
-    public TrackMapDrawing SetMapThickness(float thickness)
-    {
-        _mapThickness = thickness;
-        return this;
-    }
-
-    public TrackMapDrawing SetTrackMeter(float meters)
-    {
-        _trackMeters = meters;
-        return this;
-    }
-
-    public TrackMapDrawing SetShowCarNumber(bool show)
-    {
-        _showCarNumber = show;
-        return this;
-    }
-
-    public TrackMapDrawing SetShowPitStop(bool show)
-    {
-        _showPitStop = show;
-        return this;
-    }
-
-    public TrackMapDrawing SetColorMap(Color color)
-    {
-        _mapColor = color;
-        return this;
-    }
-
-    public TrackMapDrawing SetColorPlayer(Color color)
-    {
-        _colorCarPlayer = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorCarDefault(Color color)
-    {
-        _colorCarDefault = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorPlayerLappedOthers(Color color)
-    {
-        _colorCarPlayerLapperOthers = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorOthersLappedPlayer(Color color)
-    {
-        _colorCarOthersLappedPlayer = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorPitStop(Color color)
-    {
-        _colorPitStop = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorPitStopWithDamage(Color color)
-    {
-        _colorPitStopWithDamage = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorLeader(Color color)
-    {
-        _colorCarLeader = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing SetColorImprovingLap(Color color)
-    {
-        _colorValidForBest = new(color);
-        return this;
-    }
-
-    public TrackMapDrawing CreateBitmap(float width, float height, float margin)
-    {
-        int w = (int)(width + margin + 0.5f);
-        int h = (int)(height + margin + 0.5f);
-
-        _bitmap = new Bitmap(w, h, PixelFormat.Format32bppPArgb);
-        _bitmap.MakeTransparent();
-
-        return this;
-    }
-
-    public Bitmap Draw(CarRenderData cars, List<PointF> track)
-    {
-        var g = Graphics.FromImage(_bitmap);
+        using var g = Graphics.FromImage(bitmap);
         g.SmoothingMode = SmoothingMode.AntiAlias;
         g.CompositingMode = CompositingMode.SourceOver;
         g.TextRenderingHint = TextRenderingHint.AntiAlias;
         g.CompositingQuality = CompositingQuality.HighQuality;
 
-        g.DrawLines(new Pen(_mapColor, _mapThickness), track.ToArray());
-        return DrawCars(cars, track, g);
+        g.FillEllipse(new SolidBrush(color), outLineSize * 0.5f, outLineSize * 0.5f, diameter, diameter);
+        g.DrawEllipse(new Pen(new SolidBrush(Color.Black), outLineSize), outLineSize * 0.5f, outLineSize * 0.5f, diameter, diameter);
+
+        return bitmap;
     }
 
-    private Bitmap DrawCars(CarRenderData cars, List<PointF> track, Graphics g)
+    public static Bitmap CreateLineOfPoints(Color color, float thickness, float margin, List<PointF> points, BoundingBox boundaries)
     {
+        var w = Math.Sqrt(Math.Pow(boundaries.Right - boundaries.Left, 2)) + margin + 0.5;
+        var h = Math.Sqrt(Math.Pow(boundaries.Bottom - boundaries.Top, 2)) + margin + 0.5;
+
+        var bitmap = new Bitmap((int)w, (int)h, PixelFormat.Format32bppPArgb);
+        bitmap.MakeTransparent();
+
+        using var g = Graphics.FromImage(bitmap);
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.CompositingMode = CompositingMode.SourceOver;
+        g.TextRenderingHint = TextRenderingHint.AntiAlias;
+        g.CompositingQuality = CompositingQuality.HighQuality;
+
+        g.DrawLines(new Pen(color, thickness), points.ToArray());
+        return bitmap;
+    }
+
+    public static Bitmap Draw(List<PointF> track,CarRenderData cars, TrackMapCache cache, TrackMapConfiguration conf, float trackMeters)
+    {
+
+        var result = new Bitmap(cache.Map);
+        using var g = Graphics.FromImage(result);
+
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.CompositingMode = CompositingMode.SourceOver;
+        g.TextRenderingHint = TextRenderingHint.AntiAlias;
+        g.CompositingQuality = CompositingQuality.HighQuality;
+
         var sessionType = ACCSharedMemory.Instance.PageFileGraphic.SessionType;
-        using var font = FontUtil.FontSegoeMono(_fontSize);
+        using var font = FontUtil.FontSegoeMono(conf.Other.FontSize);
 
         foreach (var it in cars.Cars)
         {
-            SolidBrush color;
+            Bitmap bitmap;
 
             if (sessionType == ACCSharedMemory.AcSessionType.AC_RACE)
             {
-                color = GetRaceCarColor(cars.Player, it);
+                bitmap = GetRaceCarBitmap(cars.Player, it, cache, conf, trackMeters);
             }
             else
             {
-                color = GetOtherSessionCarColor(it);
+                bitmap = GetOtherSessionCarBitmap(it, cache);
             }
 
-            DrawCarOnMap(it, g, color, font);
+            DrawCarOnMap(it, bitmap, conf, g, font);
         }
 
-        if (_showPitStop)
+        if (conf.Car.ShowPitStop)
         {
-            DrawPitStopOnMap(font, g, _colorPitStop, TrackMapPitPrediction.GetPitStop(track));
-            DrawPitStopOnMap(font, g, _colorPitStopWithDamage, TrackMapPitPrediction.GetPitStopWithDamage(track));
+            DrawPitStopOnMap(font, g, cache.PitStop, TrackMapPitPrediction.GetPitStop(track));
+            DrawPitStopOnMap(font, g, cache.PitStopWithDamage, TrackMapPitPrediction.GetPitStopWithDamage(track));
         }
 
         if (cars.Player != null)
         {
             // Note(Andrei): To avoid crash when render the track preview
-            DrawCarOnMap(cars.Player, g, _colorCarPlayer, font);
+            DrawCarOnMap(cars.Player, cache.CarPlayer, conf, g, font);
         }
 
-        return _bitmap;
+        return result;
     }
 
-    private void DrawCarOnMap(CarOnTrack car, Graphics g, SolidBrush color, Font font)
+    private static void DrawCarOnMap(CarOnTrack car, Bitmap bitmap, TrackMapConfiguration conf, Graphics g, Font font)
     {
         {
-            var outBorder = 3.0f;
             PointF pos = car.Coord;
 
-            pos.X -= _dotSize * 0.5f;
-            pos.Y -= _dotSize * 0.5f;
+            pos.X -= bitmap.Width * 0.5f;
+            pos.Y -= bitmap.Height * 0.5f;
 
-            g.FillEllipse(_borderColor, pos.X - outBorder * 0.5f, pos.Y - outBorder * 0.5f, _dotSize, _dotSize);
-            g.FillEllipse(color, pos.X, pos.Y, _dotSize - outBorder, _dotSize - outBorder);
+            g.DrawImage(bitmap, pos);
         }
 
-        if (_showCarNumber && car.RaceNumber != null)
+        if (conf.Car.ShowCarNumber && car.RaceNumber != null)
         {
             using SolidBrush pen = new (Color.FromArgb(100, Color.Black));
             var size = g.MeasureString(car.RaceNumber, font);
             PointF pos = car.Coord;
 
-            pos.Y -= _dotSize * 0.5f + size.Height;
-            pos.X -= _dotSize * 0.5f;
+            pos.Y -= bitmap.Height * 0.5f + size.Height;
+            pos.X -= bitmap.Width * 0.5f;
 
             g.FillRectangle(pen, pos.X, pos.Y, size.Width, size.Height);
             g.DrawStringWithShadow(car.RaceNumber, font, new SolidBrush(Color.WhiteSmoke), pos);
         }
     }
 
-    private void DrawPitStopOnMap(Font font, Graphics g, SolidBrush color, PitStop pitStop)
+    private static void DrawPitStopOnMap(Font font, Graphics g, Bitmap bitmap, PitStop pitStop)
     {
         if (pitStop == null)
         {
             return;
         }
 
-        string symbol = pitStop.Laps > 0 ? "+" : "P";
-        SizeF textSize = g.MeasureString(symbol, font);
+        {
+            PointF p = pitStop.Position;
 
-        var car = pitStop.Position;
-        var outBorder = 3.0f;
+            p.X -= bitmap.Width * 0.5f;
+            p.Y -= bitmap.Height * 0.5f;
 
-        car.X -= _dotSize * 0.5f;
-        car.Y -= _dotSize * 0.5f;
+            g.DrawImage(bitmap, p);
+        }
 
-        g.FillEllipse(_borderColor, car.X - outBorder * 0.5f, car.Y - outBorder * 0.5f, _dotSize, _dotSize);
-        g.FillEllipse(color, car.X, car.Y, _dotSize - outBorder, _dotSize - outBorder);
+        {
+            string symbol = pitStop.Damage ? "+" : "P";
+            SizeF textSize = g.MeasureString(symbol, font);
 
-        car.Y += Math.Abs(_dotSize - textSize.Height) * 0.5f;
-        car.X += Math.Abs(_dotSize - textSize.Width) * 0.5f;
+            var pos = pitStop.Position;
+            pos.X -= textSize.Width * 0.5f;
+            pos.Y -= textSize.Height * 0.5f;
 
-        g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.Black), car);
+            g.DrawStringWithShadow(symbol, font, new SolidBrush(Color.Black), pos);
+        }
 
         if (pitStop.Laps > 0)
         {
-            using SolidBrush pen = new (Color.FromArgb(100, Color.Black));
+            using SolidBrush color = new (Color.FromArgb(100, Color.Black));
+            var pos = pitStop.Position;
 
             var laps = pitStop.Laps.ToString();
             var size = g.MeasureString(laps, font);
 
-            car.X -= size.Width * 0.25f;
-            car.Y -= size.Height;
+            pos.Y -= bitmap.Height * 0.5f + size.Height;
+            pos.X -= bitmap.Width * 0.5f;
 
-            g.FillRectangle(pen, car.X, car.Y, size.Width, size.Height);
-            g.DrawStringWithShadow(laps, font, new SolidBrush(Color.WhiteSmoke), car);
+            g.FillRectangle(color, pos.X, pos.Y, size.Width, size.Height);
+            g.DrawStringWithShadow(laps, font, new SolidBrush(Color.WhiteSmoke), pos);
         }
     }
 
-    private SolidBrush GetRaceCarColor(CarOnTrack player, CarOnTrack other)
+    private static Bitmap GetRaceCarBitmap(CarOnTrack player, CarOnTrack other, TrackMapCache cache, TrackMapConfiguration conf, float trackMeters)
     {
         if (player == null || other == null)
         {
-            return _colorCarDefault;
+            return cache.CarDefault;
         }
 
         if (other.Position == 1)
         {
-            return _colorCarLeader;
+            return cache.Leader;
         }
 
         var playerLaps = player.Laps;
         var otherLaps = other.Laps;
 
-        var playerTrackMeters = playerLaps * _trackMeters + player.Spline * _trackMeters;
-        var otherTrackMeters = otherLaps * _trackMeters + other.Spline * _trackMeters;
+        var playerTrackMeters = playerLaps * trackMeters + player.Spline * trackMeters;
+        var otherTrackMeters = otherLaps * trackMeters + other.Spline * trackMeters;
 
         if (playerLaps == otherLaps && otherLaps == 0)
         {
@@ -314,43 +234,43 @@ class TrackMapDrawing
         {
             if (playerLaps > otherLaps)
             {
-                return _colorCarPlayerLapperOthers;
+                return cache.PlayerLapperOthers;
             }
 
             if (otherLaps > playerLaps)
             {
-                return _colorCarOthersLappedPlayer;
+                return cache.OthersLappedPlayer;
             }
         }
-        else if (playerLaps >= otherLaps && (playerTrackMeters - otherTrackMeters) >= (_trackMeters - _lappedDistanceThreshold))
+        else if (playerLaps >= otherLaps && (playerTrackMeters - otherTrackMeters) >= (trackMeters - conf.Other.LappedThreshold))
         {
-            return _colorCarPlayerLapperOthers;
+            return cache.PlayerLapperOthers;
         }
-        else if (otherLaps >= playerLaps && (otherTrackMeters - playerTrackMeters) >= (_trackMeters - _lappedDistanceThreshold))
+        else if (otherLaps >= playerLaps && (otherTrackMeters - playerTrackMeters) >= (trackMeters - conf.Other.LappedThreshold))
         {
-            return _colorCarOthersLappedPlayer;
+            return cache.OthersLappedPlayer;
         }
 
-        return _colorCarDefault;
+        return cache.CarDefault;
     }
 
-    private SolidBrush GetOtherSessionCarColor(CarOnTrack car)
+    private static Bitmap GetOtherSessionCarBitmap(CarOnTrack car, TrackMapCache cache)
     {
         if (car.Location != CarLocationEnum.Track)
         {
-            return _colorCarDefault;
+            return cache.CarDefault;
         }
 
         if (!car.IsValid)
         {
-            return _colorCarPlayerLapperOthers;
+            return cache.PlayerLapperOthers;
         }
 
         if (car.Delta < 0 && car.IsValidForBest)
         {
-            return _colorValidForBest;
+            return cache.ValidForBest;
         }
 
-        return _colorCarDefault;
+        return cache.CarDefault;
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -211,7 +211,12 @@ class TrackMapDrawing
             DrawPitStopOnMap(font, g, _colorPitStopWithDamage, TrackMapPitPrediction.GetPitStopWithDamage(track));
         }
 
-        DrawCarOnMap(cars.Player, g, _colorCarPlayer, font);
+        if (cars.Player != null)
+        {
+            // Note(Andrei): To avoid crash when render the track preview
+            DrawCarOnMap(cars.Player, g, _colorCarPlayer, font);
+        }
+
         return _bitmap;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -119,7 +119,7 @@ class TrackMapDrawing
         return this;
     }
 
-    public Bitmap Draw(List<PointF> cars, List<PointF> track, TrackData broadCastTrackData)
+    public Bitmap Draw(List<PointF> cars, List<int> ids, List<PointF> track, TrackData broadCastTrackData)
     {
         if (_bitmap == null)
         {
@@ -134,10 +134,10 @@ class TrackMapDrawing
         g.CompositingQuality = CompositingQuality.HighQuality;
 
         g.DrawLines(new Pen(_mapColor, _mapThickness), track.ToArray());
-        return DrawCars(cars, track, g, broadCastTrackData);
+        return DrawCars(cars, ids, track, g, broadCastTrackData);
     }
 
-    private Bitmap DrawCars(List<PointF> cars, List<PointF> track, Graphics g, TrackData broadCastTrackData)
+    private Bitmap DrawCars(List<PointF> cars, List<int> ids, List<PointF> track, Graphics g, TrackData broadCastTrackData)
     {
         int playerIdx = 0;
         using Font font = FontUtil.FontSegoeMono(_fontSize);
@@ -147,7 +147,7 @@ class TrackMapDrawing
 
         for (int i = 0; i < cars.Count; ++i)
         {
-            if (pageFileGraphic.CarIds[i] == pageFileGraphic.PlayerCarID)
+            if (ids[i] == pageFileGraphic.PlayerCarID)
             {
                 playerIdx = i;
                 continue;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDrawing.cs
@@ -25,6 +25,7 @@ class CarOnTrack
     public float Spline;
     public int Position;
 
+    public int Delta;
     public int Laps;
     public int Id;
 }
@@ -198,7 +199,7 @@ class TrackMapDrawing
             }
             else
             {
-                color = GetOtherSessionCarColor(cars.Player, it);
+                color = GetOtherSessionCarColor(it);
             }
 
             DrawCarOnMap(it, g, color, font);
@@ -328,32 +329,23 @@ class TrackMapDrawing
         return _colorCarDefault;
     }
 
-    private SolidBrush GetOtherSessionCarColor(CarOnTrack playerCarData, CarOnTrack otherCarData)
+    private SolidBrush GetOtherSessionCarColor(CarOnTrack otherCarData)
     {
-        if (playerCarData == null || otherCarData == null)
-        {
-            return _colorCarDefault;
-        }
-
         if (otherCarData.Location != CarLocationEnum.Track)
         {
             return _colorCarDefault;
         }
 
-        var otherIsValidForBest = otherCarData.IsValidForBest;
-        var playerIsValidLap = playerCarData.IsValid;
-        var otherIsValidLap = otherCarData.IsValid;
-
-        if (playerIsValidLap && !otherIsValidLap)
+        if (!otherCarData.IsValid)
         {
             return _colorCarPlayerLapperOthers;
         }
 
-        if (!playerIsValidLap && otherIsValidLap)
+        if (otherCarData.Delta < 0 && otherCarData.IsValidForBest)
         {
-            return otherIsValidForBest ? _colorValidForBest : _colorCarOthersLappedPlayer;
+            return _colorValidForBest;
         }
 
-        return otherIsValidForBest ? _colorValidForBest : _colorCarDefault;
+        return _colorCarDefault;
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -72,7 +72,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
-        return base.ShouldRender() && _trackPositions != null;
+        return base.ShouldRender() && _trackPositions.Count != 0;
     }
 
     public override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -94,7 +94,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
     public override void Render(Graphics g)
     {
         var carsOnTrack = GetCarsOnTrack();
-        var bitmap = TrackMapDrawer.Draw(_trackPositions, carsOnTrack, _mapCache, _config, 4005/*broadCastTrackData.TrackMeters*/);
+        var bitmap = TrackMapDrawer.Draw(_trackPositions, carsOnTrack, _mapCache, _config, broadCastTrackData.TrackMeters);
 
         if (bitmap.Width != Width || bitmap.Height != Height)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -153,7 +153,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackBoundingBox = boundaries;
         _trackPositions = track;
 
-        _mapCache.Map = TrackMapDrawer.CreateLineOfPoints(_config.Color.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
+        _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Color.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
 
         if (!_config.General.SavePreview)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -3,6 +3,7 @@ using RaceElement.Data.ACC.EntryList;
 using RaceElement.Data.ACC.Session;
 
 using RaceElement.HUD.Overlay.Internal;
+using RaceElement.Broadcast;
 using RaceElement.Util;
 
 using System.Collections.Generic;
@@ -176,6 +177,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             {
                 car.IsValidForBest = it.Value.RealtimeCarUpdate.CurrentLap.IsValidForBest;
                 car.IsValid = !it.Value.RealtimeCarUpdate.CurrentLap.IsInvalid;
+                car.Delta = it.Value.RealtimeCarUpdate.Delta;
             }
 
             if (it.Value.CarInfo != null)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -196,7 +196,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             .SetColorOthersLappedPlayer(Color.DarkOrange);
 
         drawer.SetColorPitStop(_config.Car.PitStopColor)
-            .SetColorPitStopWithDamange(_config.Car.PitStopWithDamageColor);
+            .SetColorPitStopWithDamage(_config.Car.PitStopWithDamageColor);
 
         drawer.CreateBitmap(w, h, _margin);
         return drawer.Draw(cars, ids, track, broadCastTrackData);

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -209,7 +209,26 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             }
         }
 
-        carsOnTrack.Cars.Sort((a, b) => b.Position - a.Position);
+        carsOnTrack.Cars.Sort((a, b) =>
+        {
+            if (a.Location != CarLocationEnum.Track && b.Location != CarLocationEnum.Track)
+            {
+                return 0;
+            }
+
+            if (a.Location != CarLocationEnum.Track)
+            {
+                return -1;
+            }
+
+            if (b.Location != CarLocationEnum.Track)
+            {
+                return 1;
+            }
+
+            return b.Position - a.Position;
+        });
+
         return CreateBitmapForCarsAndTrack(carsOnTrack, _trackPositions);
     }
 
@@ -255,11 +274,11 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     private PointF ScaleAndRotate(PointF point, BoundingBox boundaries, float scale, float rotation)
     {
+        PointF pos = new();
         var rot = Double.DegreesToRadians(rotation);
+
         var centerX = (boundaries.Right + boundaries.Left) * 0.5f;
         var centerY = (boundaries.Top + boundaries.Bottom) * 0.5f;
-
-        PointF pos = new();
 
         pos.X = (point.X - centerX) * scale;
         pos.Y = (point.Y - centerY) * scale;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -41,17 +41,17 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         RefreshRateHz = _config.General.RefreshInterval;
         _mapCache.Map = null;
 
-        _mapCache.OthersLappedPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Color.OthersLappedPlayer, _config.General.CarSize, _outLineBorder);
-        _mapCache.PlayerLapperOthers = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PlayerLappedOthers, _config.General.CarSize, _outLineBorder);
+        _mapCache.OthersLappedPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.OthersLappedPlayer, _config.General.CarSize, _outLineBorder);
+        _mapCache.PlayerLapperOthers = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.PlayerLappedOthers, _config.General.CarSize, _outLineBorder);
 
-        _mapCache.PitStopWithDamage = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PitStopWithDamage, _config.General.CarSize, _outLineBorder);
-        _mapCache.PitStop = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PitStop, _config.General.CarSize, _outLineBorder);
+        _mapCache.PitStopWithDamage = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.PitStopWithDamage, _config.General.CarSize, _outLineBorder);
+        _mapCache.PitStop = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.PitStop, _config.General.CarSize, _outLineBorder);
 
-        _mapCache.CarDefault = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Default, _config.General.CarSize, _outLineBorder);
-        _mapCache.CarPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Player, _config.General.CarSize, _outLineBorder);
+        _mapCache.CarDefault = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.Default, _config.General.CarSize, _outLineBorder);
+        _mapCache.CarPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.Player, _config.General.CarSize, _outLineBorder);
 
-        _mapCache.ValidForBest = TrackMapDrawer.CreateCircleWithOutline(_config.Color.ImprovingLap, _config.General.CarSize, _outLineBorder);
-        _mapCache.Leader = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Leader, _config.General.CarSize, _outLineBorder);
+        _mapCache.ValidForBest = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.ImprovingLap, _config.General.CarSize, _outLineBorder);
+        _mapCache.Leader = TrackMapDrawer.CreateCircleWithOutline(_config.Colors.Leader, _config.General.CarSize, _outLineBorder);
     }
 
     public override void BeforeStart()
@@ -153,7 +153,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackBoundingBox = boundaries;
         _trackPositions = track;
 
-        _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Color.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
+        _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Colors.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
 
         if (!_config.General.SavePreview)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -38,21 +38,20 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public TrackMapOverlay(Rectangle rectangle) : base(rectangle, "Track Map")
     {
-        RefreshRateHz = 24;
-
-        _mapCache.OthersLappedPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Other.OthersLappedPlayerColor, _config.Other.CarSize, _outLineBorder);
-        _mapCache.PlayerLapperOthers = TrackMapDrawer.CreateCircleWithOutline(_config.Other.PlayerLappedOthersColor, _config.Other.CarSize, _outLineBorder);
-
-        _mapCache.PitStopWithDamage = TrackMapDrawer.CreateCircleWithOutline(_config.Car.PitStopWithDamageColor, _config.Other.CarSize, _outLineBorder);
-        _mapCache.PitStop = TrackMapDrawer.CreateCircleWithOutline(_config.Car.PitStopColor, _config.Other.CarSize, _outLineBorder);
-
-        _mapCache.CarDefault = TrackMapDrawer.CreateCircleWithOutline(_config.Car.DefaultColor, _config.Other.CarSize, _outLineBorder);
-        _mapCache.CarPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Car.PlayerColor, _config.Other.CarSize, _outLineBorder);
-
-        _mapCache.ValidForBest = TrackMapDrawer.CreateCircleWithOutline(_config.Car.ImprovingLapColor, _config.Other.CarSize, _outLineBorder);
-        _mapCache.Leader = TrackMapDrawer.CreateCircleWithOutline(_config.Car.LeaderColor, _config.Other.CarSize, _outLineBorder);
-
+        RefreshRateHz = _config.General.RefreshInterval;
         _mapCache.Map = null;
+
+        _mapCache.OthersLappedPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Color.OthersLappedPlayer, _config.General.CarSize, _outLineBorder);
+        _mapCache.PlayerLapperOthers = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PlayerLappedOthers, _config.General.CarSize, _outLineBorder);
+
+        _mapCache.PitStopWithDamage = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PitStopWithDamage, _config.General.CarSize, _outLineBorder);
+        _mapCache.PitStop = TrackMapDrawer.CreateCircleWithOutline(_config.Color.PitStop, _config.General.CarSize, _outLineBorder);
+
+        _mapCache.CarDefault = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Default, _config.General.CarSize, _outLineBorder);
+        _mapCache.CarPlayer = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Player, _config.General.CarSize, _outLineBorder);
+
+        _mapCache.ValidForBest = TrackMapDrawer.CreateCircleWithOutline(_config.Color.ImprovingLap, _config.General.CarSize, _outLineBorder);
+        _mapCache.Leader = TrackMapDrawer.CreateCircleWithOutline(_config.Color.Leader, _config.General.CarSize, _outLineBorder);
     }
 
     public override void BeforeStart()
@@ -133,14 +132,14 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackOriginalBoundingBox = TrackMapTransform.GetBoundingBox(positions);
 
         {
-            var scaled = TrackMapTransform.ScaleAndRotate(positions, _trackOriginalBoundingBox, 1, _config.Map.Rotation);
+            var scaled = TrackMapTransform.ScaleAndRotate(positions, _trackOriginalBoundingBox, 1, _config.General.Rotation);
             var bounds = TrackMapTransform.GetBoundingBox(scaled);
 
             var width = (float)Math.Sqrt(Math.Pow(bounds.Right - bounds.Left, 2));
-            _scale = _config.Map.MaxWidth / width;
+            _scale = _config.General.MaxWidth / width;
         }
 
-        var track = TrackMapTransform.ScaleAndRotate(positions, _trackOriginalBoundingBox, _scale, _config.Map.Rotation);
+        var track = TrackMapTransform.ScaleAndRotate(positions, _trackOriginalBoundingBox, _scale, _config.General.Rotation);
         var boundaries = TrackMapTransform.GetBoundingBox(track);
 
         for (var i = 0; i < track.Count; ++i)
@@ -154,9 +153,9 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackBoundingBox = boundaries;
         _trackPositions = track;
 
-        _mapCache.Map = TrackMapDrawer.CreateLineOfPoints(_config.Map.Color, _config.Map.Thickness, _margin, _trackPositions, _trackBoundingBox);
+        _mapCache.Map = TrackMapDrawer.CreateLineOfPoints(_config.Color.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
 
-        if (!_config.Map.SavePreview)
+        if (!_config.General.SavePreview)
         {
             return;
         }
@@ -205,7 +204,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             car.Position = it.Value.RealtimeCarUpdate.Position;
 
             {
-                car.Coord = TrackMapTransform.ScaleAndRotate(car.Coord, _trackOriginalBoundingBox, _scale, _config.Map.Rotation);
+                car.Coord = TrackMapTransform.ScaleAndRotate(car.Coord, _trackOriginalBoundingBox, _scale, _config.General.Rotation);
                 car.Coord.Y = car.Coord.Y - _trackBoundingBox.Bottom + _margin * 0.5f;
                 car.Coord.X = car.Coord.X - _trackBoundingBox.Left + _margin * 0.5f;
             }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -185,15 +185,16 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         drawer.SetDotSize(_config.Other.CarSize)
             .SetFontSize(_config.Other.FontSize);
 
-        drawer.SetShowCarNumber(_config.Car.ShowCarNumber)
+        drawer.SetLappedThreshold(_config.Other.LappedThreshold)
+            .SetShowCarNumber(_config.Car.ShowCarNumber)
             .SetShowPitStop(_config.Car.ShowPitStop)
             .SetMapThickness(_config.Map.Thickness)
             .SetColorMap(_config.Map.Color);
 
         drawer.SetColorPlayer(_config.Car.PlayerColor)
             .SetColorCarDefault(_config.Car.DefaultColor)
-            .SetColorPlayerLappedOthers(Color.SteelBlue)
-            .SetColorOthersLappedPlayer(Color.DarkOrange);
+            .SetColorPlayerLappedOthers(_config.Other.PlayerLappedOthersColor)
+            .SetColorOthersLappedPlayer(_config.Other.OthersLappedPlayerColor);
 
         drawer.SetColorPitStop(_config.Car.PitStopColor)
             .SetColorPitStopWithDamage(_config.Car.PitStopWithDamageColor);

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -188,6 +188,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             var x = it.Value.RealtimeCarUpdate.WorldPosX;
             var y = it.Value.RealtimeCarUpdate.WorldPosY;
 
+            car.Laps = it.Value.RealtimeCarUpdate.Laps;
             car.Coord = new PointF(x, y);
             car.Id = it.Key;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -30,7 +30,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
     private  readonly TrackMapConfiguration _config = new();
     private TrackMapCreationJob _miniMapCreationJob;
 
-    private readonly float _margin = 48.0f;
+    private readonly float _margin = 64.0f;
     private List<PointF> _trackPositions = [];
 
     public TrackMapOverlay(Rectangle rectangle) : base(rectangle, "Track Map")
@@ -186,7 +186,9 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             .SetFontSize(_config.Other.FontSize);
 
         drawer.SetLappedThreshold(_config.Other.LappedThreshold)
-            .SetShowCarNumber(_config.Car.ShowCarNumber)
+            .SetTrackMeter(broadCastTrackData.TrackMeters);
+
+        drawer.SetShowCarNumber(_config.Car.ShowCarNumber)
             .SetShowPitStop(_config.Car.ShowPitStop)
             .SetMapThickness(_config.Map.Thickness)
             .SetColorMap(_config.Map.Color);
@@ -200,7 +202,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             .SetColorPitStopWithDamage(_config.Car.PitStopWithDamageColor);
 
         drawer.CreateBitmap(w, h, _margin);
-        return drawer.Draw(cars, ids, track, broadCastTrackData);
+        return drawer.Draw(cars, ids, track);
     }
 
     private List<PointF> ScaleAndRotate(List<PointF> positions, BoundingBox boundaries, float scale, float rotation)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -121,13 +121,17 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _miniMapCreationJob.Cancel();
         _trackOriginalBoundingBox = GetBoundingBox(positions);
 
-        _height = (float)Math.Sqrt(Math.Pow(_trackOriginalBoundingBox.Top - _trackOriginalBoundingBox.Bottom, 2));
-        _width = (float)Math.Sqrt(Math.Pow(_trackOriginalBoundingBox.Right - _trackOriginalBoundingBox.Left, 2));
+        {
+            var scaled = ScaleAndRotate(positions, _trackOriginalBoundingBox, 1, _config.Map.Rotation);
+            var bounds = GetBoundingBox(scaled);
 
-        _scale = _config.Map.MaxWidth / _width;
+            float width = (float)Math.Sqrt(Math.Pow(bounds.Right - bounds.Left, 2));
+            _scale = _config.Map.MaxWidth / width;
+        }
+
         var track = ScaleAndRotate(positions, _trackOriginalBoundingBox, _scale, _config.Map.Rotation);
-
         var boundaries = GetBoundingBox(track);
+
         for (int i = 0; i < track.Count; ++i)
         {
             float y = track[i].Y - boundaries.Bottom + _margin * 0.5f;
@@ -138,6 +142,9 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
         _trackBoundingBox = boundaries;
         _trackPositions = track;
+
+        _height = (float)Math.Sqrt(Math.Pow(_trackBoundingBox.Bottom - _trackBoundingBox.Top, 2));;
+        _width= (float)Math.Sqrt(Math.Pow(_trackBoundingBox.Right - _trackBoundingBox.Left, 2));
 
         if (!_config.Map.SavePreview)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -85,7 +85,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             Width = bitmap.Width;
         }
 
-        g.DrawImage(CreateBitmapForCarsAndTrack(), 0, 0);
+        g.DrawImage(bitmap, 0, 0);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -194,7 +194,9 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             .SetColorMap(_config.Map.Color);
 
         drawer.SetColorPlayer(_config.Car.PlayerColor)
+            .SetColorLeader(_config.Car.LeaderColor)
             .SetColorCarDefault(_config.Car.DefaultColor)
+            .SetColorImprovingLap(_config.Car.ImprovingLapColor)
             .SetColorPlayerLappedOthers(_config.Other.PlayerLappedOthersColor)
             .SetColorOthersLappedPlayer(_config.Other.OthersLappedPlayerColor);
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -1,20 +1,11 @@
 ﻿using RaceElement.Data.ACC.Database.SessionData;
-using RaceElement.Data.ACC.EntryList;
 using RaceElement.Data.ACC.Session;
 
-using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.Internal;
-using RaceElement.HUD.Overlay.Util;
-
-using RaceElement.Broadcast;
 using RaceElement.Util;
 
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
-using System.Drawing.Text;
-using System.Drawing;
-
 using System.Collections.Generic;
+using System.Drawing;
 using System;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
@@ -190,15 +181,20 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
         TrackMapDrawing drawer = new();
         drawer.SetDotSize(_config.Other.CarSize)
-            .SetFontSize(_config.Other.FontSize)
-            .SetMapThickness(_config.Map.Thickness)
-            .SetShowCarNumber(_config.Car.ShowCarNumber);
+            .SetFontSize(_config.Other.FontSize);
 
-        drawer.SetColorMap(_config.Map.Color)
+        drawer.SetShowCarNumber(_config.Car.ShowCarNumber)
+            .SetShowPitStop(_config.Car.ShowPitStop)
+            .SetMapThickness(_config.Map.Thickness)
+            .SetColorMap(_config.Map.Color);
+
+        drawer.SetColorPlayer(_config.Car.PlayerColor)
             .SetColorCarDefault(_config.Car.DefaultColor)
-            .SetColorPlayer(_config.Car.PlayerColor)
-            .SetColorOthersLappedPlayer(Color.DarkOrange)
-            .SetColorPlayerLappedOthers(Color.SteelBlue);
+            .SetColorPlayerLappedOthers(Color.SteelBlue)
+            .SetColorOthersLappedPlayer(Color.DarkOrange);
+
+        drawer.SetColorPitStop(_config.Car.PitStopColor)
+            .SetColorPitStopWithDamange(_config.Car.PitStopWithDamageColor);
 
         drawer.CreateBitmap(w, h, _margin);
         return drawer.Draw(cars, track, broadCastTrackData);

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -72,7 +72,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
-        return base.ShouldRender() && _trackPositions.Count != 0;
+        return base.ShouldRender() && _trackPositions.Count != 0 && EntryListTracker.Instance.Cars.Count > 0;
     }
 
     public override void Render(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using RaceElement.Data.ACC.Database.SessionData;
+using RaceElement.Data.ACC.EntryList;
 using RaceElement.Data.ACC.Session;
 
 using RaceElement.HUD.Overlay.Internal;
@@ -7,7 +8,6 @@ using RaceElement.Util;
 using System.Collections.Generic;
 using System.Drawing;
 using System;
-using RaceElement.Data.ACC.EntryList;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -41,7 +41,9 @@ public class TrackMapPitPrediction
         { "valencia"        , 27_000 },
         { "watkins_glen"    , 27_000 },
         { "zandvoort"       , 19_000 },
-        { "zolder"          , 30_000 }
+        { "zolder"          , 30_000 },
+        { "mount_panorama"  , 25_000 },
+        { "red_bull_ring"   , 20_000 }
     };
 
     public static PitStop GetPitStop(List<PointF> track)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -9,6 +9,7 @@ namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
 public class PitStop
 {
     public PointF Position;
+    public bool Damage;
     public int Laps;
 }
 
@@ -67,7 +68,10 @@ public class TrackMapPitPrediction
         var ms = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
 
         result = result * 1000 + DefaultPitTimeMs + ms;
-        return ComputePitStop(track, result);
+        var pitstop = ComputePitStop(track, result);
+
+        pitstop.Damage = true;
+        return pitstop;
     }
 
     private static PitStop ComputePitStop(List<PointF> track, float time)

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -71,18 +71,18 @@ public class TrackMapPitPrediction
     private static PitStop ComputePitStop(List<PointF> track, float time)
     {
         var pageFileGraphic = ACCSharedMemory.Instance.PageFileGraphic;
+        var estimatedLapTime = pageFileGraphic.EstimatedLapTimeMillis;
         var currenTime = pageFileGraphic.CurrentTimeMs;
-        var bestTime = pageFileGraphic.BestTimeMs;
 
-        if (bestTime == Int32.MaxValue)
+        if (estimatedLapTime == Int32.MaxValue)
         {
             return null;
         }
 
-        var diffTime = currenTime - (time % bestTime);
-        diffTime = diffTime >= 0 ? diffTime : bestTime + diffTime;
+        var diffTime = currenTime - (time % estimatedLapTime);
+        diffTime = diffTime >= 0 ? diffTime : estimatedLapTime + diffTime;
 
-        var delta = diffTime / bestTime;
+        var delta = diffTime / estimatedLapTime;
         var trackPos = (int)(delta * track.Count);
 
         var result = new PitStop

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -1,0 +1,104 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
+
+public class PitStop
+{
+    public PointF Position;
+    public int Laps;
+}
+
+public class TrackMapPitPrediction
+{
+    private static float  _defaultPitTimeMs = 30 * 1000;
+
+    private static Dictionary<string, float> _trackPitLineTime = new Dictionary<string, float>
+    {
+        { "barcelona"       , 30 * 1000 },
+        { "bathurst"        , 19 * 1000 },
+        { "brands_hatch"    , 19 * 1000 },
+        { "cota"            , 29 * 1000 },
+        { "donington"       , 19 * 1000 },
+        { "hungaroring"     , 24 * 1000 },
+        { "imola"           , 38 * 1000 },
+        { "indianapolis"    , 44 * 1000 },
+        { "kyalami"         , 18 * 1000 },
+        { "laguna_seca"     , 21 * 1000 },
+        { "misano"          , 28 * 1000 },
+        { "monza"           , 31 * 1000 },
+        { "nurburgring"     , 25 * 1000 },
+        { "nurburgring_24h" , 25 * 1000 },
+        { "oulton_park"     , 14 * 1000 },
+        { "paul_ricard"     , 27 * 1000 },
+        { "silverstone"     , 23 * 1000 },
+        { "snetterton"      , 19 * 1000 },
+        { "spa"             , 57 * 1000 },
+        { "suzuka"          , 27 * 1000 },
+        { "valencia"        , 39 * 1000 },
+        { "watkins_glen"    , 27 * 1000 },
+        { "zandvoort"       , 19 * 1000 },
+        { "zolder"          , 30 * 1000 }
+    };
+
+    public static PitStop GetPitStop(List<PointF> track)
+    {
+        float pitLaneTime = 0;
+        var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
+
+        _trackPitLineTime.TryGetValue(name, out pitLaneTime);
+        return ComputePitStop(track, _defaultPitTimeMs + pitLaneTime);
+    }
+
+    public static PitStop GetPitStopWithDamage(List<PointF> track)
+    {
+        var a = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[0];
+        var b = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[1];
+        var c = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[2];
+        var d = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[3];
+        var e = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[4];
+        var result = a + b + c + d + e;
+
+        if (result == 0)
+        {
+            return null;
+        }
+
+        float pitLaneTime = 0;
+        var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
+
+        _trackPitLineTime.TryGetValue(name, out pitLaneTime);
+        result = result * 0.142f * 1000 + _defaultPitTimeMs + pitLaneTime;
+
+        return ComputePitStop(track, result);
+    }
+
+    private static PitStop ComputePitStop(List<PointF> track, float time)
+    {
+        var pageFileGraphic = ACCSharedMemory.Instance.PageFileGraphic;
+        var currenTime = pageFileGraphic.CurrentTimeMs;
+        var bestTime = pageFileGraphic.BestTimeMs;
+
+        if (bestTime == Int32.MaxValue)
+        {
+            return null;
+        }
+
+        var diffTime = currenTime - (time % bestTime);
+        diffTime = diffTime >= 0 ? diffTime : bestTime + diffTime;
+
+        var delta = diffTime / bestTime;
+        var trackPos = (int)(delta * track.Count);
+
+        var result = new PitStop
+        {
+            Position = track[trackPos],
+            Laps = (int)(time / pageFileGraphic.BestTimeMs)
+        };
+
+        return result;
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -14,65 +14,57 @@ public class PitStop
 
 public class TrackMapPitPrediction
 {
-    private static float  _defaultPitTimeMs = 30 * 1000;
+    private static readonly float DefaultPitTimeMs = 30_000;
 
-    private static Dictionary<string, float> _trackPitLineTime = new Dictionary<string, float>
+    private static readonly Dictionary<string, float> TrackPitLineTimeMs = new Dictionary<string, float>
     {
-        { "barcelona"       , 30 * 1000 },
-        { "bathurst"        , 19 * 1000 },
-        { "brands_hatch"    , 19 * 1000 },
-        { "cota"            , 29 * 1000 },
-        { "donington"       , 19 * 1000 },
-        { "hungaroring"     , 24 * 1000 },
-        { "imola"           , 38 * 1000 },
-        { "indianapolis"    , 44 * 1000 },
-        { "kyalami"         , 18 * 1000 },
-        { "laguna_seca"     , 21 * 1000 },
-        { "misano"          , 28 * 1000 },
-        { "monza"           , 31 * 1000 },
-        { "nurburgring"     , 25 * 1000 },
-        { "nurburgring_24h" , 25 * 1000 },
-        { "oulton_park"     , 14 * 1000 },
-        { "paul_ricard"     , 27 * 1000 },
-        { "silverstone"     , 23 * 1000 },
-        { "snetterton"      , 19 * 1000 },
-        { "spa"             , 57 * 1000 },
-        { "suzuka"          , 27 * 1000 },
-        { "valencia"        , 39 * 1000 },
-        { "watkins_glen"    , 27 * 1000 },
-        { "zandvoort"       , 19 * 1000 },
-        { "zolder"          , 30 * 1000 }
+        { "barcelona"       , 30_000 },
+        { "bathurst"        , 19_000 },
+        { "brands_hatch"    , 19_000 },
+        { "cota"            , 29_000 },
+        { "donington"       , 19_000 },
+        { "hungaroring"     , 24_000 },
+        { "imola"           , 38_000 },
+        { "indianapolis"    , 44_000 },
+        { "kyalami"         , 18_000 },
+        { "laguna_seca"     , 21_000 },
+        { "misano"          , 28_000 },
+        { "monza"           , 31_000 },
+        { "nurburgring"     , 25_000 },
+        { "nurburgring_24h" , 25_000 },
+        { "oulton_park"     , 14_000 },
+        { "paul_ricard"     , 27_000 },
+        { "silverstone"     , 23_000 },
+        { "snetterton"      , 19_000 },
+        { "spa"             , 57_000 },
+        { "suzuka"          , 27_000 },
+        { "valencia"        , 27_000 },
+        { "watkins_glen"    , 27_000 },
+        { "zandvoort"       , 19_000 },
+        { "zolder"          , 30_000 }
     };
 
     public static PitStop GetPitStop(List<PointF> track)
     {
-        float pitLaneTime = 0;
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
-
-        _trackPitLineTime.TryGetValue(name, out pitLaneTime);
-        return ComputePitStop(track, _defaultPitTimeMs + pitLaneTime);
+        float ms = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
+        return ComputePitStop(track, DefaultPitTimeMs + ms);
     }
 
     public static PitStop GetPitStopWithDamage(List<PointF> track)
     {
-        var a = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[0];
-        var b = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[1];
-        var c = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[2];
-        var d = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[3];
-        var e = ACCSharedMemory.Instance.PageFilePhysics.CarDamage[4];
-        var result = a + b + c + d + e;
+        var p = ACCSharedMemory.Instance.PageFilePhysics;
+        var result = RaceElement.Data.ACC.Cars.Damage.GetTotalRepairTime(p);
 
         if (result == 0)
         {
             return null;
         }
 
-        float pitLaneTime = 0;
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
+        var ms = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
 
-        _trackPitLineTime.TryGetValue(name, out pitLaneTime);
-        result = result * 0.142f * 1000 + _defaultPitTimeMs + pitLaneTime;
-
+        result = result * 1000 + DefaultPitTimeMs + ms;
         return ComputePitStop(track, result);
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -70,7 +70,11 @@ public class TrackMapPitPrediction
         result = result * 1000 + DefaultPitTimeMs + ms;
         var pitstop = ComputePitStop(track, result);
 
-        pitstop.Damage = true;
+        if (pitstop != null)
+        {
+            pitstop.Damage = true;
+        }
+
         return pitstop;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -50,16 +50,16 @@ public class TrackMapPitPrediction
     public static PitStop GetPitStop(List<PointF> track)
     {
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
-        float ms = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
-        return ComputePitStop(track, DefaultPitTimeMs + ms);
+        float time = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
+        return ComputePitStop(track, DefaultPitTimeMs + time);
     }
 
     public static PitStop GetPitStopWithDamage(List<PointF> track)
     {
         var p = ACCSharedMemory.Instance.PageFilePhysics;
-        var result = RaceElement.Data.ACC.Cars.Damage.GetTotalRepairTime(p);
+        var time = RaceElement.Data.ACC.Cars.Damage.GetTotalRepairTime(p);
 
-        if (result == 0)
+        if (time == 0)
         {
             return null;
         }
@@ -67,18 +67,18 @@ public class TrackMapPitPrediction
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
         var ms = TrackPitLineTimeMs.GetValueOrDefault(name, 0.0f);
 
-        result = result * 1000 + DefaultPitTimeMs + ms;
-        var pitstop = ComputePitStop(track, result);
+        time = time * 1000 + DefaultPitTimeMs + ms;
+        var pitStop = ComputePitStop(track, time);
 
-        if (pitstop != null)
+        if (pitStop != null)
         {
-            pitstop.Damage = true;
+            pitStop.Damage = true;
         }
 
-        return pitstop;
+        return pitStop;
     }
 
-    private static PitStop ComputePitStop(List<PointF> track, float time)
+    private static PitStop ComputePitStop(List<PointF> track, float pitTime)
     {
         var pageFileGraphic = ACCSharedMemory.Instance.PageFileGraphic;
         var estimatedLapTime = pageFileGraphic.EstimatedLapTimeMillis;
@@ -89,7 +89,7 @@ public class TrackMapPitPrediction
             return null;
         }
 
-        var diffTime = currenTime - (time % estimatedLapTime);
+        var diffTime = currenTime - (pitTime % estimatedLapTime);
         diffTime = diffTime >= 0 ? diffTime : estimatedLapTime + diffTime;
 
         var delta = diffTime / estimatedLapTime;
@@ -98,7 +98,7 @@ public class TrackMapPitPrediction
         var result = new PitStop
         {
             Position = track[trackPos],
-            Laps = (int)(time / pageFileGraphic.BestTimeMs)
+            Laps = (int)(pitTime / pageFileGraphic.BestTimeMs)
         };
 
         return result;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapTransform.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapTransform.cs
@@ -1,0 +1,73 @@
+﻿
+using System;
+using System.Drawing;
+
+using System.Collections.Generic;
+
+namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
+
+public struct BoundingBox
+{
+    public float Left, Right;
+    public float Bottom, Top;
+}
+
+public class TrackMapTransform
+{
+    public static BoundingBox GetBoundingBox(List<PointF> positions)
+    {
+        BoundingBox result = new();
+
+        if (positions.Count > 0)
+        {
+            result.Right = positions[0].X;
+            result.Left = positions[0].X;
+
+            result.Top = positions[0].Y;
+            result.Bottom = positions[0].Y;
+        }
+
+        foreach (var it in positions)
+        {
+            result.Right = Math.Max(result.Right, it.X);
+            result.Left = Math.Min(result.Left, it.X);
+
+            result.Top = Math.Max(result.Top, it.Y);
+            result.Bottom = Math.Min(result.Bottom, it.Y);
+        }
+
+        return result;
+    }
+
+    public static PointF ScaleAndRotate(PointF point, BoundingBox boundaries, float scale, float rotation)
+    {
+        PointF pos = new();
+        var rot = Double.DegreesToRadians(rotation);
+
+        var centerX = (boundaries.Right + boundaries.Left) * 0.5f;
+        var centerY = (boundaries.Top + boundaries.Bottom) * 0.5f;
+
+        pos.X = (point.X - centerX) * scale;
+        pos.Y = (point.Y - centerY) * scale;
+
+        var x = pos.X * Math.Cos(rot) - pos.Y * Math.Sin(rot);
+        var y = pos.X * Math.Sin(rot) + pos.Y * Math.Cos(rot);
+
+        pos.X = (float)x;
+        pos.Y = (float)y;
+
+        return pos;
+    }
+
+    public static List<PointF> ScaleAndRotate(List<PointF> positions, BoundingBox boundaries, float scale, float rotation)
+    {
+        List<PointF> result = new();
+        foreach (var it in positions)
+        {
+            var pos = ScaleAndRotate(it, boundaries, scale, rotation);
+            result.Add(pos);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Feature
* Pit stop exit prediction
* [race - only] Color for race leader
* [race - only] Lapped car logic (shows different color)
* [other session - no race] Cars on lap, cars with invalidated lap, cars improving their lap

Pit stop algorithm
```
pitStopTotalTime = pitStopTime + (pitLaneTime % EstimatedLapTime)
trackTime = currentLapTime - pitStopTotalTime

if (trackTime < 0)
{
    trackTime += EstimatedLapTime;
}

trackNormalizedPos = trackTime / EstimatedLapTime
trackPosIndex = trackNormalizedPos * trackMappedPoints;

PointF pos = trackMappedPoints[trackPosIndex] <-- Where the car should end on track
int laps = pitStopTotalTime / BestTimeMs      <-- Number of laps needed to fix the car
```