### PR TITLE
1.1.0.2

### DIFF
--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.1.0.2", "- Setup Importer: disabled multi-track import when opened from SetupLink." },
         {"1.1.0.0", "- Rain Prediction HUD: Added configurable time multiplier."+
                     "\n- Track Info HUD: Increased precision of air and track temps."+
                     "\n- Brake Temp History HUD: Updated background set min and max values."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
-        {"1.1.0.2", "- Setup Importer: disabled multi-track import when opened from SetupLink." },
+        {"1.1.0.2", "- Setup Importer: disabled multi-track import when opened from SetupLink."+
+                    "\n- Setup Browser: Added Copy As SetupLink for Discord, this automatically creates a nice readable link in markdown. It contains the name of the setup, the car and the track."},
         {"1.1.0.0", "- Rain Prediction HUD: Added configurable time multiplier."+
                     "\n- Track Info HUD: Increased precision of air and track temps."+
                     "\n- Brake Temp History HUD: Updated background set min and max values."+

--- a/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
@@ -379,7 +379,7 @@ public partial class SetupBrowser : UserControl
         copy.Click += CopyToClipBoard_Click;
         contextMenu.Items.Add(copy);
 
-        MenuItem copyAsLink = ContextMenuHelper.DefaultMenuItem("Copy as Link", PackIconKind.Link);
+        MenuItem copyAsLink = ContextMenuHelper.DefaultMenuItem("Copy as SetupLink", PackIconKind.Link);
         copyAsLink.ToolTip = "Anyone who uses Race Element can click this link, the setup importer will be automatically opened.\nThe link is the setup, your data is yours.";
         copyAsLink.CommandParameter = file;
         copyAsLink.Click += CopyAsSetupLink_Click;

--- a/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
@@ -426,7 +426,7 @@ public partial class SetupBrowser : UserControl
             {
                 Root setup = GetSetupJsonRoot(file);
                 CarModels model = ConversionFactory.ParseCarName(setup.CarName);
-                Clipboard.SetText($"[SetupLink | {file.Name[..^4]}\n{ConversionFactory.GetCarName(setup.CarName)}]({website}{setupLink})");
+                Clipboard.SetText($"[SetupLink: {file.Name[..^5]}\n{ConversionFactory.GetCarName(setup.CarName)} - {file.Directory.Name}]({website}{setupLink})");
 
                 Dispatcher.Invoke(new Action(() =>
                 {

--- a/Race_Element/Controls/Setup/SetupImporter.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupImporter.xaml.cs
@@ -171,7 +171,7 @@ public partial class SetupImporter : UserControl
 
         if (filePath == string.Empty) return false;
         Thread.Sleep(200);
-        Dispatcher.Invoke(() => { return Open(filePath, true, false); });
+        Dispatcher.Invoke(() => { return Open(filePath, false, false); });
         return false;
     }
 

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.1.0.0</ApplicationVersion>
-        <AssemblyVersion>1.1.0.0</AssemblyVersion>
-        <Version>1.1.0.0</Version>
+        <ApplicationVersion>1.1.0.1</ApplicationVersion>
+        <AssemblyVersion>1.1.0.1</AssemblyVersion>
+        <Version>1.1.0.1</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.1.0.1</ApplicationVersion>
-        <AssemblyVersion>1.1.0.1</AssemblyVersion>
-        <Version>1.1.0.1</Version>
+        <ApplicationVersion>1.1.0.2</ApplicationVersion>
+        <AssemblyVersion>1.1.0.2</AssemblyVersion>
+        <Version>1.1.0.2</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
- Setup Importer: disabled multi-track import when opened from SetupLink.
- Setup Browser: Added Copy As SetupLink for Discord, this automatically creates a nice readable link in markdown. It contains the name of the setup, the car and the track.