### PR TITLE
AC1 opponent car telemetry

### DIFF
--- a/Race Element.Data/Common/SimulatorData/CarInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/CarInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Numerics;
 
 namespace RaceElement.Data.Common.SimulatorData;
 
@@ -50,6 +51,12 @@ public sealed class CarInfo
     /// </summary>
     /// Might not be available for all sims. 
     public float LapDeltaToSessionBestLap { get; set; }
+
+    /// <summary>
+    /// Location (x/y/z)
+    /// </summary>
+    /// Note: this is not provided by all sims.
+    public Vector3 Location { get; set; } = new();
 
     public CarInfo(int carIndex)
     {

--- a/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
+++ b/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
@@ -1,9 +1,11 @@
-﻿using RaceElement.Data.Common.SimulatorData;
+﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
 using RaceElement.Data.Games.AssettoCorsa.DataMapper;
 using RaceElement.Data.Games.AssettoCorsa.DataMapper.LocalCar;
 using RaceElement.Data.Games.AssettoCorsa.SharedMemory;
 using System.Drawing;
-using System.Drawing.Drawing2D;
+using System.Numerics;
+using System.Text;
 using static RaceElement.Data.Games.AssettoCorsa.SharedMemory.AcSharedMemory;
 
 namespace RaceElement.Data.Games.AssettoCorsa;
@@ -11,6 +13,10 @@ namespace RaceElement.Data.Games.AssettoCorsa;
 internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
 {
     static int lastPhysicsPacketId = -1;
+
+    // AC1 seems to have only one class. Or at least no race class info in the telemetry.
+    static string dummyCarClass = "Race";
+    List<string> classes = [ dummyCarClass ];
 
     public AssettoCorsa1DataProvider()
     {
@@ -26,6 +32,7 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
 
         var graphicsPage = AcSharedMemory.ReadGraphicsPageFile();
         var staticPage = AcSharedMemory.ReadStaticPageFile();
+        var crewChiefPage = AcSharedMemory.ReadCrewChiefPageFile();
 
         MapLocalCar(ref graphicsPage, ref physicsPage, ref localCar);
         LocalCarMapper.WithStaticPage(staticPage, localCar);
@@ -37,7 +44,81 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         GameDataMapper.WithStaticPage(staticPage, gameData);
         gameData.Name = GameName;
 
+        SessionData.Instance.PlayerCarIndex = graphicsPage.PlayerCarID;
+        SimDataProvider.LocalCar.CarModel.CarClass = dummyCarClass;
+
+        // TODO: AC1 does not provide delta info like ACC and iRacing. We need to try to calculate it.
+        // But that would mean we need some way of telling if the car is at 66% of track and has 12345ms from 12000ms expected at
+        // that precentage -> delta is 345ms.
+        // SessionData.Instance.LapDeltaToSessionBestLapMs 
+
+        MapEntryList(CrewChiefPage, GraphicsPage);
+
         lastPhysicsPacketId = physicsPage.PacketId;
+    }
+
+    private void MapEntryList(PageFileCrewChief crewChiefPage, PageFileGraphics graphicsPage)
+    {
+        for (int i = 0; i < crewChiefPage.numVehicles; i++)
+        {
+            AcsVehicleInfo vehicle = crewChiefPage.vehicle[i];
+            CarInfo carInfo = new CarInfo(i);
+            carInfo.Position = vehicle.carLeaderboardPosition;
+            carInfo.CupPosition = vehicle.carLeaderboardPosition;
+
+            if (vehicle.isCarInPit != 0)
+            {
+                carInfo.CarLocation = CarInfo.CarLocationEnum.Pitlane;
+            } else if (vehicle.isCarInPitline != 0)
+            {            
+                if (vehicle.spLineLength < 0.1F)
+                {
+                    carInfo.CarLocation = CarInfo.CarLocationEnum.PitExit;
+                }
+                else if (vehicle.spLineLength > 0.9F)
+                {
+
+                    carInfo.CarLocation = CarInfo.CarLocationEnum.PitEntry;
+                }
+            } else
+            {
+                carInfo.CarLocation = CarInfo.CarLocationEnum.Track;
+            }
+            carInfo.CarClass = dummyCarClass;
+            carInfo.RaceNumber = vehicle.carId;
+
+            LapInfo fastest = new LapInfo();
+            fastest.LaptimeMS = vehicle.bestLapMS;
+            carInfo.FastestLap = fastest;
+
+            LapInfo last = new LapInfo();
+            last.LaptimeMS = vehicle.lastLapTimeMS;
+            carInfo.LastLap = last;
+
+            LapInfo current = new LapInfo();
+            current.LaptimeMS = vehicle.currentLapTimeMS;
+            carInfo.CurrentLap = current;
+            carInfo.CurrentLap.IsInvalid = vehicle.currentLapInvalid != 0;
+
+            carInfo.TrackPercentCompleted = vehicle.spLineLength;           
+
+            DriverInfo driverInfo = new DriverInfo();
+            driverInfo.Name = Encoding.UTF8.GetString(vehicle.driverName);
+            carInfo.AddDriver(driverInfo);
+            SessionData.Instance.AddOrUpdateCar(i, carInfo);
+
+            // m/s -> km/h
+            carInfo.Kmh = (int) (vehicle.speedMS * 3.6F);
+            carInfo.Laps = vehicle.lapCount;
+            
+
+            carInfo.Location = new Vector3(vehicle.worldPosition.x, vehicle.worldPosition.y, vehicle.worldPosition.z);
+
+            carInfo.GapToClassLeaderMs = vehicle.currentLapTimeMS - crewChiefPage.vehicle[0].currentLapTimeMS;
+            carInfo.GapToRaceLeaderMs = carInfo.GapToClassLeaderMs;
+            // TODO: double-check
+            carInfo.GapToPlayerMs = vehicle.currentLapTimeMS - crewChiefPage.vehicle[SessionData.Instance.PlayerCarIndex].currentLapTimeMS;            
+        }
     }
 
 
@@ -50,23 +131,30 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
     }
 
     public override List<string> GetCarClasses()
-    {
-        throw new NotImplementedException();
+    {        
+        return classes;
     }
 
     public override Color GetColorForCarClass(string carClass)
     {
-        throw new NotImplementedException();
+        // There's only one class. 
+        return Color.AliceBlue;
     }
 
     public override bool HasTelemetry()
     {
-        return lastPhysicsPacketId > -1;
+        return lastPhysicsPacketId > 0;
     }
 
     
     internal override void Stop()
     {
         // No-op
+    }
+
+    override public  bool IsSpectating(int playerCarIndex, int focusedIndex)
+    {
+        // TODO: Can we spectate other cars in the pits in AC1?
+        return false;
     }
 }

--- a/Race Element.Data/Games/AssettoCorsa/DataMapper/LocalCarMapper.cs
+++ b/Race Element.Data/Games/AssettoCorsa/DataMapper/LocalCarMapper.cs
@@ -26,6 +26,7 @@ internal static partial class LocalCarMapper
     // -- Electronics activation
     [MapProperty(nameof(PageFilePhysics.TC), nameof(@LocalCarData.Electronics.TractionControlActivation))]
     [MapProperty(nameof(PageFilePhysics.Abs), nameof(@LocalCarData.Electronics.AbsActivation))]
+    [MapProperty(nameof(PageFilePhysics.Fuel), nameof(@LocalCarData.Engine.FuelLiters))]    
     private static partial void WithPhysicsPage(PageFilePhysics pagePhysics, LocalCarData commonData);
 
     internal static void AddPhysics(ref PageFilePhysics pagePhysics, ref LocalCarData commonData)
@@ -47,7 +48,8 @@ internal static partial class LocalCarMapper
 
     // Engine Data
     [MapProperty(nameof(PageFileStatic.MaxRpm), nameof(@LocalCarData.Engine.MaxRpm))]
+    [MapProperty(nameof(PageFileStatic.MaxFuel), nameof(@LocalCarData.Engine.MaxFuelLiters))]
     // Model Data
-    [MapProperty(nameof(PageFileStatic.CarModel), nameof(@LocalCarData.CarModel.GameName))]
+    [MapProperty(nameof(PageFileStatic.CarModel), nameof(@LocalCarData.CarModel.GameName))]    
     internal static partial void WithStaticPage(PageFileStatic pageStatic, LocalCarData commonData);
 }


### PR DESCRIPTION
This handles the AC1 opponent car telemetry that the crew chief plugin provides. The telemetry for the players car and the session was already working

In order for this to work, you need to install crew chief, start it once with AC1 to let it copy the plugin into the AC1 install folder (e.g. steamapps\common\assettocorsa\apps\python\CrewChiefEx). Once the plugin is installed, crew chief does not have to be running in order for the Race Element HUDs to use its telemetry.

Working HUDs are:
- input based HUDs: input values/trace, shift indicator, current gear
- track bar
- live standings (some issues with the interval calculation)

Not working:
- Delta: AC1 does not provide the delta and we need manual calculation.
