### PR TITLE
Request broadcast data after Overlay is loaded and simplify EntryListTracker

### DIFF
--- a/Race_Element.Broadcast/ACCUdpRemoteClient.cs
+++ b/Race_Element.Broadcast/ACCUdpRemoteClient.cs
@@ -35,6 +35,12 @@ public class ACCUdpRemoteClient : IDisposable
         _listenerTask = ConnectAndRun();
     }
 
+    public void RequestData()
+    {
+        // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
+        MessageHandler.RequestData();
+    }
+
     private void Send(byte[] payload)
     {
         if (_client != null)

--- a/Race_Element.Broadcast/BroadcastingEnums.cs
+++ b/Race_Element.Broadcast/BroadcastingEnums.cs
@@ -38,6 +38,7 @@ public enum SessionPhase
     PostSession = 7,
     ResultUI = 8
 };
+
 public enum RaceSessionType
 {
     Practice = 0,

--- a/Race_Element.Broadcast/BroadcastingNetworkProtocol.cs
+++ b/Race_Element.Broadcast/BroadcastingNetworkProtocol.cs
@@ -524,6 +524,7 @@ public class BroadcastingNetworkProtocol
     public void RequestData()
     {
         // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
-        RequestEntryList(); RequestTrackData();
+        RequestEntryList();
+        RequestTrackData();
     }
 }

--- a/Race_Element.Broadcast/BroadcastingNetworkProtocol.cs
+++ b/Race_Element.Broadcast/BroadcastingNetworkProtocol.cs
@@ -336,7 +336,7 @@ public class BroadcastingNetworkProtocol
         else
             lap.Type = LapType.Regular;
 
-        // Now it's possible that this is "no" lap that doesn't even include a 
+        // Now it's possible that this is "no" lap that doesn't even include a
         // first split, we can detect this by comparing with int32.Max
         while (lap.Splits.Count < 3)
         {
@@ -405,7 +405,7 @@ public class BroadcastingNetworkProtocol
 
     /// <summary>
     /// Will ask the ACC client for an updated entry list, containing all car and driver data.
-    /// The client will send this automatically when something changes; however if you detect a carIndex or driverIndex, this may cure the 
+    /// The client will send this automatically when something changes; however if you detect a carIndex or driverIndex, this may cure the
     /// problem for future updates
     /// </summary>
     private void RequestEntryList()
@@ -519,5 +519,11 @@ public class BroadcastingNetworkProtocol
 
             Send(ms.ToArray());
         }
+    }
+
+    public void RequestData()
+    {
+        // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
+        RequestEntryList(); RequestTrackData();
     }
 }

--- a/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
+++ b/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
@@ -79,12 +79,7 @@ public class EntryListTracker
     private void CleanupEntryList()
     {
         var cleanupWaitTime = TimeSpan.FromSeconds(5);
-        List<KeyValuePair<int, CarData>> cars;
-
-        lock (_entryListCars)
-        {
-            cars = _entryListCars.ToList();
-        }
+        List<KeyValuePair<int, CarData>> cars = [.. _entryListCars];
 
         foreach (var entry in cars)
         {
@@ -98,11 +93,7 @@ public class EntryListTracker
                 continue;
             }
 
-            lock (_entryListCars)
-            {
-                CarData removed = null;
-                _entryListCars.Remove(entry.Key, out removed);
-            }
+            _entryListCars.Remove(entry.Key, out CarData _);
 
             PositionGraph.Instance.RemoveCar(entry.Key);
         }

--- a/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
+++ b/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
@@ -151,31 +151,18 @@ public class EntryListTracker
         }
     }
 
