### PR TITLE
1.1.0.4

### DIFF
--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ public static class ReleaseNotes
 {
     internal readonly static Dictionary<string, string> Notes = new()
     {
+        {"1.1.0.4", "- Updated SetupLinks to use the new website format, read the news article on the website for migrating your pre 1.1.0.4 SetupLinks links." },
         {"1.1.0.2", "- Setup Importer: disabled multi-track import when opened from SetupLink."+
                     "\n- Setup Browser: Added Copy As SetupLink for Discord, this automatically creates a nice readable link in markdown. It contains the name of the setup, the car and the track."},
         {"1.1.0.0", "- Rain Prediction HUD: Added configurable time multiplier."+

--- a/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupBrowser.xaml.cs
@@ -418,7 +418,7 @@ public partial class SetupBrowser : UserControl
             FileInfo file = (FileInfo)button.CommandParameter;
             // command is RaceElement://Setup=
             // The Race Element website enables linking.
-            string website = new("https://race.elementfuture.com/?setup=");
+            string website = new("https://race.elementfuture.com/setup?link=");
 
             string setupLink = GetSetupLink(file);
 
@@ -446,7 +446,7 @@ public partial class SetupBrowser : UserControl
 
             // command is RaceElement://Setup=
             // The Race Element website enables linking.
-            string website = new("https://race.elementfuture.com/?setup=");
+            string website = new("https://race.elementfuture.com/setup?link=");
 
             string setupLink = GetSetupLink(file);
 

--- a/Race_Element/Controls/Setup/SetupImporter.xaml.cs
+++ b/Race_Element/Controls/Setup/SetupImporter.xaml.cs
@@ -77,7 +77,8 @@ public partial class SetupImporter : UserControl
                 Content = trackData.FullName,
                 Margin = new Thickness(0, 0, 0, 0),
                 Padding = new Thickness(0, 4, 0, 6),
-                DataContext = trackData.GameName
+                DataContext = trackData.GameName,
+                ToolTip = trackData.GameName
             };
 
             if (listViewTracks.SelectionMode == SelectionMode.Single)

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.1.0.3</ApplicationVersion>
-        <AssemblyVersion>1.1.0.3</AssemblyVersion>
-        <Version>1.1.0.3</Version>
+        <ApplicationVersion>1.1.0.4</ApplicationVersion>
+        <AssemblyVersion>1.1.0.4</AssemblyVersion>
+        <Version>1.1.0.4</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>1.1.0.2</ApplicationVersion>
-        <AssemblyVersion>1.1.0.2</AssemblyVersion>
-        <Version>1.1.0.2</Version>
+        <ApplicationVersion>1.1.0.3</ApplicationVersion>
+        <AssemblyVersion>1.1.0.3</AssemblyVersion>
+        <Version>1.1.0.3</Version>
         <UseApplicationTrust>true</UseApplicationTrust>
         <CreateDesktopShortcut>true</CreateDesktopShortcut>
         <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
- Updated SetupLinks to use the new website format, read the news article on the website for migrating your pre 1.1.0.4 SetupLinks links.