### PR TITLE
Delta, Fuel and Wind overlays complete.

### DIFF
--- a/Race Element.Data/Common/SimulatorData/CarInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/CarInfo.cs
@@ -45,6 +45,11 @@ public sealed class CarInfo
     public string CarClass { get; set; }
     public bool IsSpectator { get; set; }
 
+    /// <summary>
+    /// Delta to driver's best session lap
+    /// </summary>
+    /// Might not be available for all sims. 
+    public float LapDeltaToSessionBestLap { get; set; }
 
     public CarInfo(int carIndex)
     {

--- a/Race Element.Data/Common/SimulatorData/LocalCarData.cs
+++ b/Race Element.Data/Common/SimulatorData/LocalCarData.cs
@@ -37,6 +37,12 @@ namespace RaceElement.Data.Common.SimulatorData
         /// Maximum revolutions per minute
         /// </summary>
         public int MaxRpm { get; set; }
+
+        // Fuel info
+        public float FuelLiters { get; set; }
+        public float MaxFuelLiters { get; set; }
+        public float FuelLitersXLap { get; set; }
+        public float FuelEstimatedLaps { get; set; }
     }
     public sealed record TyresData
     {
@@ -78,6 +84,13 @@ namespace RaceElement.Data.Common.SimulatorData
         /// The g-forces. (X,Y,Z)
         /// </summary>
         public Vector3 Acceleration { get; set; } = new();
+
+        /// <summary>
+        /// Heading relative to north in radians.
+        /// </summary>
+        public float Heading { get; set; }
+        public float Pitch { get; internal set; }
+        public float Roll { get; internal set; }
     }
     public sealed record InputsData
     {

--- a/Race Element.Data/Common/SimulatorData/SessionData.cs
+++ b/Race Element.Data/Common/SimulatorData/SessionData.cs
@@ -43,6 +43,10 @@ namespace RaceElement.Data.Common.SimulatorData
         public int FocusedCarIndex {get; set;}
         public RaceSessionType SessionType { get; set; }
         public SessionPhase Phase { get; set; }
+        public float LapDeltaToSessionBestLapMs { get; set; }
+        
+        public bool IsSetupMenuVisible { get; set; }
+        public double SessionTimeLeftSecs { get; set; }        
     }
 
     public sealed record TrackData
@@ -73,7 +77,7 @@ namespace RaceElement.Data.Common.SimulatorData
         public float AirVelocity { get; set; }
 
         /// <summary>
-        /// The direction of the air in degrees
+        /// The direction of the air in radians
         /// </summary>
         public float AirDirection { get; set; }
     }

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -20,7 +20,8 @@ public abstract class AbstractSimDataProvider
 
     public virtual void SetupPreviewData() { }
 
-
-
-    
+    public virtual bool IsSpectating(int playerCarIndex, int focusedIndex)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/BarSpotter/BarSpotterOverlay.cs
@@ -123,7 +123,8 @@ internal sealed class BarSpotterOverlay : CommonAbstractOverlay
                 leftRectY = (int)(_config.Bar.Height * this.Scale * (1.0F - overlapPercent));
                 leftRectHeight = (int)(_config.Bar.Height * this.Scale * overlapPercent);
             }
-          
+            g.DrawRectangle(Pens.Black, 0, 0, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+
         } else if (spotterCallout == CarLeftRight.CarRight)
         {
             if (closestCarDistance > 0)
@@ -135,6 +136,7 @@ internal sealed class BarSpotterOverlay : CommonAbstractOverlay
                 rightRectY = (int)(_config.Bar.Height * this.Scale * (1.0F - overlapPercent));
                 rightRectHeight = (int)(_config.Bar.Height * this.Scale * overlapPercent);
             }