-    private void Broadcast_EventHandler(object sender, BroadcastingEvent broadcastingEvent)
+    private void Broadcast_EventHandler(object sender, BroadcastingEvent evt)
     {
-        // Remove drives that haven't received updates in a while
-        CleanupEntryList();
-
-        switch (broadcastingEvent.Type)
+        switch (evt.Type)
         {
-            case BroadcastingCarEventType.BestSessionLap:
-            {
-                Debug.WriteLine(JsonConvert.SerializeObject(broadcastingEvent));
-            } break;
-
             case BroadcastingCarEventType.LapCompleted:
             {
-                UpdateEntryList(broadcastingEvent.CarData.CarIndex, broadcastingEvent.CarData, true);
-            } break;
-
-            case BroadcastingCarEventType.Accident:
-            {
-                Debug.WriteLine(JsonConvert.SerializeObject(broadcastingEvent));
+                UpdateEntryList(evt.CarData.CarIndex, evt.CarData, true);
             } break;
 
             default:
             {
-                Debug.WriteLine(JsonConvert.SerializeObject(broadcastingEvent));
+                Debug.WriteLine(JsonConvert.SerializeObject(evt));
             } break;
         }
     }

--- a/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
+++ b/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
@@ -7,13 +7,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace RaceElement.Data.ACC.EntryList;
 
-public class EntryListTracker
+public sealed class EntryListTracker
 {
-    public class CarData
+    public sealed class CarData
     {
         public DateTime LastUpdate;
         public CarInfo CarInfo { get; set; }

--- a/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
+++ b/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
@@ -29,7 +29,7 @@ public class BroadcastTracker : IDisposable
     public void RequestData()
     {
         // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
-        _client.RequestData();
+        _client?.RequestData();
     }
 
     public event EventHandler<RealtimeUpdate> OnRealTimeUpdate;

--- a/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
+++ b/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using RaceElement.Broadcast;
+﻿using RaceElement.Broadcast;
 using RaceElement.Broadcast.Structs;
 using System;
 using System.Diagnostics;

--- a/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
+++ b/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
@@ -57,6 +57,7 @@ public class BroadcastTracker : IDisposable
         {
             OnRealTimeUpdate?.Invoke(this, realTimeUpdate);
         };
+
         client.MessageHandler.OnConnectionStateChanged += (int connectionId, bool connectionSuccess, bool isReadonly, string error) =>
         {
             ConnectionState state = new()
@@ -75,35 +76,24 @@ public class BroadcastTracker : IDisposable
         client.MessageHandler.OnEntrylistUpdate += (s, carInfo) =>
         {
             OnEntryListUpdate?.Invoke(this, carInfo);
-
-            //Debug.WriteLine("");
-            //Debug.WriteLine("---- OnEntryListUpdate (s, carinfo) ----");
-            //Debug.WriteLine($"#{carInfo.RaceNumber}, Index:{carInfo.CarIndex}, Name: {carInfo.GetCurrentDriverName()}");
-            //Debug.WriteLine("");
         };
 
         client.MessageHandler.OnBroadcastingEvent += (s, broadcastEvent) =>
         {
-            //Debug.WriteLine("");
-            //Debug.WriteLine("---- OnBroadcastingEvent (s, broadcastEvent) ----");
-            //Debug.WriteLine($"#{broadcastEvent.CarData.RaceNumber}, Index:{broadcastEvent.CarId}, Type: {broadcastEvent.Type}, Msg: {broadcastEvent.Msg}");
-
-            if (broadcastEvent.Type == BroadcastingCarEventType.BestSessionLap)
-            {
-                //Debug.WriteLine(JsonConvert.SerializeObject(broadcastEvent, Formatting.Indented));
-            }
-
             OnBroadcastEvent?.Invoke(this, broadcastEvent);
         };
-        client.MessageHandler.OnTrackDataUpdate += (s, trackData) => OnTrackDataUpdate?.Invoke(this, trackData);
+
+        client.MessageHandler.OnTrackDataUpdate += (s, trackData) =>
+        {
+            OnTrackDataUpdate?.Invoke(this, trackData);
+        };
 
         client.MessageHandler.OnRealtimeCarUpdate += (s, e) =>
         {
             OnRealTimeCarUpdate?.Invoke(this, e);
 
             int localCarIndex = ACCSharedMemory.Instance.ReadGraphicsPageFile(true).PlayerCarID;
-            if (e.CarIndex == localCarIndex)
-                OnRealTimeLocalCarUpdate?.Invoke(this, e);
+            if (e.CarIndex == localCarIndex)  OnRealTimeLocalCarUpdate?.Invoke(this, e);
         };
     }
 
@@ -127,6 +117,7 @@ public class BroadcastTracker : IDisposable
             _client.Dispose();
             _client = null;
         }
+
         Debug.WriteLine("Disconnected broadcast client");
     }
 

