### PR TITLE
Bar spotter

### DIFF
--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -17,4 +17,8 @@ public abstract class AbstractSimDataProvider
     abstract internal void Stop();
 
     abstract public bool HasTelemetry();
+
+    public virtual void SetupPreviewData()
+    {        
+    }
 }

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -285,7 +285,11 @@ namespace RaceElement.Data.Games.iRacing
         public override void SetupPreviewData()
         {
             SessionData.Instance.FocusedCarIndex = 1;
-            SessionData.Instance.Track.Length = 2000;
+
+            SessionData.Instance.Track.GameName = "Spa";
+            SessionData.Instance.Track.Length = 7004;
+            SessionData.Instance.Track.Temperature = 21;
+
             SimDataProvider.LocalCar.CarModel.CarClass = "F1";
 
             var lap1 = new LapInfo();
@@ -315,7 +319,8 @@ namespace RaceElement.Data.Games.iRacing
 
 
             CarInfo car2 = new CarInfo(2);
-            car2.TrackPercentCompleted = 10.03f;
+            // 1 meter behind car1
+            car2.TrackPercentCompleted = car1.TrackPercentCompleted + (1.0F / ((float) SessionData.Instance.Track.Length));
             car2.Position = 2;
             car2.CarLocation = CarInfo.CarLocationEnum.Track;
             car2.CurrentDriverIndex = 0;            
@@ -335,7 +340,7 @@ namespace RaceElement.Data.Games.iRacing
             AddCarClassEntry("F1", Color.Sienna);
 
             SpotterCallout = CarLeftRight.CarLeft;
-
+            
             hasTelemetry = true; // TODO: will this work when we have real telemetry? And is this sample telemetry valid for all sim providers?
         }
 

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotter.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotter.cs
@@ -1,0 +1,172 @@
+﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.Data.Games.iRacing;
+using RaceElement.Data.Games.iRacing.SDK;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkEnum;
+using CarInfo = RaceElement.Data.Common.SimulatorData.CarInfo;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayBarSpotter;
+
+[Overlay(Name = "Bar Spotter",
+    Description = "Spotter indicating overlap with other drivers with bars. (BETA)",
+    Version = 1.00,
+    OverlayType = OverlayType.Drive,
+    OverlayCategory = OverlayCategory.Driving,
+Authors = ["Dirk Wolf"])]
+internal sealed class BarSpotter : CommonAbstractOverlay
+{
+    private readonly BarSpotterConfiguration _config = new();
+    
+    //private CachedBitmap _cachedBackground;       
+    private Color _color;
+    private CachedBitmap _cachedColorBar;
+
+    public BarSpotter(Rectangle rectangle) : base(rectangle, "Bar Spotter")
+    {
+        this.RefreshRateHz = this._config.Bar.RefreshRate;
+        this.Height = _config.Bar.Height + 1;
+        // We need width for 2 bars "Distance" apart
+        this.Width = (2 * _config.Bar.Width + _config.Bar.Distance) + 1;
+    }
+
+    public sealed override void SetupPreviewData()
+    {
+        SimDataProvider.Instance.SetupPreviewData();
+    }
+
+    public sealed override void BeforeStart()
+    {                
+        int cornerRadius = (int)(10 * this.Scale);
+        _color = Color.FromArgb(_config.Colors.NormalOpacity, _config.Colors.NormalColor);
+        
+        /*
+        _cachedColorBar = new CachedBitmap((int)(Width * this.Scale + 1), (int)(_config.Bar.Height * this.Scale + 1), g =>
+            {
+                Rectangle rectL = new(0, 1, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+                using HatchBrush hatchBrushL = new(HatchStyle.LightUpwardDiagonal, _color, Color.FromArgb(_color.A - 40, _color));
+                g.FillRoundedRectangle(hatchBrushL, rectL, cornerRadius);
+                Rectangle rectR = new(_config.Bar.Distance, 1, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+                using HatchBrush hatchBrushR = new(HatchStyle.LightUpwardDiagonal, _color, Color.FromArgb(_color.A - 40, _color));
+                g.FillRoundedRectangle(hatchBrushL, rectR, cornerRadius);
+            });
+                
+        
+        _cachedBackground = new CachedBitmap((int)(Width * this.Scale + 1), (int)(_config.Bar.Height * this.Scale + 1), g =>
+        {
+            int midHeight = (int)(_config.Bar.Height * this.Scale) / 2;
+            using LinearGradientBrush linerBrush = new(new Point(0, midHeight), new Point((int)(Width * this.Scale), midHeight), Color.FromArgb(160, 0, 0, 0), Color.FromArgb(230, 0, 0, 0));
+            g.FillRoundedRectangle(linerBrush, new Rectangle(0, 0, (int)(Width * this.Scale), (int)(_config.Bar.Height * this.Scale)), cornerRadius);
+            using Pen pen = new(Color.Black, 1 * this.Scale);
+            g.DrawRoundedRectangle(pen, new Rectangle(0, 0, (int)(Width * this.Scale), (int)(_config.Bar.Height * this.Scale)), cornerRadius);
+        });        */
+    }
+
+    public sealed override void BeforeStop()
+    {
+        //_cachedBackground?.Dispose();        
+
+        if (_cachedColorBar != null)
+            _cachedColorBar.Dispose();
+    }
+
+    public sealed override void Render(Graphics g)
+    {
+        if (!SimDataProvider.HasTelemetry()) return;
+
+        if (SimDataProvider.Instance.GetType() != typeof(IRacingDataProvider))
+        {
+            // TODO: can we give users error popups or make this only selectable for iRacing?
+            Debug.WriteLine("Only supported for iRacing!");
+            return;
+        }
+
+        //_cachedBackground?.Draw(g, _config.Bar.Width, _config.Bar.Height);
+
+        DrawSpotterBars(g);
+
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.TextRenderingHint = TextRenderingHint.AntiAlias;
+        g.TextContrast = 1;
+    }
+
+
+    private void DrawSpotterBars(Graphics g)
+    {
+        IRacingDataProvider racingDataProvider = (IRacingDataProvider) SimDataProvider.Instance;
+        CarLeftRight spotterCallout = racingDataProvider.GetSpotterCallout();
+
+        // Off, Clear -> Nothing to show
+        if (spotterCallout == CarLeftRight.Off || spotterCallout == CarLeftRight.Clear) return;        
+       
+
+        // if there's a 0.5% difference in percent track completed add the car to the list we need to possibly spot
+        float distanceThreshold = 0.05F;
+        // cars we consider for spotting
+        List<KeyValuePair<float, CarInfo>> spottableCars = [];
+
+        CarInfo playerCar = SessionData.Instance.Cars[SessionData.Instance.FocusedCarIndex].Value;
+        foreach (KeyValuePair<int, CarInfo> kvp in SessionData.Instance.Cars) {
+            CarInfo carInfo = kvp.Value;
+            
+            if (carInfo == playerCar) continue;
+            float distance = Math.Abs(carInfo.TrackPercentCompleted - playerCar.TrackPercentCompleted);
+            if (distance < distanceThreshold) {
+                spottableCars.Add(KeyValuePair.Create(distance, carInfo));
+                Debug.WriteLine("Car {0} is in distance {1} ", carInfo.CupPosition, distance);
+            } else
+            {
+                Debug.WriteLine("Car {0} is NOT in distance {1} ", carInfo.CupPosition, distance);
+            }
+        }
+        var orderedSpottableCars = spottableCars.OrderBy(d => d.Key);
+
+        // CarLeft, CarRight: show overlap of one car clipping from start or end        
+        // Use track length and fixed aberage car length to determine what the overlap is in terms of car lenths. And then either
+        // show the overlap on the front or rear (on the correct side).
+        if (spotterCallout == CarLeftRight.CarLeft)
+        {
+          
+        } else if (spotterCallout == CarLeftRight.CarRight)
+        {
+
+        } else
+        {
+            // CarLeftRight: Show full bars in different color like iOverlay? We can figure out overlap, but don't know whether cars are left or right. https://youtu.be/RTWNssC6tQY?t=107 TODO: remove 
+            throw new NotImplementedException("Spotter callout handling for " + spotterCallout + " not implemented yet.");
+        }
+
+
+
+        // TODO: sample data for now. player's car has 2 cars on left overlapping and 1 on right.
+        // percentages of bar where overlap starts and ends.
+        // Needs to be calculated from car positions that are next to the player
+        int leftFrontOverlap = 10;
+        int leftRearOverlap = 30;
+        int rightFrontOverlap = 0;
+        int rightRearOverlap = 50;
+
+        // TODO: calculate these using bar height
+        int leftClipYStart = 10;
+        int leftClipYEnd = _config.Bar.Height; // 2;
+        int rightClipYStart = 50;
+        int rightClipYEnd = _config.Bar.Height;  // 3;        
+
+        g.SetClip(new Rectangle(0, leftClipYStart, _config.Bar.Width, leftClipYEnd));
+        g.SetClip(new Rectangle(_config.Bar.Distance, rightClipYStart, _config.Bar.Width, rightClipYEnd), CombineMode.Union);
+        // _cachedColorBar.Draw(g, 1, 0, Width - 1, _config.Bar.Height - 1);
+
+        int cornerRadius = (int)(10 * this.Scale);
+        Rectangle rectL = new(0, 1, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+        using HatchBrush hatchBrushL = new(HatchStyle.LightUpwardDiagonal, _color, Color.FromArgb(_color.A - 40, _color));
+        g.FillRoundedRectangle(hatchBrushL, rectL, cornerRadius);
+        Rectangle rectR = new(_config.Bar.Distance, 1, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+        using HatchBrush hatchBrushR = new(HatchStyle.LightUpwardDiagonal, _color, Color.FromArgb(_color.A - 40, _color));
+        g.FillRoundedRectangle(hatchBrushL, rectR, cornerRadius);
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using RaceElement.HUD.Overlay.Configuration;
 using System.Drawing;
 
-namespace RaceElement.HUD.Common.Overlays.OverlayBarSpotter;
+namespace RaceElement.HUD.Common.Overlays.BarSpotter;
 
 internal sealed class BarSpotterConfiguration : OverlayConfiguration
 {

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
@@ -37,6 +37,10 @@ internal sealed class BarSpotterConfiguration : OverlayConfiguration
     {
         public Color NormalColor { get; init; } = Color.FromArgb(255, 5, 255, 5);
         [IntRange(75, 255, 1)]
+
+        public Color ThreeCarsColor { get; init; } = Color.FromArgb(255, 5, 255, 5);
+        [IntRange(75, 255, 1)]
+
         public int NormalOpacity { get; init; } = 255;
 
    }

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterConfiguration.cs
@@ -1,0 +1,48 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using System.Drawing;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayBarSpotter;
+
+internal sealed class BarSpotterConfiguration : OverlayConfiguration
+{
+    [ConfigGrouping("Bar", "The shape and options of the spotter indicator bar.")]
+    public BarsGrouping Bar { get; init; } = new BarsGrouping();
+    public sealed class BarsGrouping
+    {
+        [ToolTip("Sets the Width of the spotter indicator bar.")]
+        [IntRange(10, 50, 1)]
+        public int Width { get; init; } = 20;
+
+        [ToolTip("Sets the Height of the spotter indicator bar.")]
+        [IntRange(200, 500, 5)]
+        public int Height { get; init; } = 250;
+
+        [ToolTip("Distance between the spotter indicator bars.")]
+        [IntRange(200, 800, 5)]
+        public int Distance { get; init; } = 400;
+
+
+
+
+        [ToolTip("Sets the refresh rate.")]
+        [IntRange(20, 70, 2)]
+        public int RefreshRate { get; init; } = 50;        
+    }
+
+    
+
+    [ConfigGrouping("Colors", "Adjust the colors used in the spotter bar")]
+    public ColorsGrouping Colors { get; init; } = new ColorsGrouping();
+    public sealed class ColorsGrouping
+    {
+        public Color NormalColor { get; init; } = Color.FromArgb(255, 5, 255, 5);
+        [IntRange(75, 255, 1)]
+        public int NormalOpacity { get; init; } = 255;
+
+   }
+
+    public BarSpotterConfiguration()
+    {
+        this.GenericConfiguration.AllowRescale = true;
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterOverlay.cs
@@ -1,6 +1,7 @@
 ﻿using RaceElement.Broadcast.Structs;
 using RaceElement.Data.Common;
 using RaceElement.Data.Common.SimulatorData;
+using RaceElement.Data.Games;
 using RaceElement.Data.Games.iRacing;
 using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
@@ -11,7 +12,7 @@ using System.Drawing.Text;
 using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkEnum;
 using CarInfo = RaceElement.Data.Common.SimulatorData.CarInfo;
 
-namespace RaceElement.HUD.Common.Overlays.OverlayBarSpotter;
+namespace RaceElement.HUD.Common.Overlays.BarSpotter;
 
 [Overlay(Name = "Bar Spotter",
     Description = "Spotter indicating overlap with other drivers with bars. (BETA)",
@@ -19,13 +20,13 @@ namespace RaceElement.HUD.Common.Overlays.OverlayBarSpotter;
     OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Driving,
 Authors = ["Dirk Wolf"])]
-internal sealed class BarSpotter : CommonAbstractOverlay
+internal sealed class BarSpotterOverlay : CommonAbstractOverlay
 {
     private readonly BarSpotterConfiguration _config = new();
     
-    private List<Color> colors = [];
+    private readonly List<Color> colors = [];
 
-    public BarSpotter(Rectangle rectangle) : base(rectangle, "Bar Spotter")
+    public BarSpotterOverlay(Rectangle rectangle) : base(rectangle, "Bar Spotter")
     {
         this.RefreshRateHz = this._config.Bar.RefreshRate;
         this.Height = _config.Bar.Height + 1;
@@ -52,7 +53,7 @@ internal sealed class BarSpotter : CommonAbstractOverlay
     {
         if (!SimDataProvider.HasTelemetry()) return;
 
-        if (SimDataProvider.Instance.GetType() != typeof(IRacingDataProvider))
+        if (GameManager.CurrentGame != Game.iRacing) 
         {
             // This HUD makes only sense if the sim provider gives the e.g. the "car left" and "three wide" callouts. This could be refactored
             // for other sims using the car world coordination, but then the radar is a better visualization.

--- a/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
@@ -200,13 +200,8 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         // Interval based on the type of session:
         // - practice/qualifying: interval is gap to driver in front's BEST time (within) same class 
         // - race: interval is gap to car in front in the same class.        
-<<<<<<< HEAD
         int intervalMs = 0;        
         if (standingsTableRows.Count > 1)
-=======
-        int intervalMs = 0;
-        if (standingsTableRows.Count > 0)
->>>>>>> adc20ef0d99804698613857f4765fbf11fee1ac5
         {
             if (SessionData.Instance.SessionType != RaceSessionType.Race)
             {

--- a/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
@@ -42,54 +42,7 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
 
     public sealed override void SetupPreviewData()
     {
-        SessionData.Instance.FocusedCarIndex = 1;
-        SessionData.Instance.Track.Length = 2000;
-        CarClasses = ["F1"];
-        
-
-        var lap1 = new LapInfo();
-        lap1.Splits = [ 10000, 22000, 11343];
-        lap1.LaptimeMS = lap1.Splits.Sum();
-        var lap2 = new LapInfo();
-        lap2.Splits = [ 9000, 22000, 11343];
-        lap2.LaptimeMS = lap2.Splits.Sum();
-
-        var car1 = new CarInfo(1);
-        car1.TrackPercentCompleted = 1.0f;
-        car1.Position = 1;
-        car1.CarLocation = CarInfo.CarLocationEnum.Track;
-        car1.CurrentDriverIndex = 0;
-        car1.TrackPercentCompleted = 0.1f;
-        car1.Kmh = 140;
-        car1.CupPosition = 1;
-        car1.RaceNumber = 17;
-        car1.LastLap = lap1;
-        car1.CurrentLap = lap2;
-        car1.GapToClassLeaderMs = 0;
-        car1.CarClass = "F1";
-        SessionData.Instance.AddOrUpdateCar(1, car1);
-        var car1driver0 = new DriverInfo();
-        car1driver0.Name = "Max Verstappen";        
-        car1.AddDriver(car1driver0);
-    
-
-        CarInfo car2 = new CarInfo(2);
-        car2.TrackPercentCompleted = 1.03f;
-        car2.Position = 2;
-        car2.CarLocation = CarInfo.CarLocationEnum.Track;
-        car2.CurrentDriverIndex = 0;
-        car2.TrackPercentCompleted = 0.3f;
-        car2.Kmh = 160;
-        car2.CupPosition = 2;
-        car2.RaceNumber = 5;        
-        car2.LastLap = lap2;
-        car2.CurrentLap = lap1;
-        car2.GapToClassLeaderMs = 1000;
-        car2.CarClass = "F1";
-        SessionData.Instance.AddOrUpdateCar(2, car2);
-        var car2driver0 = new DriverInfo();
-        car2driver0.Name = "Michael Schumacher";
-        car2.AddDriver(car2driver0);        
+        SimDataProvider.Instance.SetupPreviewData();
     }
 
 
@@ -249,7 +202,7 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         // - practice/qualifying: interval is gap to driver in front's BEST time (within) same class 
         // - race: interval is gap to car in front in the same class.        
         int intervalMs = 0;        
-        if (standingsTableRows.Count > 0)
+        if (standingsTableRows.Count > 1)
         {
             if (SessionData.Instance.SessionType != RaceSessionType.Race)
             {


### PR DESCRIPTION
Implement Bar Spotter that shows overlap of other cars with player's cars. This is only supported in iRacing for now.

1 car overlap: bars on the left or right indicate the amount of overlap
2 car overlap: bars on both sides are showing overlap (but not amount) or in other words full bars are showing.

E.g. here's a car on the high side, so the orange bar is center left showing about 30% overlap:
![BarSpotterLeft](https://github.com/user-attachments/assets/56dea5a6-2c6d-47fb-b681-278423c364d8)

