### PR TITLE
Fixes and callbacks for Standings Overlay

### DIFF
--- a/Race Element.Data/Common/SimDataProvider.cs
+++ b/Race Element.Data/Common/SimDataProvider.cs
@@ -94,5 +94,19 @@ namespace RaceElement.Data.Common
         {
             return (Instance != null && Instance.HasTelemetry());
         }
+
+        public static event EventHandler<RaceSessionType> OnSessionTypeChanged;
+        public static event EventHandler<SessionPhase> OnSessionPhaseChanged;
+        public static event EventHandler<Status> OnStatusChanged;
+
+        internal static void CallSessionTypeChanged(AbstractSimDataProvider simDataProvider, RaceSessionType sessionType)
+        {
+            OnSessionTypeChanged?.Invoke(simDataProvider, SessionData.Instance.SessionType);
+        }
+
+        internal static void CallSessionPhaseChanged(AbstractSimDataProvider simDataProvider, SessionPhase sessionPhase)
+        {
+            OnSessionPhaseChanged?.Invoke(simDataProvider, SessionData.Instance.Phase);
+        }
     }
 }

--- a/Race Element.Data/Common/SimulatorData/CarInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/CarInfo.cs
@@ -69,6 +69,7 @@ public sealed class CarInfo
         Track = 1,
         Pitlane = 2,
         PitEntry = 3,
-        PitExit = 4
+        PitExit = 4,
+        Garage = 5
     }
 }

--- a/Race Element.Data/Common/SimulatorData/SessionData.cs
+++ b/Race Element.Data/Common/SimulatorData/SessionData.cs
@@ -32,6 +32,14 @@ namespace RaceElement.Data.Common.SimulatorData
             }
         }
 
+        /// <summary>
+        /// Car index of the player. This is game provided that can differ from
+        /// session to session. E.g. not the race car number.
+        /// </summary>
+        public int PlayerCarIndex { get; internal set; }
+        /// <summary>
+        /// Car index that is focused on. E.g. in a replay or in the pit.
+        /// </summary>
         public int FocusedCarIndex {get; set;}
         public RaceSessionType SessionType { get; set; }
         public SessionPhase Phase { get; set; }
@@ -71,26 +79,34 @@ namespace RaceElement.Data.Common.SimulatorData
     }
 
     public enum RaceSessionType
-{
-    Practice = 0,
-    Qualifying = 4,
-    Superpole = 9,
-    Race = 10,
-    Hotlap = 11,
-    Hotstint = 12,
-    HotlapSuperpole = 13,
-    Replay = 14
-};
-public enum SessionPhase
-{
-    NONE = 0,
-    Starting = 1,
-    PreFormation = 2,
-    FormationLap = 3,
-    PreSession = 4,
-    Session = 5,
-    SessionOver = 6,
-    PostSession = 7,
-    ResultUI = 8
-};
+    {
+        Practice = 0,
+        Qualifying = 4,
+        Superpole = 9,
+        Race = 10,
+        Hotlap = 11,
+        Hotstint = 12,
+        HotlapSuperpole = 13,
+        Replay = 14
+    };
+    public enum SessionPhase
+    {
+        NONE = 0,
+        Starting = 1,
+        PreFormation = 2,
+        FormationLap = 3,
+        PreSession = 4,
+        Session = 5,
+        SessionOver = 6,
+        PostSession = 7,
+        ResultUI = 8
+    };
+
+    public enum Status : int
+    {
+        OFF,
+        REPLAY,
+        LIVE,
+        PAUSE,
+    }
 }

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -18,7 +18,9 @@ public abstract class AbstractSimDataProvider
 
     abstract public bool HasTelemetry();
 
-    public virtual void SetupPreviewData()
-    {        
-    }
+    public virtual void SetupPreviewData() { }
+
+
+
+    
 }

--- a/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
@@ -39,7 +39,6 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
 
     public sealed override void SetupPreviewData()
     {
-
         SimDataProvider.Instance.SetupPreviewData();        
     }
 
@@ -47,7 +46,15 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
     public sealed override void BeforeStart()
     {
         InitCarClassEntryLists();
+        // Can be registered before SimDataProvider.Instance was created
+        SimDataProvider.OnSessionTypeChanged += Instance_OnSessionTypeChanged;
+  
         base.BeforeStart();
+    }
+
+    private void Instance_OnSessionTypeChanged(object? sender, RaceSessionType e)
+    {
+        ClearCarClassEntryList();            
     }
 
     private void ClearCarClassEntryList()
@@ -56,14 +63,14 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         {
             CarClasses = SimDataProvider.Instance.GetCarClasses();
         }
-        foreach (string carClass in CarClasses)
+        foreach (string carClass in _entryListForCarClass.Keys)
         {
             if (!_entryListForCarClass.ContainsKey(carClass))
             {
                 InitCarClassEntryLists();
             }
             _entryListForCarClass[carClass].Clear();
-        }
+        }                
     }
 
     private void InitCarClassEntryLists()
@@ -101,6 +108,7 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         List<KeyValuePair<int, CarInfo>> cars = SessionData.Instance.Cars;
         if (cars.Count == 0) return;
 
+        // TODO: optimize. DetermineDriversClass and SplitEntryList should not be necessary every Render. Just Sort.
         DetermineDriversClass(cars);
         SplitEntryList(cars);
         SortAllEntryLists();

--- a/Race_Element.HUD/Overlay/Internal/CommonAbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/CommonAbstractOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
 using RaceElement.HUD.Overlay.Configuration;
 using RaceElement.Util;
 using RaceElement.Util.Settings;
@@ -68,6 +69,11 @@ public abstract class CommonAbstractOverlay : FloatingWindow
         
         if (!SimDataProvider.HasTelemetry())
             return false;
+
+        // For show only HUDs when player is on track. 
+        // TODO: Distinguish in sim data providers between pit and garage and only show in pit, but not garage or make configurable.
+        CarInfo carInfo = SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value;
+        if (carInfo.CarLocation != CarInfo.CarLocationEnum.Track) return false;
 
         bool shouldRender = true;
 


### PR DESCRIPTION
Main fixes:
- Creates a callback `OnSessionTypeChanged`, `OnSessionPhaseChanged` and `OnStatusChanged` in `SimDataProvider` 
 that HUDs can listen on.
 - IRacingDataProvider uses IRSDKSharpe's  `OnTelemetryData` and `OnSessionInfo` listeners to update either telemetry (realtime) or session data.
 - `StandingsOverlay` uses the `OnSessionTypeChanged` events to clear the entry list and car class list when the session changes.
 - Makes HUDs only visible outside of pit and garage (maybe only in garage later)
 - fixes standings HUD ordering when car doesn't have a time set.