--- a/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
+++ b/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
@@ -21,6 +21,7 @@ public class BroadcastTracker : IDisposable
 
     private ACCUdpRemoteClient _client;
     public bool IsConnected { get; private set; }
+    private DateTime _lastRequestTime = DateTime.MinValue;
 
     private BroadcastTracker()
     {
@@ -29,7 +30,11 @@ public class BroadcastTracker : IDisposable
     public void RequestData()
     {
         // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
-        _client?.RequestData();
+        if (DateTime.UtcNow - _lastRequestTime > TimeSpan.FromSeconds(5))
+        {
+            _client?.RequestData();
+            _lastRequestTime = DateTime.UtcNow;
+        }
     }
 
     public event EventHandler<RealtimeUpdate> OnRealTimeUpdate;
@@ -97,7 +102,7 @@ public class BroadcastTracker : IDisposable
             OnRealTimeCarUpdate?.Invoke(this, e);
 
             int localCarIndex = ACCSharedMemory.Instance.ReadGraphicsPageFile(true).PlayerCarID;
-            if (e.CarIndex == localCarIndex)  OnRealTimeLocalCarUpdate?.Invoke(this, e);
+            if (e.CarIndex == localCarIndex) OnRealTimeLocalCarUpdate?.Invoke(this, e);
         };
     }
 

--- a/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
+++ b/Race_Element.Data.ACC/Tracker/BroadcastTracker.cs
@@ -25,7 +25,12 @@ public class BroadcastTracker : IDisposable
 
     private BroadcastTracker()
     {
+    }
 
+    public void RequestData()
+    {
+        // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
+        _client.RequestData();
     }
 
     public event EventHandler<RealtimeUpdate> OnRealTimeUpdate;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDataStructures.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapDataStructures.cs
@@ -122,38 +122,37 @@ public class PitStop
     public int Laps;
 }
 