+            g.DrawRectangle(Pens.Black, 0, _config.Bar.Distance, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
         } else if (spotterCallout == CarLeftRight.Off || spotterCallout == CarLeftRight.Clear)
         {
             return;
@@ -144,6 +146,8 @@ internal sealed class BarSpotterOverlay : CommonAbstractOverlay
             color = colors[1]; 
             leftRectHeight = (int)(_config.Bar.Height * this.Scale);            
             rightRectHeight = (int)(_config.Bar.Height * this.Scale);
+            g.DrawRectangle(Pens.Black, 0, 0, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
+            g.DrawRectangle(Pens.Black, 0, _config.Bar.Distance, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale));
         }
 
         Rectangle rectL = new(0, leftRectY, (int)(_config.Bar.Width * this.Scale), leftRectHeight);

--- a/Race Element.HUD.Common/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/FuelInfo/FuelInfoOverlay.cs
@@ -1,0 +1,252 @@
+﻿//using RaceElement.Data.ACC.Database.LapDataDB;
+//using RaceElement.Data.ACC.Tracker.Laps;
+using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.Util;
+using RaceElement.Util.SystemExtensions;
+using System;
+using System.Drawing;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayFuelInfo;
+
+[Overlay(Name = "Fuel Info (ALPHA)",
+    Description = "A panel showing information about the fuel: laps left, fuel to end of race. Optionally showing stint information." +
+    "\nBest to be used in a race, Do not use this before you start it as the game doesn't provide accurate data at that point.",
+    Version = 1.00,
+    OverlayType = OverlayType.Drive,
+    OverlayCategory = OverlayCategory.Car,
+Authors = ["Kris Vickers", "Reinier Klarenberg", "Dirk Wolf"])]
+internal sealed class FuelInfoOverlay : CommonAbstractOverlay
+{
+    private readonly InfoPanel _infoPanel;
+
+    private readonly FuelInfoConfig _config = new();
+    private sealed class FuelInfoConfig : OverlayConfiguration
+    {
+
+        public enum LapTimeSource
+        {
+            LastThenBest,
+            LastTwoLapsAverage,
+            BestOnly,
+            LastOnly,
+        }
+
+        [ConfigGrouping("Data Source", "Adjust the Source of the data used in the fuel calculation. NOTE: at the moment only last lap supported.")]
+        public DataSourceGrouping DataSource { get; init; } = new();
+        public sealed class DataSourceGrouping
+        {
+            [ToolTip("Sets the source of the laptime used in the fuel calculation" +
+                     "\nLast Then Best: Uses your last lap until you set a best lap." +
+                     "\nLast Two Laps Average: Uses the average laptime of your last 2 laps." +
+                     "\nBest Only: Only uses your best valid lap if any was set." +
+                     "\nLast Only: Only uses your last lap if any was set.")]
+            public LapTimeSource LapTimeSource { get; init; } = LapTimeSource.LastThenBest;
+        }
+
+        [ConfigGrouping("Info Panel", "Show or hide additional information in the panel.")]
+        public InfoPanelGrouping InfoPanel { get; init; } = new();
+        public sealed class InfoPanelGrouping
+        {
+            [ToolTip("Sets the number of additional laps as a fuel buffer.")]
+            [IntRange(0, 3, 1)]
+            public int FuelBufferLaps { get; init; } = 0;
+
+            [ToolTip("Displays Fuel time remaining which is green if it's higher than stint time or session time and red if it is not.")]
+            public bool FuelTime { get; init; } = true;
+
+            [ToolTip("Displays stint time remaining and the suggested amount of fuel to the end of the stint or the session.")]
+            public bool StintInfo { get; init; } = true;
+
+            [ToolTip("When viewing the setup menu it will still display the HUD.\nOverriding the default.")]
+            public bool ShowInSetup { get; init; } = false;
+        }
+
+        [ConfigGrouping("Colors", "Adjust colors for the fuel bar.")]
+        public ColorsGrouping Colors { get; init; } = new();
+        public sealed class ColorsGrouping
+        {
+            [ToolTip("Change the color of the fuel bar when full fuel.")]
+            public Color FullColor { get; init; } = Color.FromArgb(255, Color.Green);
+
+            [ToolTip("Change the medium fuel percentage for the fuel bar to change color.")]
+            [FloatRange(0.30f, 0.75f, 0.01f, 2)]
+            public float MediumPercent { get; init; } = 0.5f;
+            [ToolTip("Change the color of the fuel bar when medium fuel.")]
+            public Color MediumColor { get; init; } = Color.FromArgb(255, 255, 135, 0);
+
+            [ToolTip("Change the low fuel percentage for the fuel bar to change color.")]
+            [FloatRange(0.01f, 0.25f, 0.01f, 2)]
+            public float LowPercent { get; init; } = 0.15f;
+            [ToolTip("Change the color of the fuel bar when low fuel.")]
+            public Color LowColor { get; init; } = Color.FromArgb(255, Color.Red);
+        }
+
+        public FuelInfoConfig()
+        {
+            this.GenericConfiguration.AllowRescale = true;
+        }
+    }
+
+    public FuelInfoOverlay(Rectangle rectangle) : base(rectangle, "Fuel Info")
+    {
+        this.Width = 222;
+        _infoPanel = new InfoPanel(10, this.Width - 1) { FirstRowLine = 1 };
+        this.Height = this._infoPanel.FontHeight * 6 + 1;
+        RefreshRateHz = 2;
+    }
+
+    public override void SetupPreviewData()
+    {
+        SimDataProvider.Instance.SetupPreviewData();
+    }
+
+    public sealed override void BeforeStart()
+    {
+        if (!_config.InfoPanel.StintInfo)
+            this.Height -= _infoPanel.FontHeight * 2;
+
+        if (!_config.InfoPanel.FuelTime)
+            this.Height -= _infoPanel.FontHeight;
+    }
+
+    public sealed override bool ShouldRender()
+    {
+        if (_config.InfoPanel.ShowInSetup && SessionData.Instance.IsSetupMenuVisible)
+            return true;
+
+        return base.ShouldRender();
+    }
+
+    public sealed override void Render(Graphics g)
+    {
+        float fuelLiters = SimDataProvider.LocalCar.Engine.FuelLiters;
+        using SolidBrush fuelBarBrush = new(GetFuelBarColor());
+        _infoPanel.AddProgressBarWithCenteredText($"{fuelLiters:F2} L", 0, SimDataProvider.LocalCar.Engine.MaxFuelLiters, fuelLiters, fuelBarBrush);
+        // Some global variants
+        double lapBufferVar = SimDataProvider.LocalCar.Engine.FuelLitersXLap * this._config.InfoPanel.FuelBufferLaps;
+        double bestLapTime = GetLapTimeMS();
+        if (bestLapTime <= 0)
+        {
+            if (!IsPreviewing)
+            {
+                string header = "No Laptime";
+                header = header.FillEnd(10, ' ');
+                _infoPanel.AddLine(header, "Waiting...");
+                _infoPanel.Draw(g);
+                return;
+            }
+
+        }
+
+        double fuelTimeLeft = SimDataProvider.LocalCar.Engine.FuelEstimatedLaps * bestLapTime;
+        // ACC uses -1 for single driver races. TODO In iRacing we hardcode this the same for now
+        // double stintDebug = pageGraphics.DriverStintTimeLeft; stintDebug.ClipMin(-1);
+        double stintDebug = -1.0D;
+        //**********************
+        // Workings
+        // TODO ACC uses -1000 in single player races. We use the same for iRacing right now.
+        int driverStintTimeLeft = -1000;
+        double stintFuel = 0; // TODO not used w/o stints driverStintTimeLeft / bestLapTime * SimDataProvider.LocalCar.Engine.FuelLitersXLap + pageGraphics.UsedFuelSinceRefuel;
+        
+        double fuelToEnd = SessionData.Instance.SessionTimeLeftSecs / bestLapTime * SimDataProvider.LocalCar.Engine.FuelLitersXLap;
+        double fuelToAdd = FuelToAdd(lapBufferVar, stintDebug, stintFuel, fuelToEnd);
+        string fuelTime = $"{TimeSpan.FromMilliseconds(fuelTimeLeft):hh\\:mm\\:ss}";
+        string stintTime = $"{TimeSpan.FromMilliseconds(stintDebug):hh\\:mm\\:ss}";
+        //**********************
+        using SolidBrush fuelTimeBrush = new(GetFuelTimeColor(fuelTimeLeft, stintDebug));
+        //Start (Basic)
+        _infoPanel.AddLine("Laps Left", $"{SimDataProvider.LocalCar.Engine.FuelEstimatedLaps:F1} @ {SimDataProvider.LocalCar.Engine.FuelLitersXLap:F2}L");
+        _infoPanel.AddLine("Fuel-End", $"{fuelToEnd + lapBufferVar:F1} : Add {fuelToAdd:F0}");
+        //End (Basic)
+        //Magic Start (Advanced)
+        if (this._config.InfoPanel.FuelTime)
+            _infoPanel.AddLine("Fuel Time", fuelTime, fuelTimeBrush);
+
+        if (_config.InfoPanel.StintInfo)
+        {
+            _infoPanel.AddLine("Stint Time", stintTime);
+
+            if (stintDebug == -1)
+                _infoPanel.AddLine("Stint Fuel", "No Stints");
+            else
+                _infoPanel.AddLine("Stint Fuel", $"{stintFuel + lapBufferVar:F1}");
+        }
+        //Magic End (Advanced)
+        _infoPanel.Draw(g);
+    }
+
+    private int GetLapTimeMS()
+    {
+        int lapTime = -1;
+        switch (_config.DataSource.LapTimeSource)
+        {
+            /* TODO: port the LapTracker to be independent of ACC
+            case FuelInfoConfig.LapTimeSource.LastTwoLapsAverage:
+                {
+                    lapTime = LapTracker.Instance.Laps.GetAverageLapTime(2);
+                    break;
+                }
+            case FuelInfoConfig.LapTimeSource.LastOnly:
+                {
+                    lapTime = LapTracker.Instance.Laps.GetLastLapTime();
+                    break;
+                }
+            case FuelInfoConfig.LapTimeSource.BestOnly:
+                {
+                    lapTime = LapTracker.Instance.Laps.GetBestLapTime();
+                    break;
+                }
+            case FuelInfoConfig.LapTimeSource.LastThenBest:
+            */
+            default:
+                {
+                    CarInfo carInfo = SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value;
+                    lapTime = (int)carInfo.FastestLap.LaptimeMS;
+                    if (lapTime > TimeSpan.FromMinutes(12).TotalMilliseconds || lapTime == 0)
+                    {
+                        if (carInfo.LastLap.LaptimeMS < TimeSpan.FromMinutes(12).TotalMilliseconds && carInfo.LastLap.LaptimeMS != 0)
+                            lapTime = (int)carInfo.LastLap.LaptimeMS;
+                    }
+                    break;
+                }
+
+        }
+
+        return lapTime;
+    }
+
+    private double FuelToAdd(double lapBufferVar, double stintDebug, double stintFuel, double fuelToEnd)
+    {
+        double fuel;
+        if (stintDebug == -1)
+            fuel = Math.Min(Math.Ceiling(fuelToEnd - SimDataProvider.LocalCar.Engine.FuelLiters), SimDataProvider.LocalCar.Engine.FuelLiters) + lapBufferVar;
+        else
+            fuel = Math.Min(stintFuel - SimDataProvider.LocalCar.Engine.FuelLiters, SimDataProvider.LocalCar.Engine.MaxFuelLiters) + lapBufferVar;
+        fuel.ClipMin(0);
+        return fuel;
+    }
+
+    private Color GetFuelBarColor()
+    {
+        float percentage = SimDataProvider.LocalCar.Engine.FuelLiters / SimDataProvider.LocalCar.Engine.MaxFuelLiters;
+
+        Color color = _config.Colors.FullColor;
+        if (percentage <= _config.Colors.MediumPercent) color = _config.Colors.MediumColor;
+        if (percentage <= _config.Colors.LowPercent) color = _config.Colors.LowColor;
+
+        return color;
+    }
+
+    private Color GetFuelTimeColor(double fuelTimeLeft, double stintDebug)
+    {
+        Color color;
+        if (stintDebug > -1)
+            color = fuelTimeLeft <= stintDebug ? Color.Red : Color.LimeGreen;
+        else
+            color = fuelTimeLeft <= SessionData.Instance.SessionTimeLeftSecs ? Color.Red : Color.LimeGreen;
+        return color;
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/LapDeltaBar/LapDeltaOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/LapDeltaBar/LapDeltaOverlay.cs
@@ -1,0 +1,187 @@
+﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.Util;
+using RaceElement.Util.SystemExtensions;
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Linq;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayLapDeltaBar;
+
+[Overlay(Name = "Lap Delta Bar (BETA)", Description = "A customizable Laptime Delta Bar (BETA)", OverlayType = OverlayType.Drive, Version = 1,
+    OverlayCategory = OverlayCategory.Lap,
+Authors = ["Reinier Klarenberg", "Dirk Wolf"])]
+internal sealed class LapDeltaOverlay : CommonAbstractOverlay
+{
+    private readonly LapTimeDeltaConfiguration _config = new();
+
+    private float _deltaStringWidth = -1;
+    private readonly Font _font;
+
+    private CachedBitmap _cachedBackground;
+    private CachedBitmap _cachedPositiveDelta;
+    private CachedBitmap _cachedNegativeDelta;
+
+    public LapDeltaOverlay(Rectangle rectangle) : base(rectangle, "Lap Delta Bar")
+    {
+        this.Width = _config.Bar.Width + 1;
+        this.Height = _config.Bar.Height + 1;
+
+        _font = FontUtil.FontSegoeMono(_config.Delta.FontSize);
+        this.Height += _font.Height * 1;
+
+        this.RefreshRateHz = 5;
+    }
+
+    public sealed override void SetupPreviewData()
+    {
+        SessionData.Instance.LapDeltaToSessionBestLapMs = -0137;
+    }
+
+    public sealed override void BeforeStart()
+    {
+        try
+        {
+            int cornerRadius = (int)(_config.Bar.Roundness * this.Scale);
+
+            _cachedBackground = new CachedBitmap((int)(_config.Bar.Width * this.Scale + 1), (int)(_config.Bar.Height * this.Scale + 1), g =>
+            {
+                Color bgColor = Color.FromArgb(185, 0, 0, 0);
+                HatchBrush hatchBrush = new(HatchStyle.LightUpwardDiagonal, bgColor, Color.FromArgb(bgColor.A - 50, bgColor));
+                g.FillRoundedRectangle(hatchBrush, new Rectangle(0, 0, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale)), cornerRadius);
+                g.DrawRoundedRectangle(new Pen(Color.Black, 1 * this.Scale), new Rectangle(0, 0, (int)(_config.Bar.Width * this.Scale), (int)(_config.Bar.Height * this.Scale)), cornerRadius);
+            });
+
+            _cachedPositiveDelta = new CachedBitmap((int)(_config.Bar.Width / 2 * this.Scale + 1), (int)(_config.Bar.Height * this.Scale + 1), g =>
+            {
+                Rectangle rect = new(0, 0, (int)(_config.Bar.Width / 2 * this.Scale), (int)(_config.Bar.Height * this.Scale));
+                using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(rect, cornerRadius, 0, 0, cornerRadius);
+                g.FillPath(new SolidBrush(Color.FromArgb(_config.Colors.SlowerOpacity, _config.Colors.SlowerColor)), path);
+            });
+
+            _cachedNegativeDelta = new CachedBitmap((int)(_config.Bar.Width / 2 * this.Scale + 1), (int)(_config.Bar.Height * this.Scale + 1), g =>
+            {
+                Rectangle rect = new(0, 0, (int)(_config.Bar.Width / 2 * this.Scale), (int)(_config.Bar.Height * this.Scale));
+                using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(rect, 0, cornerRadius, cornerRadius, 0);
+                g.FillPath(new SolidBrush(Color.FromArgb(_config.Colors.FasterOpacity, _config.Colors.FasterColor)), path);
+            });
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+        }
+    }
+
+    public sealed override void BeforeStop()
+    {
+        _cachedBackground?.Dispose();
+        _cachedPositiveDelta?.Dispose();
+        _cachedNegativeDelta?.Dispose();
+
+        _font?.Dispose();
+    }
+
+    public sealed override bool ShouldRender()
+    {        
+        if (_config.Delta.HideForRace && !this.IsRepositioning && SessionData.Instance.SessionType == RaceSessionType.Race)
+            return false;
+
+        /* TODO
+        if (_config.Delta.Spectator && RaceSessionState.IsSpectating(pageGraphics.PlayerCarID, broadCastRealTime.FocusedCarIndex))
+            return true; */
+
+        return base.ShouldRender();
+    }
+
+    public sealed override void Render(Graphics g)
+    {
+        _cachedBackground?.Draw(g, 0, 0, _config.Bar.Width, _config.Bar.Height);
+
+        float delta = GetDelta();
+        DrawDeltaBar(g, delta);
+        DrawDeltaText(g, delta);
+    }
+
+    private float GetDelta()
+    {
+        float delta = (float)SessionData.Instance.LapDeltaToSessionBestLapMs;
+        if (_config.Delta.Spectator)
+        {
+            int focusedIndex = SessionData.Instance.FocusedCarIndex;
+            if (SimDataProvider.Instance.IsSpectating(SessionData.Instance.PlayerCarIndex, focusedIndex))
+                lock (SessionData.Instance.Cars)
+                {
+                    if (SessionData.Instance.Cars.Any())
+                    {
+                        var car = SessionData.Instance.Cars.First(car => car.Key == focusedIndex);
+                        delta = car.Value.LapDeltaToSessionBestLap;
+                    }
+                }
+        }
+
+        delta.Clip(-_config.Delta.MaxDelta, _config.Delta.MaxDelta);
+
+        return delta;
+    }
+
+    private void DrawDeltaBar(Graphics g, float delta)
+    {
+        float halfBarWidth = _config.Bar.Width / 2f;
+
+        if (delta > 0)
+        {
+            float fillPercent = delta / _config.Delta.MaxDelta;
+            float drawWidth = halfBarWidth * fillPercent;
+            drawWidth.ClipMin(1);
+
+            g.SetClip(new Rectangle((int)(halfBarWidth - drawWidth), 0, (int)drawWidth, _config.Bar.Height));
+            _cachedPositiveDelta?.Draw(g, 0, 0, (int)halfBarWidth, _config.Bar.Height);
+            g.ResetClip();
+        }
+        else if (delta < 0)
+        {
+            float fillPercent = delta / -_config.Delta.MaxDelta;
+            float drawWidth = halfBarWidth * fillPercent;
+            drawWidth.ClipMin(1);
+
+            g.SetClip(new Rectangle((int)(halfBarWidth), 0, (int)drawWidth, _config.Bar.Height));
+            _cachedNegativeDelta?.Draw(g, (int)halfBarWidth, 0, (int)halfBarWidth, _config.Bar.Height);
+            g.ResetClip();
+        }
+    }
+
+    private void DrawDeltaText(Graphics g, float delta)
+    {
+        string currentDelta = $"{delta.ToString($"F{_config.Delta.Decimals}")}";
+        if (delta >= 0) currentDelta = "+" + currentDelta;
+
+        currentDelta.FillStart(_config.Delta.Decimals + 3, ' '); // (+3) = ('-' or '+') plus "0."
+
+        if (_deltaStringWidth < 0)
+            _deltaStringWidth = g.MeasureString(currentDelta, _font).Width;
+
+        int x = _config.Bar.Width / 2;
+        int y = _config.Bar.Height + 2;
+        DrawTextWithOutline(g, !SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value.CurrentLap.IsInvalid || 
+            SimDataProvider.Instance.IsSpectating(SessionData.Instance.PlayerCarIndex, SessionData.Instance.FocusedCarIndex) ? Color.White : Color.Red, currentDelta, x, y);
+    }
+
+    private void DrawTextWithOutline(Graphics g, Color textColor, string text, int x, int y)
+    {
+        Rectangle backgroundDimension = new((int)(x - _deltaStringWidth / 2), y, (int)(_deltaStringWidth), (int)(_font.Height * 0.9));
+
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        using SolidBrush backgroundBrush = new(Color.FromArgb(185, 0, 0, 0));
+        g.FillRoundedRectangle(backgroundBrush, backgroundDimension, (int)(2 * this.Scale));
+
+        g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+        g.TextContrast = 1;
+
+        g.DrawStringWithShadow(text, _font, textColor, new PointF(x - _deltaStringWidth / 2, y), 1.3f);
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/LapDeltaBar/LapTimeDeltaConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/LapDeltaBar/LapTimeDeltaConfiguration.cs
@@ -1,0 +1,63 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+using System.Drawing;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayLapDeltaBar;
+
+internal sealed class LapTimeDeltaConfiguration : OverlayConfiguration
+{
+    [ConfigGrouping("Delta", "Adjust how the delta is displayed")]
+    public DeltaGrouping Delta { get; init; } = new DeltaGrouping();
+    public sealed class DeltaGrouping
+    {
+        [ToolTip("Sets the maximum range in seconds for the delta bar.")]
+        [FloatRange(0.02f, 9.98f, 0.02f, 2)]
+        public float MaxDelta { get; init; } = 2;
+
+        [ToolTip("Sets the amount of decimals.")]
+        [IntRange(1, 3, 1)]
+        public int Decimals { get; init; } = 3;
+
+        [ToolTip("Sets the size of the font.")]
+        [IntRange(12, 30, 2)]
+        public int FontSize { get; init; } = 20;
+
+        [ToolTip("Hide the Lap Delta HUD during a Race session.")]
+        public bool HideForRace { get; init; } = false;
+
+        [ToolTip("Show the Lap Delta HUD when spectating.")]
+        public bool Spectator { get; init; } = true;
+    }
+
+    [ConfigGrouping("Bar", "Adjust bar behavior.")]
+    public BarGrouping Bar { get; init; } = new BarGrouping();
+    public sealed class BarGrouping
+    {
+        [ToolTip("Sets the Width of the Delta Bar.")]
+        [IntRange(180, 800, 10)]
+        public int Width { get; init; } = 300;
+
+        [ToolTip("Sets the Height of the Delta Bar.")]
+        [IntRange(20, 60, 2)]
+        public int Height { get; init; } = 32;
+
+        [IntRange(1, 9, 1)]
+        public int Roundness { get; init; } = 5;
+    }
+
+    [ConfigGrouping("Colors", "Adjust Colors.")]
+    public ColorsGrouping Colors { get; init; } = new ColorsGrouping();
+    public sealed class ColorsGrouping
+    {
+        [ToolTip("Sets the color when the delta is negative (faster).")]
+        public Color FasterColor { get; init; } = Color.FromArgb(255, Color.LimeGreen);
+        [IntRange(75, 255, 1)]
+        public int FasterOpacity { get; init; } = 255;
+
+        [ToolTip("Sets the color when the delta is positive (slower).")]
+        public Color SlowerColor { get; init; } = Color.FromArgb(255, Color.OrangeRed);
+        [IntRange(75, 255, 1)]
+        public int SlowerOpacity { get; init; } = 255;
+    }
+
+    public LapTimeDeltaConfiguration() => this.GenericConfiguration.AllowRescale = true;
+}

--- a/Race Element.HUD.Common/Overlays/Driving/Wind/WindOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Wind/WindOverlay.cs
@@ -1,0 +1,113 @@
+﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.OverlayUtil.Drawing;
+using RaceElement.HUD.Overlay.Util;
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace RaceElement.HUD.Common.Overlays.OverlayWind;
+
+[Overlay(Name = "Wind Direction (BETA)", Description = "Shows wind direction relative to car heading. For iRacing the wind direction is on the pit straight - not at the player's location.",
+    OverlayType = OverlayType.Drive,
+    OverlayCategory = OverlayCategory.Track,
+    Version = 1.00,
+Authors = ["Reinier Klarenberg"])]
+internal sealed class WindDirectionOverlay : CommonAbstractOverlay
+{
+    private readonly WindDirectionConfiguration _config = new();
+    private sealed class WindDirectionConfiguration : OverlayConfiguration
+    {
+        [ConfigGrouping("Wind", "Adjust settings related to the wind")]
+        public WindGrouping Wind { get; init; } = new WindGrouping();
+        public sealed class WindGrouping
+        {
+            [ToolTip("Below this wind speed(km/h) the hud will hide itself.")]
+            [FloatRange(0f, 10f, 0.5f, 1)]
+            public float ShowThreshold { get; init; } = 0.5f;
+        }
+
+        [ConfigGrouping("Shape", "Adjust the shape")]
+        public ShapeGrouping Shape { get; init; } = new ShapeGrouping();
+        public sealed class ShapeGrouping
+        {
+            [IntRange(100, 200, 1)]
+            public int Size { get; init; } = 120;
+        }
+
+        public WindDirectionConfiguration() => GenericConfiguration.AllowRescale = true;
+    }
+
+    private CachedBitmap _background;
+    private DrawableTextCell _textCell;
+    private const int padding = 50;
+
+    public WindDirectionOverlay(Rectangle rectangle) : base(rectangle, "Wind Direction")
+    {
+        Width = _config.Shape.Size;
+        Height = _config.Shape.Size;
+        RefreshRateHz = 8;
+    }
+
+    public sealed override void BeforeStart() => RenderBackground();
+
+    private void RenderBackground()
+    {
+        int scaledSize = (int)(_config.Shape.Size * Scale);
+
+        int scaledPadding = (int)(padding * this.Scale);
+        _background = new CachedBitmap(scaledSize + 1, scaledSize + 1, g =>
+        {
+            Rectangle rect = new(scaledPadding / 2, scaledPadding / 2, scaledSize - scaledPadding, scaledSize - scaledPadding);
+            using SolidBrush brush = new(Color.FromArgb(90, 0, 0, 0));
+            g.FillEllipse(brush, rect);
+            using Pen outlinePen = new(Color.FromArgb(165, 0, 0, 0), 18 * this.Scale);
+            g.DrawEllipse(outlinePen, new Rectangle(scaledPadding / 2, scaledPadding / 2, scaledSize - scaledPadding, scaledSize - scaledPadding));
+        });
+
+        Font font = FontUtil.FontSegoeMono(15f * Scale);
+        Rectangle rect = new(0, 0, scaledSize, scaledSize);
+        _textCell = new DrawableTextCell(rect, font);
+    }
+
+    public sealed override void BeforeStop()
+    {
+        _background?.Dispose();
+        _textCell?.Dispose();
+    }
+
+    public sealed override bool ShouldRender()
+    {
+        if (_config.Wind.ShowThreshold > SessionData.Instance.Weather.AirVelocity && !this.IsRepositioning)
+            return false;
+
+        return base.ShouldRender();
+    }
+
+    public sealed override void Render(Graphics g)
+    {
+        _background?.Draw(g, 0, 0, _config.Shape.Size, _config.Shape.Size);
+
+        double vaneAngle = SessionData.Instance.Weather.AirDirection;
+        double carDirection = 90 + (SimDataProvider.LocalCar.Physics.Heading * -180d) / Math.PI;
+        double relativeAngle = vaneAngle + carDirection;
+        
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        Rectangle rect = new(padding / 2, padding / 2, _config.Shape.Size - padding, _config.Shape.Size - padding);
+
+        // draw relative angle (blowing to)
+        using Pen limeGreenPen = new(Brushes.LimeGreen, 16);
+        g.DrawArc(limeGreenPen, rect, (float)relativeAngle - 4, 8);
+
+        // draw angle where the wind is coming from
+        using Pen redPen = new(Brushes.Red, 8);
+        g.DrawArc(redPen, rect, (float)relativeAngle - 180 - 35, 70);
+
+        _textCell?.UpdateText($"{SessionData.Instance.Weather.AirVelocity:F1}");
+        _textCell?.Draw(g, 1f / Scale);
+    }
+}


### PR DESCRIPTION
Adds ports for 3 Overlays:
- Wind direction. Note: iRacing only gives the wind direction on start/end of the track and not the player's location.
- Fuel. Fuel calculation is only done based on last lap. Other options will be ported later. This is in alpha state. Please check against the sim's builtin fuel estimation.
- delta. Difference to session's fastest lap.