-public class TrackInfo(float pitLaneTimeMs, float lengthMeters, float scale)
+public class TrackInfo(float pitLaneTimeMs, float scale)
 {
     public readonly float PitLaneTimeMs = pitLaneTimeMs;
-    public readonly float LengthMeters = lengthMeters;
     public readonly float Scale = scale;
 
     public static readonly Dictionary<string, TrackInfo> Data = new()
     {
-        { "barcelona"       , new TrackInfo(30_000,  4655, 0.310f) },
-        { "brands_hatch"    , new TrackInfo(19_000,  3908, 0.370f) },
-        { "cota"            , new TrackInfo(29_000,  5513, 0.200f) },
-        { "donington"       , new TrackInfo(19_000,  4020, 0.270f) },
-        { "hungaroring"     , new TrackInfo(24_000,  4381, 0.230f) },
-        { "imola"           , new TrackInfo(38_000,  4959, 0.200f) },
-        { "indianapolis"    , new TrackInfo(44_000,  4167, 0.250f) },
-        { "kyalami"         , new TrackInfo(18_000,  4522, 0.200f) },
-        { "laguna_seca"     , new TrackInfo(21_000,  3602, 0.360f) },
-        { "misano"          , new TrackInfo(28_000,  4226, 0.310f) },
-        { "monza"           , new TrackInfo(31_000,  5793, 0.160f) },
-        { "nurburgring"     , new TrackInfo(25_000,  5137, 0.240f) },
-        { "nurburgring_24h" , new TrackInfo(25_000, 25300, 0.061f) },
-        { "oulton_park"     , new TrackInfo(14_000,  4307, 0.230f) },
-        { "paul_ricard"     , new TrackInfo(27_000,  5770, 0.160f) },
-        { "silverstone"     , new TrackInfo(23_000,  5891, 0.210f) },
-        { "snetterton"      , new TrackInfo(19_000,  4779, 0.300f) },
-        { "spa"             , new TrackInfo(57_000,  7004, 0.190f) },
-        { "suzuka"          , new TrackInfo(27_000,  5807, 0.180f) },
-        { "valencia"        , new TrackInfo(27_000,  4005, 0.370f) },
-        { "watkins_glen"    , new TrackInfo(27_000,  5552, 0.210f) },
-        { "zandvoort"       , new TrackInfo(19_000,  4252, 0.270f) },
-        { "zolder"          , new TrackInfo(30_000,  4011, 0.280f) },
-        { "mount_panorama"  , new TrackInfo(25_000,  6213, 0.170f) },
-        { "red_bull_ring"   , new TrackInfo(20_000,  4318, 0.290f) }
+        { "barcelona"       , new TrackInfo(30_000, 0.310f) },
+        { "brands_hatch"    , new TrackInfo(19_000, 0.370f) },
+        { "cota"            , new TrackInfo(29_000, 0.200f) },
+        { "donington"       , new TrackInfo(19_000, 0.270f) },
+        { "hungaroring"     , new TrackInfo(24_000, 0.230f) },
+        { "imola"           , new TrackInfo(38_000, 0.200f) },
+        { "indianapolis"    , new TrackInfo(44_000, 0.250f) },
+        { "kyalami"         , new TrackInfo(18_000, 0.200f) },
+        { "laguna_seca"     , new TrackInfo(21_000, 0.360f) },
+        { "misano"          , new TrackInfo(28_000, 0.310f) },
+        { "monza"           , new TrackInfo(31_000, 0.160f) },
+        { "nurburgring"     , new TrackInfo(25_000, 0.240f) },
+        { "nurburgring_24h" , new TrackInfo(25_000, 0.061f) },
+        { "oulton_park"     , new TrackInfo(14_000, 0.230f) },
+        { "paul_ricard"     , new TrackInfo(27_000, 0.160f) },
+        { "silverstone"     , new TrackInfo(23_000, 0.210f) },
+        { "snetterton"      , new TrackInfo(19_000, 0.300f) },
+        { "spa"             , new TrackInfo(57_000, 0.190f) },
+        { "suzuka"          , new TrackInfo(27_000, 0.180f) },
+        { "valencia"        , new TrackInfo(27_000, 0.370f) },
+        { "watkins_glen"    , new TrackInfo(27_000, 0.210f) },
+        { "zandvoort"       , new TrackInfo(19_000, 0.270f) },
+        { "zolder"          , new TrackInfo(30_000, 0.280f) },
+        { "mount_panorama"  , new TrackInfo(25_000, 0.170f) },
+        { "red_bull_ring"   , new TrackInfo(20_000, 0.290f) }
     };
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -174,24 +174,21 @@ internal sealed class TrackMapOverlay : AbstractOverlay
             var y = track[i].Y - boundaries.Bottom + _margin * 0.5f;
             var x = track[i].X - boundaries.Left + _margin * 0.5f;
 
-            track[i] = new(track[i]) { X = x, Y = y };
+            track[i] = new TrackPoint(track[i]) { X = x, Y = y };
         }
 
         _trackBoundingBox = boundaries;
         _trackPositions = track;
 
         _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Colors.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
-        Debug.WriteLine("[MAP] " + pageStatic.Track.ToLower() + " -> [" + _scale + "] [" + broadCastTrackData.TrackMeters + "] [" + _trackPositions.Count + "]");
+        Debug.WriteLine($"[MAP] {broadCastTrackData.TrackName} ({pageStatic.Track}) -> [S: {_scale:F3}] [L: {broadCastTrackData.TrackMeters:F3}] [P: {_trackPositions.Count}]");
 
-        if (!_config.Others.SavePreview)
+        if (!_config.Others.SavePreview || pageStatic.Track.Length == 0)
         {
             return;
         }
 
-        var pageFileStatic = ACCSharedMemory.Instance.PageFileStatic;
-        if (pageFileStatic.Track.Length == 0) return;
-
-        var path = FileUtil.RaceElementTracks + pageFileStatic.Track.ToLower() + ".jpg";
+        var path = FileUtil.RaceElementTracks + pageStatic.Track.ToLower() + ".jpg";
         _mapCache.Map.Save(path);
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -37,15 +37,11 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     private readonly float _outLineBorder = 2.0f;
     private readonly float _margin = 64.0f;
-
-    private float _trackLength;
-    private float _scale;
+    private float _scale = 0.15f;
 
     public TrackMapOverlay(Rectangle rectangle) : base(rectangle, "Track Map")
     {
         RefreshRateHz = _config.Others.RefreshInterval;
-        _trackLength = 0.0f;
-        _scale = 0.15f;
 
         _mapCache.Map = null;
         _mapCache.YellowFlag = TrackMapDrawer.CreateCircleWithOutline(Color.Yellow, _config.Others.CarSize, _outLineBorder);
@@ -123,7 +119,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         }
 
         var carsOnTrack = GetCarsOnTrack();
-        var bitmap = TrackMapDrawer.Draw(_trackPositions, carsOnTrack, _mapCache, _config, _trackLength);
+        var bitmap = TrackMapDrawer.Draw(_trackPositions, carsOnTrack, _mapCache, _config, broadCastTrackData.TrackMeters);
 
         if (bitmap.Width != Width || bitmap.Height != Height)
         {
@@ -164,9 +160,8 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     private void OnMapPositionsCallback(object sender, List<TrackPoint> positions)
     {
-        var trackInfo = TrackInfo.Data.GetValueOrDefault(pageStatic.Track.ToLower(), new TrackInfo(0, 0, 0));
+        var trackInfo = TrackInfo.Data.GetValueOrDefault(pageStatic.Track.ToLower(), new TrackInfo(0, 0));
         _scale = trackInfo.Scale * _config.General.ScaleFactor;
-        _trackLength = trackInfo.LengthMeters;
 
         _miniMapCreationJob.Cancel();
         _trackOriginalBoundingBox = TrackMapTransform.GetBoundingBox(positions);
@@ -186,7 +181,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackPositions = track;
 
         _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Colors.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
-        Debug.WriteLine("[MAP] " + pageStatic.Track.ToLower() + " -> [" + _scale + "] [" + _trackLength + "] [" + _trackPositions.Count + "]");
+        Debug.WriteLine("[MAP] " + pageStatic.Track.ToLower() + " -> [" + _scale + "] [" + broadCastTrackData.TrackMeters + "] [" + _trackPositions.Count + "]");
 
         if (!_config.Others.SavePreview)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -100,24 +100,34 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public override void Render(Graphics g)
     {
-        if (_trackingProgress != null && _trackPositions.Count == 0)
+        if (_trackingProgress != null && _mapCache.Map == null)
         {
-            using var font = FontUtil.FontSegoeMono(_config.Others.FontSize);
-            using SolidBrush pen = new(Color.FromArgb(100, Color.Black));
-            var size = g.MeasureString(_trackingProgress, font);
-
-            g.FillRectangle(pen, 0, 0, size.Width, size.Height);
-            g.DrawStringWithShadow(_trackingProgress, font, Color.White, new PointF());
-
-            if ((int)size.Width != Width || (int)size.Height != Height)
-            {
-                Height = (int)size.Height;
-                Width = (int)size.Width;
-            }
-
-            return;
+            RenderTrackingProgress(g);
         }
+        else
+        {
+            RenderMap(g);
+        }
+    }
 
+    private void RenderTrackingProgress(Graphics g)
+    {
+        using var font = FontUtil.FontSegoeMono(_config.Others.FontSize);
+        using SolidBrush pen = new(Color.FromArgb(100, Color.Black));
+        var size = g.MeasureString(_trackingProgress, font);
+
+        g.FillRectangle(pen, 0, 0, size.Width, size.Height);
+        g.DrawStringWithShadow(_trackingProgress, font, Color.White, new PointF());
+
+        if ((int)size.Width != Width || (int)size.Height != Height)
+        {
+            Height = (int)size.Height;
+            Width = (int)size.Width;
+        }
+    }
+
+    private void RenderMap(Graphics g)
+    {
         var carsOnTrack = GetCarsOnTrack();
         var bitmap = TrackMapDrawer.Draw(_trackPositions, carsOnTrack, _mapCache, _config, broadCastTrackData.TrackMeters);
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -10,6 +10,7 @@ using RaceElement.Broadcast;
 using RaceElement.Util;
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.TrackMap;
@@ -185,6 +186,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
         _trackPositions = track;
 
         _mapCache.Map = TrackMapDrawer.CreateLineFromPoints(_config.Colors.Map, _config.General.Thickness, _margin, _trackPositions, _trackBoundingBox);
+        Debug.WriteLine("[MAP] " + pageStatic.Track.ToLower() + " -> [" + _scale + "] [" + _trackLength + "] [" + _trackPositions.Count + "]");
 
         if (!_config.Others.SavePreview)
         {

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -99,13 +99,13 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public override void Render(Graphics g)
     {
-        if (_trackingProgress != null && _mapCache.Map == null)
-        {
-            RenderTrackingProgress(g);
-        }
-        else
+        if (_mapCache.Map != null)
         {
             RenderMap(g);
+        }
+        else if (_trackingProgress != null)
+        {
+            RenderTrackingProgress(g);
         }
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -94,8 +94,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
-        var shouldRender = (_trackingProgress != null) || (_trackPositions.Count > 0 && EntryListTracker.Instance.Cars.Count > 0);
-        return base.ShouldRender() && shouldRender;
+        return base.ShouldRender() && (_trackingProgress != null || _mapCache.Map != null);
     }
 
     public override void Render(Graphics g)
@@ -139,7 +138,6 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
         g.DrawImage(bitmap, 0, 0);
     }
-
 
     #region Event Listeners
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -9,7 +9,7 @@ public static class TrackMapPitPrediction
     public static PitStop GetPitStop(List<TrackPoint> track, float pitTimeMs)
     {
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
-        var info = TrackInfo.Data.GetValueOrDefault(name, new TrackInfo(0, 0, 0));
+        var info = TrackInfo.Data.GetValueOrDefault(name, new TrackInfo(0, 0));
 
         return ComputePitStop(track, pitTimeMs + info.PitLaneTimeMs);
     }
@@ -25,7 +25,7 @@ public static class TrackMapPitPrediction
         }
 
         var name = ACCSharedMemory.Instance.PageFileStatic.Track.ToLower();
-        var info = TrackInfo.Data.GetValueOrDefault(name, new TrackInfo(0, 0, 0));
+        var info = TrackInfo.Data.GetValueOrDefault(name, new TrackInfo(0, 0));
 
         time = time * 1000 + pitTimeMs + info.PitLaneTimeMs;
         var pitStop = ComputePitStop(track, time);

--- a/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/AbstractOverlay.cs
@@ -169,6 +169,9 @@ public abstract class AbstractOverlay : FloatingWindow
                 BroadcastTracker.Instance.OnTrackDataUpdate += BroadCastTrackDataChanged;
                 BroadcastTracker.Instance.OnRealTimeLocalCarUpdate += BroadCastRealTimeLocalCarUpdateChanged;
                 RaceSessionTracker.Instance.OnNewSessionStarted += Instance_OnNewSessionStarted;
+
+                // TODO(Andrei): This is just a temporal solution until we find a better way to redo the callbacks
+                BroadcastTracker.Instance.RequestData();
             }
 
             pageStatic = ACCSharedMemory.Instance.ReadStaticPageFile(false);

--- a/Race_Element.SharedMemory/ACCSharedMemory.cs
+++ b/Race_Element.SharedMemory/ACCSharedMemory.cs
@@ -209,7 +209,7 @@ public unsafe class ACCSharedMemory
         /// <summary>Session time lef</summary>
         public float SessionTimeLeft;
 
-        /// <summary>Distance travelled in the current stin</summary>
+        /// <summary>Distance travelled in the current stint</summary>
         public float DistanceTraveled;
 
         /// <summary>Car is pitting</summary>


### PR DESCRIPTION
* If you started the application while you were in a session, the broacast data could not be accessed as the broadcast system had already made all the relevant notifications. This has been temporarily solved by asking broadcast system data again.

* Unify EntryListTracker data processing. This way there is only one point in charge of updating the data allowing a better maintenance, adding new functionalities, etc.