### PR TITLE
Relative (ALPAH) HUD and Standings and iRacing Provider  fixes

### DIFF
--- a/Race Element.Data/Common/DataUtil.cs
+++ b/Race Element.Data/Common/DataUtil.cs
@@ -1,0 +1,65 @@
+﻿
+using RaceElement.Data.Common.SimulatorData;
+
+namespace RaceElement.Data.Common
+{
+    public static class DataUtil
+    {
+
+        // Get the grap to the car in front.
+        // Restrictions
+        //   1) Does not take into account classes
+        //   2) Needs the sim to provide the speed of each car (Kmh)
+        public static string GetGapToCarInFront(List<KeyValuePair<int, CarInfo>> list, int i)
+        {
+            // inspired by acc bradcasting client
+
+            if (i < 1 || SessionData.Instance.Track.Length == 0) return "---";
+
+            var carInFront = list[i - 1].Value;
+            var currentCar = list[i].Value;
+            var splineDistance = Math.Abs(carInFront.TrackPercentCompleted - currentCar.TrackPercentCompleted);
+            while (splineDistance > 1f)
+                splineDistance -= 1f;
+            var gabMeters = splineDistance * SessionData.Instance.Track.Length;
+
+            if (currentCar.Kmh < 10)
+            {
+                return "---";
+            }
+            return $"{gabMeters / currentCar.Kmh * 3.6:F1}s ⇅";
+
+        }
+
+        /// <summary>
+        /// Format a lap time difference in milliseconds
+        /// </summary>        
+        public static String GetTimeDiff(int? LaptimeMS)
+        {
+            if (LaptimeMS == null || LaptimeMS == 0)
+            {
+                return "--:--.---";
+            }
+
+            TimeSpan lapTime = TimeSpan.FromMilliseconds((double)LaptimeMS);
+            if (lapTime.Minutes > 0)
+                return $"{lapTime:m\\:s\\.f}";
+            else
+                return $"{lapTime:s\\.f}";
+        }
+
+        /// <summary>
+        /// Format a lap time
+        /// </summary>
+        public static String GetLapTime(LapInfo lap)
+        {
+            if (lap == null || !lap.LaptimeMS.HasValue || lap.LaptimeMS < 0)
+            {
+                return "--:--.---";
+            }
+
+            TimeSpan lapTime = TimeSpan.FromMilliseconds(lap.LaptimeMS.Value);
+            return $"{lapTime:mm\\:ss\\.fff}";
+        }
+    }
+}

--- a/Race Element.Data/Common/SimulatorData/CarInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/CarInfo.cs
@@ -6,7 +6,7 @@ namespace RaceElement.Data.Common.SimulatorData;
 public sealed class CarInfo
 {
     public int CarIndex { get; }
-    
+
     public string TeamName { get; protected internal set; }
     public int RaceNumber { get; set; }
     public byte CupCategory { get; protected internal set; }
@@ -15,7 +15,7 @@ public sealed class CarInfo
 
     // Percentage 0.0f (0%) to 1.0f to (100%) of track completed. Might not read full 0% and 100% at start and end of lap and is therefore rounded in that case.
     public float TrackPercentCompleted { get; set; }
-    
+
 
     public CarLocationEnum CarLocation { get; set; }
 
@@ -39,7 +39,7 @@ public sealed class CarInfo
     // Gap to class leader
     public int GapToClassLeaderMs { get; set; }
     // Gap from player's car to others regardless of class
-    public int GapToPlayerMs { get; set; }    
+    public int GapToPlayerMs { get; set; }
 
     // lap number the car is in
     public int LapIndex{ get; set; }
@@ -49,7 +49,7 @@ public sealed class CarInfo
     /// <summary>
     /// Delta to driver's best session lap
     /// </summary>
-    /// Might not be available for all sims. 
+    /// Might not be available for all sims.
     public float LapDeltaToSessionBestLap { get; set; }
 
     /// <summary>

--- a/Race Element.Data/Common/SimulatorData/DriverInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/DriverInfo.cs
@@ -3,7 +3,7 @@
 public struct DriverInfo
 {
     // "Firstname Lastname" or whatever the sim wants displayed
-    public string Name { get; set; }    
+    public string Name { get; set; }
     public string ShortName { get; internal set; }
     // Something like Rookie/D-class/Gold.
     public string Category { get; internal set; }

--- a/Race Element.Data/Common/SimulatorData/LapInfo.cs
+++ b/Race Element.Data/Common/SimulatorData/LapInfo.cs
@@ -62,7 +62,6 @@ public sealed class LapInfo
         return $"{LaptimeMS,5}|{string.Join("|", Splits)}";
     }
 
-    
 public enum LapType
 {
     ERROR = 0,

--- a/Race Element.Data/Common/SimulatorData/SessionData.cs
+++ b/Race Element.Data/Common/SimulatorData/SessionData.cs
@@ -44,9 +44,9 @@ namespace RaceElement.Data.Common.SimulatorData
         public RaceSessionType SessionType { get; set; }
         public SessionPhase Phase { get; set; }
         public float LapDeltaToSessionBestLapMs { get; set; }
-        
+
         public bool IsSetupMenuVisible { get; set; }
-        public double SessionTimeLeftSecs { get; set; }        
+        public double SessionTimeLeftSecs { get; set; }
     }
 
     public sealed record TrackData

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -8,11 +8,19 @@ namespace RaceElement.Data.Games;
 
 public abstract class AbstractSimDataProvider
 {
-    // Get color to be used for a car class (GT3, GT4,..)
+    /// <summary>
+    /// Get color to be used for a car class (GT3, GT4,..)
+    /// </summary>
+    /// <param name="carClass">Name of the class. This depends on the sim.</param>
+    /// <returns>Color to be used for this car class in HUDs.</returns>
     abstract public Color GetColorForCarClass(String carClass);
 
-    // Get color to be used for a driver's category (Gold, A-License,..)
-    abstract public Color? GetColorForCategory(string category);
+    /// <summary>
+    /// Get color to be used for a driver's category (Gold, A-License,..)
+    /// </summary>
+    /// <param name="category">Sim dependent category name. E.g. in iRacing "A 2.7" for an A license driver, which returns blue. In ACC this could be "Gold" or an LFM license level.</param>
+    /// <returns>The color to be used for this category in the HUDs.</returns>
+    virtual public Color GetColorForCategory(string category) => Color.Gray;
     abstract public List<string> GetCarClasses();    
     abstract public void Update(ref LocalCarData localCar, ref SessionData sessionData, ref GameData gameData);
 

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -8,10 +8,12 @@ namespace RaceElement.Data.Games;
 
 public abstract class AbstractSimDataProvider
 {
+    // Get color to be used for a car class (GT3, GT4,..)
     abstract public Color GetColorForCarClass(String carClass);
-    abstract public List<string> GetCarClasses();
-    // TODO: Should we allow for both Update being driven and the simracing data provider doing its own polls? E.g. Update could return true if 
-    // all future updates can be handes w/o calls to Update
+
+    // Get color to be used for a driver's category (Gold, A-License,..)
+    abstract public Color? GetColorForCategory(string category);
+    abstract public List<string> GetCarClasses();    
     abstract public void Update(ref LocalCarData localCar, ref SessionData sessionData, ref GameData gameData);
 
     abstract internal void Stop();
@@ -23,5 +25,5 @@ public abstract class AbstractSimDataProvider
     public virtual bool IsSpectating(int playerCarIndex, int focusedIndex)
     {
         throw new NotImplementedException();
-    }
+    }        
 }

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -13,7 +13,7 @@ public abstract class AbstractSimDataProvider
     /// </summary>
     /// <param name="carClass">Name of the class. This depends on the sim.</param>
     /// <returns>Color to be used for this car class in HUDs.</returns>
-    abstract public Color GetColorForCarClass(String carClass);
+    virtual public Color GetColorForCarClass(String carClass) => Color.White;
 
     /// <summary>
     /// Get color to be used for a driver's category (Gold, A-License,..)

--- a/Race Element.Data/Games/AbstractSimDataProvider.cs
+++ b/Race Element.Data/Games/AbstractSimDataProvider.cs
@@ -21,7 +21,7 @@ public abstract class AbstractSimDataProvider
     /// <param name="category">Sim dependent category name. E.g. in iRacing "A 2.7" for an A license driver, which returns blue. In ACC this could be "Gold" or an LFM license level.</param>
     /// <returns>The color to be used for this category in the HUDs.</returns>
     virtual public Color GetColorForCategory(string category) => Color.Gray;
-    abstract public List<string> GetCarClasses();    
+    abstract public List<string> GetCarClasses();
     abstract public void Update(ref LocalCarData localCar, ref SessionData sessionData, ref GameData gameData);
 
     abstract internal void Stop();
@@ -33,5 +33,5 @@ public abstract class AbstractSimDataProvider
     public virtual bool IsSpectating(int playerCarIndex, int focusedIndex)
     {
         throw new NotImplementedException();
-    }        
+    }
 }

--- a/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
+++ b/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
@@ -157,4 +157,9 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         // TODO: Can we spectate other cars in the pits in AC1?
         return false;
     }
+
+    public override Color? GetColorForCategory(string category)
+    {
+        return Color.Gray;
+    }
 }

--- a/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
+++ b/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
@@ -158,8 +158,8 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         return false;
     }
 
-    public override Color? GetColorForCategory(string category)
+    public override Color GetColorForCategory(string category)
     {
-        return Color.Gray;
+        return Color.White;
     }
 }

--- a/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
+++ b/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
@@ -50,7 +50,7 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         // TODO: AC1 does not provide delta info like ACC and iRacing. We need to try to calculate it.
         // But that would mean we need some way of telling if the car is at 66% of track and has 12345ms from 12000ms expected at
         // that precentage -> delta is 345ms.
-        // SessionData.Instance.LapDeltaToSessionBestLapMs 
+        // SessionData.Instance.LapDeltaToSessionBestLapMs
 
         MapEntryList(CrewChiefPage, GraphicsPage);
 
@@ -70,7 +70,7 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
             {
                 carInfo.CarLocation = CarInfo.CarLocationEnum.Pitlane;
             } else if (vehicle.isCarInPitline != 0)
-            {            
+            {
                 if (vehicle.spLineLength < 0.1F)
                 {
                     carInfo.CarLocation = CarInfo.CarLocationEnum.PitExit;
@@ -100,7 +100,7 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
             carInfo.CurrentLap = current;
             carInfo.CurrentLap.IsInvalid = vehicle.currentLapInvalid != 0;
 
-            carInfo.TrackPercentCompleted = vehicle.spLineLength;           
+            carInfo.TrackPercentCompleted = vehicle.spLineLength;
 
             DriverInfo driverInfo = new DriverInfo();
             driverInfo.Name = Encoding.UTF8.GetString(vehicle.driverName);
@@ -110,14 +110,13 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
             // m/s -> km/h
             carInfo.Kmh = (int) (vehicle.speedMS * 3.6F);
             carInfo.Laps = vehicle.lapCount;
-            
 
             carInfo.Location = new Vector3(vehicle.worldPosition.x, vehicle.worldPosition.y, vehicle.worldPosition.z);
 
             carInfo.GapToClassLeaderMs = vehicle.currentLapTimeMS - crewChiefPage.vehicle[0].currentLapTimeMS;
             carInfo.GapToRaceLeaderMs = carInfo.GapToClassLeaderMs;
             // TODO: double-check
-            carInfo.GapToPlayerMs = vehicle.currentLapTimeMS - crewChiefPage.vehicle[SessionData.Instance.PlayerCarIndex].currentLapTimeMS;            
+            carInfo.GapToPlayerMs = vehicle.currentLapTimeMS - crewChiefPage.vehicle[SessionData.Instance.PlayerCarIndex].currentLapTimeMS;
         }
     }
 
@@ -131,13 +130,13 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
     }
 
     public override List<string> GetCarClasses()
-    {        
+    {
         return classes;
     }
 
     public override Color GetColorForCarClass(string carClass)
     {
-        // There's only one class. 
+        // There's only one class.
         return Color.AliceBlue;
     }
 
@@ -146,7 +145,7 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         return lastPhysicsPacketId > 0;
     }
 
-    
+
     internal override void Stop()
     {
         // No-op

--- a/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
+++ b/Race Element.Data/Games/AssettoCorsa/AssettoCorsa1DataProvider.cs
@@ -134,12 +134,6 @@ internal class AssettoCorsa1DataProvider : AbstractSimDataProvider
         return classes;
     }
 
-    public override Color GetColorForCarClass(string carClass)
-    {
-        // There's only one class.
-        return Color.AliceBlue;
-    }
-
     public override bool HasTelemetry()
     {
         return lastPhysicsPacketId > 0;

--- a/Race Element.Data/Games/AssettoCorsa/DataMapper/LocalCarMapper.cs
+++ b/Race Element.Data/Games/AssettoCorsa/DataMapper/LocalCarMapper.cs
@@ -26,7 +26,7 @@ internal static partial class LocalCarMapper
     // -- Electronics activation
     [MapProperty(nameof(PageFilePhysics.TC), nameof(@LocalCarData.Electronics.TractionControlActivation))]
     [MapProperty(nameof(PageFilePhysics.Abs), nameof(@LocalCarData.Electronics.AbsActivation))]
-    [MapProperty(nameof(PageFilePhysics.Fuel), nameof(@LocalCarData.Engine.FuelLiters))]    
+    [MapProperty(nameof(PageFilePhysics.Fuel), nameof(@LocalCarData.Engine.FuelLiters))]
     private static partial void WithPhysicsPage(PageFilePhysics pagePhysics, LocalCarData commonData);
 
     internal static void AddPhysics(ref PageFilePhysics pagePhysics, ref LocalCarData commonData)
@@ -50,6 +50,6 @@ internal static partial class LocalCarMapper
     [MapProperty(nameof(PageFileStatic.MaxRpm), nameof(@LocalCarData.Engine.MaxRpm))]
     [MapProperty(nameof(PageFileStatic.MaxFuel), nameof(@LocalCarData.Engine.MaxFuelLiters))]
     // Model Data
-    [MapProperty(nameof(PageFileStatic.CarModel), nameof(@LocalCarData.CarModel.GameName))]    
+    [MapProperty(nameof(PageFileStatic.CarModel), nameof(@LocalCarData.CarModel.GameName))]
     internal static partial void WithStaticPage(PageFileStatic pageStatic, LocalCarData commonData);
 }

--- a/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
+++ b/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
@@ -18,11 +18,6 @@ namespace RaceElement.Data.Games.RaceRoom
             return [];
         }
 
-        public override Color GetColorForCarClass(string carClass)
-        {
-            return Color.White;
-        }        
-
         public override bool HasTelemetry()
         {
             return false;

--- a/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
+++ b/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
@@ -23,6 +23,12 @@ namespace RaceElement.Data.Games.RaceRoom
             return Color.White;
         }
 
+        public override Color? GetColorForCategory(string category)
+        {
+            // TODO: if RRE supports multiple classes with different colors in HUDs.
+            return Color.White;
+        }
+
         public override bool HasTelemetry()
         {
             return false;

--- a/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
+++ b/Race Element.Data/Games/RaceRoom/RaceRoomDataProvider.cs
@@ -21,13 +21,7 @@ namespace RaceElement.Data.Games.RaceRoom
         public override Color GetColorForCarClass(string carClass)
         {
             return Color.White;
-        }
-
-        public override Color? GetColorForCategory(string category)
-        {
-            // TODO: if RRE supports multiple classes with different colors in HUDs.
-            return Color.White;
-        }
+        }        
 
         public override bool HasTelemetry()
         {

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -24,7 +24,7 @@ namespace RaceElement.Data.Games.iRacing
 
         private IRSDKSharper _iRacingSDK;
         private int lastSessionNumber = -1;
-       
+
         private int lastLapIndex = 0;
         private float lastLapFuelLevelLiters = 0;
         private float lastLapFuelConsumption = 0;
@@ -63,12 +63,12 @@ namespace RaceElement.Data.Games.iRacing
 
         public CarLeftRight SpotterCallout { get; private set; }
 
-        public IRacingDataProvider() {                    
+        public IRacingDataProvider() {
             if (_iRacingSDK == null)
             {
                 _iRacingSDK = new IRSDKSharper
                 {
-                    UpdateInterval = 1, // update every 1/60 second                    
+                    UpdateInterval = 1, // update every 1/60 second
                 };
                 _iRacingSDK.OnTelemetryData += OnTelemetryData;
                 _iRacingSDK.OnSessionInfo += OnSessionInfo;
@@ -76,7 +76,7 @@ namespace RaceElement.Data.Games.iRacing
                 _iRacingSDK.OnDisconnected += OnDisconnected;
 
                 _iRacingSDK.Start();
-            }                
+            }
         }
 
         /// <summary>
@@ -95,11 +95,11 @@ namespace RaceElement.Data.Games.iRacing
             carIdxF2TimeDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxF2Time"];
             playerCarPositionDatum = _iRacingSDK.Data.TelemetryDataProperties["PlayerCarPosition"];
             fuelLevelDatum = _iRacingSDK.Data.TelemetryDataProperties["FuelLevel"];
-            rPMDatum = _iRacingSDK.Data.TelemetryDataProperties["RPM"];            
+            rPMDatum = _iRacingSDK.Data.TelemetryDataProperties["RPM"];
             speedDatum = _iRacingSDK.Data.TelemetryDataProperties["Speed"];
             yawNorthDatum = _iRacingSDK.Data.TelemetryDataProperties["YawNorth"];
             pitchDatum = _iRacingSDK.Data.TelemetryDataProperties["Pitch"];
-            rollDatum = _iRacingSDK.Data.TelemetryDataProperties["Roll"];            
+            rollDatum = _iRacingSDK.Data.TelemetryDataProperties["Roll"];
             gearDatum = _iRacingSDK.Data.TelemetryDataProperties["Gear"];
             brakeDatum = _iRacingSDK.Data.TelemetryDataProperties["Brake"];
             throttleDatum = _iRacingSDK.Data.TelemetryDataProperties["Throttle"];
@@ -135,12 +135,12 @@ namespace RaceElement.Data.Games.iRacing
         /// </summary>
         /// The telemetry variables are documented here: https://sajax.github.io/irsdkdocs/telemetry/
         private void OnTelemetryData()
-        {         
+        {
            if (!_iRacingSDK.IsConnected && _iRacingSDK.IsStarted) {
             return;
            }
            if (_iRacingSDK.Data.SessionInfo == null)
-           { 
+           {
             Debug.WriteLine("No session info");
                 return;
            }
@@ -170,12 +170,12 @@ namespace RaceElement.Data.Games.iRacing
                     }
                     carInfo.Position = _iRacingSDK.Data.GetInt(carIdxPositionDatum, iRSDKindex);
                     carInfo.CupPosition = _iRacingSDK.Data.GetInt(carIdxClassPositionDatum, iRSDKindex);
-                    
+
                     carInfo.TrackPercentCompleted = _iRacingSDK.Data.GetFloat(carIdxLapDistPctDatum, iRSDKindex);
 
                     // Track surface: NotInWorld, OffTrack, InPitStall, AproachingPits, OnTrack
                     // TODO: we can still distinguish between CarLocationEnum.Pitlane/PitEntry/Exit
-                    TrkLoc trackSurface = (TrkLoc)_iRacingSDK.Data.GetInt(carIdxTrackSurfaceDatum, iRSDKindex);                    
+                    TrkLoc trackSurface = (TrkLoc)_iRacingSDK.Data.GetInt(carIdxTrackSurfaceDatum, iRSDKindex);
                     if (_iRacingSDK.Data.GetBool(carIdxOnPitRoadDatum, iRSDKindex)) {
                         carInfo.CarLocation = CarInfo.CarLocationEnum.Pitlane;
                     } else if (trackSurface == TrkLoc.NotInWorld )
@@ -183,19 +183,19 @@ namespace RaceElement.Data.Games.iRacing
                         carInfo.CarLocation = CarInfo.CarLocationEnum.NONE;
                     } else
                     {
-                        carInfo.CarLocation = CarInfo.CarLocationEnum.Track;                        
-                    }                                        
-                    
-                    carInfo.CurrentDriverIndex = 0;                                        
+                        carInfo.CarLocation = CarInfo.CarLocationEnum.Track;
+                    }
+
+                    carInfo.CurrentDriverIndex = 0;
                     carInfo.LapIndex = _iRacingSDK.Data.GetInt(carIdxLapDatum, iRSDKindex);
-                    
+
 
                     LapInfo lapInfo = new LapInfo();
                     carInfo.CurrentLap = lapInfo;
                     if (trackSurface == TrkLoc.OffTrack)
                     {
                         // TODO: we need to reset this for other cars. Right now we only do so for player's car
-                        carInfo.CurrentLap.IsInvalid = true;                         
+                        carInfo.CurrentLap.IsInvalid = true;
                     }
 
                     // "CarIdxF2Time: Race time behind leader or fastest lap time otherwise"
@@ -207,8 +207,8 @@ namespace RaceElement.Data.Games.iRacing
                     {
                         classLeaderTrackPositionTimeDict[carInfo.CarClass] = trackPositionTime;
                     }
-                    carInfo.GapToRaceLeaderMs = (int)(trackPositionTime * 1000.0);                                        
-                    
+                    carInfo.GapToRaceLeaderMs = (int)(trackPositionTime * 1000.0);
+
                     carInfo.GapToPlayerMs = GetGapToPlayerMs(iRSDKindex, SessionData.Instance.PlayerCarIndex);
                 }
 
@@ -219,7 +219,7 @@ namespace RaceElement.Data.Games.iRacing
                     var position = _iRacingSDK.Data.GetInt(carIdxClassPositionDatum, carInfo.CarIndex);
                     float f2Time = _iRacingSDK.Data.GetFloat(carIdxF2TimeDatum, carInfo.CarIndex);
                     if (position <= 0) continue;
-                                        
+
                     carInfo.GapToClassLeaderMs = 0;
                     // special case for multi-class qualifying
                     if (classLeaderTrackPositionTimeDict.ContainsKey(carInfo.CarClass))
@@ -235,7 +235,7 @@ namespace RaceElement.Data.Games.iRacing
                 int playerCarIdx = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarIdx;
                 CarInfo playerCarInfo = SessionData.Instance.Cars[playerCarIdx].Value;
                 localCar.Race.GlobalPosition = _iRacingSDK.Data.GetInt(playerCarPositionDatum);
-                
+
                 localCar.Engine.FuelLiters = _iRacingSDK.Data.GetFloat(fuelLevelDatum);
                 int lapIndex = playerCarInfo.LapIndex;
                 // check if we completed a lap
@@ -246,7 +246,7 @@ namespace RaceElement.Data.Games.iRacing
                     playerCarInfo.CurrentLap.IsInvalid = false;
                     lastLapIndex = lapIndex;
                     Debug.WriteLine("new lap lastLapFuelConsumption {0} lastLapFuelLevelLiters {1}", lastLapFuelConsumption, lastLapFuelLevelLiters);
-                }                
+                }
 
                 localCar.Engine.Rpm = (int)_iRacingSDK.Data.GetFloat(rPMDatum);
                 // m/s -> km/h
@@ -260,36 +260,36 @@ namespace RaceElement.Data.Games.iRacing
                 localCar.Inputs.Throttle = _iRacingSDK.Data.GetFloat(throttleDatum);
                 localCar.Inputs.Steering = _iRacingSDK.Data.GetFloat(steeringWheelAngleDatum);
 
-                
+
                 SessionData.Instance.LapDeltaToSessionBestLapMs = _iRacingSDK.Data.GetFloat(lapDeltaToSessionBestLapDatum);
-                
+
                 SessionData.Instance.Weather.AirTemperature = _iRacingSDK.Data.GetFloat(airTempDatum);
                 SessionData.Instance.Weather.AirVelocity = _iRacingSDK.Data.GetFloat(windVelDatum) * 3.6f;
                 SessionData.Instance.Weather.AirDirection = _iRacingSDK.Data.GetFloat(windDirDatum);
 
                 SessionData.Instance.Track.Temperature = _iRacingSDK.Data.GetFloat(trackTempCrewDatum);
 
-                // Fuel telemetry and fuel consumption calc. This is using the last lap                
+                // Fuel telemetry and fuel consumption calc. This is using the last lap
                 var fuelLevelPercent = _iRacingSDK.Data.GetFloat(fuelLevelPctDatum);
                 localCar.Engine.MaxFuelLiters = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarFuelMaxLtr;
 
                 // TODO: iRacing gives unreasonable values for fuelUseKgPerHour. At least off by a factor 10
                 // We keep track of fuel usage in the last lap until this is worked out.
-                /* var fuelUseKgPerHour = _iRacingSDK.Data.GetFloat("FuelUsePerHour");                 
+                /* var fuelUseKgPerHour = _iRacingSDK.Data.GetFloat("FuelUsePerHour");
                 float fuelKgPerLtr = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarFuelKgPerLtr;
                 float lapsPerHour = (float)TimeSpan.FromMinutes(60).TotalMilliseconds /
                     ((float) SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value.LastLap.LaptimeMS);
                 float fuelKgPerLap = fuelUseKgPerHour / lapsPerHour;
-                float fuelLitersXLap = fuelKgPerLap / fuelKgPerLtr; 
+                float fuelLitersXLap = fuelKgPerLap / fuelKgPerLtr;
                 Debug.WriteLine("Fuel kgPerLr {0} KgPerHour {1} lapsPerHour {2} kgPerLap {3} LitersXLap {4} ", fuelKgPerLtr, fuelUseKgPerHour, lapsPerHour, fuelKgPerLap, fuelLitersXLap);
                 */
 
-                localCar.Engine.FuelLitersXLap = lastLapFuelConsumption; 
-                localCar.Engine.FuelEstimatedLaps = localCar.Engine.FuelLiters / localCar.Engine.FuelLitersXLap;                
+                localCar.Engine.FuelLitersXLap = lastLapFuelConsumption;
+                localCar.Engine.FuelEstimatedLaps = localCar.Engine.FuelLiters / localCar.Engine.FuelLitersXLap;
 
                 // ABS. We don't seem to get any other info for localCar.Electronics such as TC and engine map.
                 // There is brake bias in CarSetupModel, but it is unclear if that would be updated when the user changes it when driving.
-                localCar.Electronics.AbsActivation = _iRacingSDK.Data.GetBool(brakeABSactiveDatum) ? 1.0F : 0.0F; 
+                localCar.Electronics.AbsActivation = _iRacingSDK.Data.GetBool(brakeABSactiveDatum) ? 1.0F : 0.0F;
 
                 // TODO : public int DriverIncidentCount { get; set; } and other incident info (CurDriverIncidentCount , TeamIncidentCount, ..)
 
@@ -310,7 +310,7 @@ namespace RaceElement.Data.Games.iRacing
                         Debug.WriteLine("Unknown session type " + sessionType);
                         SessionData.Instance.SessionType = RaceSessionType.Race; break;
                 }
-                
+
                 IRacingSdkEnum.SessionState sessionState = (SessionState)_iRacingSDK.Data.GetInt(sessionStateDatum);
                 switch (sessionState)
                 {
@@ -333,7 +333,7 @@ namespace RaceElement.Data.Games.iRacing
                         break;
                 }
 
-                
+
                 if (sessionNumber != lastSessionNumber)
                 {
                     Debug.WriteLine("session change. curr# {0} last# {1} new state {2} type {3}", sessionNumber, lastSessionNumber, sessionState, sessionType);
@@ -341,7 +341,7 @@ namespace RaceElement.Data.Games.iRacing
                     SimDataProvider.CallSessionPhaseChanged(this, SessionData.Instance.Phase);
                     lastSessionNumber = sessionNumber;
                 }
-                SessionData.Instance.SessionTimeLeftSecs = _iRacingSDK.Data.GetDouble(sessionTimeRemainDatum);                
+                SessionData.Instance.SessionTimeLeftSecs = _iRacingSDK.Data.GetDouble(sessionTimeRemainDatum);
                 // TODO more session info SessionLapsRemain, SessionLapsRemainEx, SessionTimeTotal, SessionLapsTotal, SessionTimeOfDay
 
                 SpotterCallout = (CarLeftRight)_iRacingSDK.Data.GetInt(carLeftRightDatum);
@@ -390,7 +390,7 @@ namespace RaceElement.Data.Games.iRacing
 
             LocalCarData localCar = SimDataProvider.LocalCar;
             localCar.Engine.MaxRpm = (int)_iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarSLLastRPM;
-            
+
             DriverModel driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[SessionData.Instance.PlayerCarIndex];
             localCar.Race.CarNumber = driverModel.CarNumberRaw;
             localCar.CarModel.CarClass = driverModel.CarClassShortName != null ? driverModel.CarClassShortName : driverModel.CarScreenNameShort;
@@ -414,7 +414,7 @@ namespace RaceElement.Data.Games.iRacing
 
             // dictionary from carIdx to results index
             Dictionary<int, int> carIndexResults = new Dictionary<int, int>();
-             
+
             for (int resultsPosIndex = 0; resultsPosIndex < session.ResultsPositions.Count; resultsPosIndex++)
             {
                 PositionModel result = session.ResultsPositions[resultsPosIndex];
@@ -436,11 +436,11 @@ namespace RaceElement.Data.Games.iRacing
             }*/
 
             for (var index = 0; index < _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers.Count; index++)
-            {                
+            {
                 driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index];
                 if (driverModel.CarIsPaceCar > 0) continue;
-                
-                CarInfo carInfo = TryAddDriver(driverModel);                                      
+
+                CarInfo carInfo = TryAddDriver(driverModel);
                 carInfo.RaceNumber = driverModel.CarNumberRaw;
 
                 if (carIndexResults.ContainsKey(index))
@@ -456,7 +456,7 @@ namespace RaceElement.Data.Games.iRacing
                 } /* else
                 {
                     Debug.WriteLine("carIndexResults does not contain carArrayINdex {0} carIdx {1}", index, driverModel.CarIdx);
-                }    */            
+                }    */
 
                 // For multi-make classes like GT4/GT3, we use CarClassShortName otherwise (e.g. MX5 or GR86) we use CarScreenNameShort
                 carInfo.CarClass = driverModel.CarClassShortName;
@@ -466,7 +466,7 @@ namespace RaceElement.Data.Games.iRacing
                 }
                 carInfo.IsSpectator = driverModel.IsSpectator == 1;
 
-                AddCarClassEntry(carInfo.CarClass, driverModel.CarClassColor);                
+                AddCarClassEntry(carInfo.CarClass, driverModel.CarClassColor);
 
                 // TODO: add qualifying time info
             }
@@ -512,12 +512,12 @@ namespace RaceElement.Data.Games.iRacing
         // for debugging
         private void PrintAllCarInfo()
         {
-            
+
             for (var index = 0; index < SessionData.Instance.Cars.Count; index++)
             {
                 CarInfo carInfo = SessionData.Instance.Cars[index].Value;
-                Debug.WriteLine("Car " + index + " #" + carInfo.RaceNumber + " " + carInfo.Drivers[0].Name + " pos: " + carInfo.CupPosition + " GL: " + carInfo.GapToClassLeaderMs + " GP:" + carInfo.GapToPlayerMs);                
-            }               
+                Debug.WriteLine("Car " + index + " #" + carInfo.RaceNumber + " " + carInfo.Drivers[0].Name + " pos: " + carInfo.CupPosition + " GL: " + carInfo.GapToClassLeaderMs + " GP:" + carInfo.GapToPlayerMs);
+            }
         }
 
         public override void SetupPreviewData()
@@ -542,7 +542,7 @@ namespace RaceElement.Data.Games.iRacing
             car1.TrackPercentCompleted = 10.0f;
             car1.Position = 1;
             car1.CarLocation = CarInfo.CarLocationEnum.Track;
-            car1.CurrentDriverIndex = 0;            
+            car1.CurrentDriverIndex = 0;
             car1.Kmh = 140;
             car1.CupPosition = 1;
             car1.RaceNumber = 17;
@@ -567,7 +567,7 @@ namespace RaceElement.Data.Games.iRacing
             car2.TrackPercentCompleted = car1.TrackPercentCompleted + (1.0F / ((float) SessionData.Instance.Track.Length));
             car2.Position = 2;
             car2.CarLocation = CarInfo.CarLocationEnum.Track;
-            car2.CurrentDriverIndex = 0;            
+            car2.CurrentDriverIndex = 0;
             car2.Kmh = 160;
             car2.CupPosition = 2;
             car2.RaceNumber = 5;
@@ -614,18 +614,18 @@ namespace RaceElement.Data.Games.iRacing
             AddCarClassEntry("F1", "0xffffff");
 
             SpotterCallout = CarLeftRight.CarLeft;
-            
+
             hasTelemetry = true; // TODO: will this work when we have real telemetry? And is this sample telemetry valid for all sim providers?
         }
 
-        // Gap calculation according to https://github.com/lespalt/iRon 
+        // Gap calculation according to https://github.com/lespalt/iRon
         // TODO:  Gap should be showing in the shortest direction. e.g. -15sec instead of +50sec
         private int GetGapToPlayerMs(int index, int playerCarIdx)
-        {            
+        {
             float bestForPlayer = _iRacingSDK.Data.GetFloat("CarIdxBestLapTime", playerCarIdx); // TODO: this might not work if the driver is out of e.g. practice
             if (bestForPlayer == 0)
                 bestForPlayer = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[playerCarIdx].CarClassEstLapTime;
-            
+
             float C = _iRacingSDK.Data.GetFloat("CarIdxEstTime", index);
             float S = _iRacingSDK.Data.GetFloat("CarIdxEstTime", playerCarIdx);
 
@@ -668,7 +668,7 @@ namespace RaceElement.Data.Games.iRacing
 
 
         public override void Update(ref LocalCarData localCar, ref SessionData sessionData, ref GameData gameData)
-        {            
+        {
             gameData.Name = Game.iRacing.ToShortName();
             // Updates for iRacing are done with event handlers and don't need to be driven by Race Element with this Update method
         }
@@ -682,12 +682,12 @@ namespace RaceElement.Data.Games.iRacing
         public override bool HasTelemetry()
         {
             return hasTelemetry;
-        }        
+        }
 
         private void AddCarClassEntry(string carClass, string aCarClassColor)
-        {            
+        {
             carClasses.Add(carClass);
-            carClassColor.TryAdd(carClass, MapCarClassColor(aCarClassColor)); 
+            carClassColor.TryAdd(carClass, MapCarClassColor(aCarClassColor));
         }
 
         private Color MapCarClassColor(string carClassColor)
@@ -706,19 +706,19 @@ namespace RaceElement.Data.Games.iRacing
 
         public CarLeftRight GetSpotterCallout()
         {
-            return SpotterCallout;            
+            return SpotterCallout;
         }
 
         override public bool IsSpectating(int playerCarIndex, int focusedIndex)
         {
-            // TODO We need to test how spotting team mates works in a multi-driver team race. 
+            // TODO We need to test how spotting team mates works in a multi-driver team race.
             // E.g. what telemetry is available
             return false;
         }
 
         /// <summary>
         /// iRacing license class to color mapping.
-        /// </summary>        
+        /// </summary>
         public override Color GetColorForCategory(string category)
         {
             if (category.StartsWith("A"))
@@ -736,7 +736,7 @@ namespace RaceElement.Data.Games.iRacing
             else if (category.StartsWith("D"))
             {
                 return Color.Orange;
-            } else if (category.StartsWith("R")) 
+            } else if (category.StartsWith("R"))
             {
                 return Color.Red;
             } else
@@ -747,5 +747,5 @@ namespace RaceElement.Data.Games.iRacing
         }
     }
 
-    
+
 }

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -612,7 +612,7 @@ namespace RaceElement.Data.Games.iRacing
             car3driver0.Category = "B 2.7";
             car3.AddDriver(car3driver0);
 
-            AddCarClassEntry("F1", "TODOPrevieColor");
+            AddCarClassEntry("F1", "0xffffff");
 
             SpotterCallout = CarLeftRight.CarLeft;
             

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -6,7 +6,7 @@ using RaceElement.Data.Common;
 using System.Drawing;
 using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkEnum;
 using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.SessionInfoModel.SessionModel;
-using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.SessionInfoModel
+using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.SessionInfoModel;
 
 // https://github.com/mherbold/IRSDKSharper
 // https://sajax.github.io/irsdkdocs/telemetry/
@@ -702,6 +702,7 @@ namespace RaceElement.Data.Games.iRacing
             // Convert hex string to Color
             Color color = ColorTranslator.FromHtml("#" + carClassColor);
             if (color == null) return Color.White;
+            return color;
         }
 
         public CarLeftRight GetSpotterCallout()

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -720,7 +720,7 @@ namespace RaceElement.Data.Games.iRacing
         /// <summary>
         /// iRacing license class to color mapping.
         /// </summary>        
-        public override Color? GetColorForCategory(string category)
+        public override Color GetColorForCategory(string category)
         {
             if (category.StartsWith("A"))
             {

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -5,6 +5,8 @@ using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.DriverInfo
 using RaceElement.Data.Common;
 using System.Drawing;
 using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkEnum;
+using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.SessionInfoModel.SessionModel;
+using static RaceElement.Data.Games.iRacing.SDK.IRacingSdkSessionInfo.SessionInfoModel
 
 // https://github.com/mherbold/IRSDKSharper
 // https://sajax.github.io/irsdkdocs/telemetry/
@@ -15,7 +17,7 @@ namespace RaceElement.Data.Games.iRacing
     public class IRacingDataProvider : AbstractSimDataProvider
     {
         Dictionary<string, Color> carClassColor = [];
-        HashSet<string> carClasses = null;
+        HashSet<string> carClasses = new HashSet<string>();
 
         bool hasTelemetry = false;
 
@@ -25,6 +27,38 @@ namespace RaceElement.Data.Games.iRacing
         private int lastLapIndex = 0;
         private float lastLapFuelLevelLiters = 0;
         private float lastLapFuelConsumption = 0;
+
+        private IRacingSdkDatum carIdxLapDistPctDatum;
+        private IRacingSdkDatum carIdxPositionDatum;
+        private IRacingSdkDatum carIdxClassPositionDatum;
+        private IRacingSdkDatum carIdxTrackSurfaceDatum;
+        private IRacingSdkDatum carIdxOnPitRoadDatum;
+        private IRacingSdkDatum carIdxLapDatum;
+        private IRacingSdkDatum carIdxEstTimeDatum;
+        private IRacingSdkDatum carIdxF2TimeDatum;
+        private IRacingSdkDatum playerCarPositionDatum;
+        private IRacingSdkDatum fuelLevelDatum;
+        private IRacingSdkDatum rPMDatum;
+        private IRacingSdkDatum speedDatum;
+        private IRacingSdkDatum yawNorthDatum;
+        private IRacingSdkDatum pitchDatum;
+        private IRacingSdkDatum rollDatum;
+        private IRacingSdkDatum gearDatum;
+        private IRacingSdkDatum brakeDatum;
+        private IRacingSdkDatum throttleDatum;
+        private IRacingSdkDatum steeringWheelAngleDatum;
+        private IRacingSdkDatum lapDeltaToSessionBestLapDatum;
+        private IRacingSdkDatum airTempDatum;
+        private IRacingSdkDatum windVelDatum;
+        private IRacingSdkDatum windDirDatum;
+        private IRacingSdkDatum trackTempCrewDatum;
+        private IRacingSdkDatum fuelLevelPctDatum;
+        private IRacingSdkDatum sessionTimeRemainDatum;
+        private IRacingSdkDatum carLeftRightDatum;
+        private IRacingSdkDatum brakeABSactiveDatum;
+        private IRacingSdkDatum sessionNumDatum;
+        private IRacingSdkDatum sessionStateDatum;
+        private bool datumsInitialized = false;
 
         public CarLeftRight SpotterCallout { get; private set; }
 
@@ -38,9 +72,55 @@ namespace RaceElement.Data.Games.iRacing
                 _iRacingSDK.OnTelemetryData += OnTelemetryData;
                 _iRacingSDK.OnSessionInfo += OnSessionInfo;
                 _iRacingSDK.OnStopped += OnStopped;
+                _iRacingSDK.OnDisconnected += OnDisconnected;
 
                 _iRacingSDK.Start();
             }                
+        }
+
+        /// <summary>
+        /// Datums are used for iRacing telemetry access with doing the "string telemetry name" lookup only once.
+        /// </summary>
+        private void InitDatums()
+        {
+            if (datumsInitialized) return;
+            carIdxLapDistPctDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxLapDistPct"];
+            carIdxPositionDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxPosition"];
+            carIdxClassPositionDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxClassPosition"];
+            carIdxTrackSurfaceDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxTrackSurface"];
+            carIdxOnPitRoadDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxOnPitRoad"];
+            carIdxLapDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxLap"];
+            carIdxEstTimeDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxEstTime"];
+            carIdxF2TimeDatum = _iRacingSDK.Data.TelemetryDataProperties["CarIdxF2Time"];
+            playerCarPositionDatum = _iRacingSDK.Data.TelemetryDataProperties["PlayerCarPosition"];
+            fuelLevelDatum = _iRacingSDK.Data.TelemetryDataProperties["FuelLevel"];
+            rPMDatum = _iRacingSDK.Data.TelemetryDataProperties["RPM"];            
+            speedDatum = _iRacingSDK.Data.TelemetryDataProperties["Speed"];
+            yawNorthDatum = _iRacingSDK.Data.TelemetryDataProperties["YawNorth"];
+            pitchDatum = _iRacingSDK.Data.TelemetryDataProperties["Pitch"];
+            rollDatum = _iRacingSDK.Data.TelemetryDataProperties["Roll"];            
+            gearDatum = _iRacingSDK.Data.TelemetryDataProperties["Gear"];
+            brakeDatum = _iRacingSDK.Data.TelemetryDataProperties["Brake"];
+            throttleDatum = _iRacingSDK.Data.TelemetryDataProperties["Throttle"];
+            steeringWheelAngleDatum = _iRacingSDK.Data.TelemetryDataProperties["SteeringWheelAngle"];
+            lapDeltaToSessionBestLapDatum = _iRacingSDK.Data.TelemetryDataProperties["LapDeltaToSessionBestLap"];
+            airTempDatum = _iRacingSDK.Data.TelemetryDataProperties["AirTemp"];
+            windVelDatum = _iRacingSDK.Data.TelemetryDataProperties["WindVel"];
+            windDirDatum = _iRacingSDK.Data.TelemetryDataProperties["WindDir"];
+            trackTempCrewDatum = _iRacingSDK.Data.TelemetryDataProperties["TrackTempCrew"];
+            fuelLevelPctDatum = _iRacingSDK.Data.TelemetryDataProperties["FuelLevelPct"];
+            sessionTimeRemainDatum = _iRacingSDK.Data.TelemetryDataProperties["SessionTimeRemain"];
+            carLeftRightDatum = _iRacingSDK.Data.TelemetryDataProperties["CarLeftRight"];
+            brakeABSactiveDatum = _iRacingSDK.Data.TelemetryDataProperties["BrakeABSactive"];
+            sessionNumDatum = _iRacingSDK.Data.TelemetryDataProperties["SessionNum"];
+            sessionStateDatum = _iRacingSDK.Data.TelemetryDataProperties["SessionState"];
+
+            datumsInitialized = true;
+        }
+
+        private void OnDisconnected()
+        {
+            hasTelemetry = false;
         }
 
         private void OnStopped()
@@ -68,59 +148,48 @@ namespace RaceElement.Data.Games.iRacing
             Debug.WriteLine("No SessionData.Instance.Cars or DriverInfo");
             return;
            };
-            
+
+            InitDatums();
+
             try
             {
                 // for each class, the time to get to the track position for the leader in that class
                 Dictionary<string, float> classLeaderTrackPositionTimeDict = new Dictionary<string, float>();
-                
-                for (var index = 0; index < SessionData.Instance.Cars.Count; index++)
-                {                                    
-                    CarInfo carInfo = SessionData.Instance.Cars[index].Value;
-                    carInfo.Position = _iRacingSDK.Data.GetInt("CarIdxPosition", index);
-                    carInfo.CupPosition = _iRacingSDK.Data.GetInt("CarIdxClassPosition", index);
-                    
-                    carInfo.TrackPercentCompleted = _iRacingSDK.Data.GetFloat("CarIdxLapDistPct", index);
 
-                    TrkLoc trackSurface = (TrkLoc)_iRacingSDK.Data.GetInt("CarIdxTrackSurface", index);
-                    // TODO: more finer mapping for CarLocation? Figure out how to detect whether the player is in the garage or pit.
-                    // And allow HUDs to check if players are off track/approaching pits
-                    // PlayerCarInPitStall
-                    /* CarIdxTrackSurface irsdk_TrkLoc :
-                        NotInWorld = -1,
-                        OffTrack,
-                        InPitStall,
-                        AproachingPits,
-                        OnTrack
-                    */
-                    /* if (index == SessionData.Instance.PlayerCarIndex)
+                for (var iRSDKindex = 0; iRSDKindex < _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers.Count; iRSDKindex++)
+                {
+                    DriverModel driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[iRSDKindex];
+                    if (driverModel.CarIsPaceCar > 0) continue;
+
+                    CarInfo carInfo = GetCarInfo(driverModel.CarIdx);
+                    if (carInfo == null)
                     {
-                        Debug.WriteLine("CarIdxOnPitRoad {0} garage {1} PlayerCarInPitStall {2} IsGarageVisible {3} IsSpectator {4} CarIdxTrackSurface {5} CamCarIdx {6}", 
-                            _iRacingSDK.Data.GetBool("CarIdxOnPitRoad", index), _iRacingSDK.Data.GetBool("IsInGarage", index), 
-                            _iRacingSDK.Data.GetBool("PlayerCarInPitStall", index), _iRacingSDK.Data.GetBool("IsGarageVisible", index),
-                            _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index].IsSpectator, trackSurface,
-                            _iRacingSDK.Data.GetInt("CamCarIdx"));
-                    } */
-                    if (_iRacingSDK.Data.GetBool("CarIdxOnPitRoad", index)) {
+                        Debug.WriteLine("Car not found with CarIdx {0}", driverModel.CarIdx);
+                        continue;
+                    }
+                    carInfo.Position = _iRacingSDK.Data.GetInt(carIdxPositionDatum, iRSDKindex);
+                    carInfo.CupPosition = _iRacingSDK.Data.GetInt(carIdxClassPositionDatum, iRSDKindex);
+                    
+                    carInfo.TrackPercentCompleted = _iRacingSDK.Data.GetFloat(carIdxLapDistPctDatum, iRSDKindex);
+
+                    // Track surface: NotInWorld, OffTrack, InPitStall, AproachingPits, OnTrack
+                    // TODO: we can still distinguish between CarLocationEnum.Pitlane/PitEntry/Exit
+                    TrkLoc trackSurface = (TrkLoc)_iRacingSDK.Data.GetInt(carIdxTrackSurfaceDatum, iRSDKindex);                    
+                    if (_iRacingSDK.Data.GetBool(carIdxOnPitRoadDatum, iRSDKindex)) {
                         carInfo.CarLocation = CarInfo.CarLocationEnum.Pitlane;
+                    } else if (trackSurface == TrkLoc.NotInWorld )
+                    {
+                        carInfo.CarLocation = CarInfo.CarLocationEnum.NONE;
                     } else
                     {
                         carInfo.CarLocation = CarInfo.CarLocationEnum.Track;                        
                     }                                        
                     
-                    carInfo.CurrentDriverIndex = 0;
-                    LapInfo lapInfo = new LapInfo();
-                    lapInfo.LaptimeMS = (int)(_iRacingSDK.Data.GetFloat("CarIdxLastLapTime", index) * 1000.0);                    
-                    carInfo.LastLap = lapInfo;
+                    carInfo.CurrentDriverIndex = 0;                                        
+                    carInfo.LapIndex = _iRacingSDK.Data.GetInt(carIdxLapDatum, iRSDKindex);
                     
-                    carInfo.LapIndex = _iRacingSDK.Data.GetInt("CarIdxLap", index);
 
-                    lapInfo = new LapInfo();
-                    float fl = _iRacingSDK.Data.GetFloat("CarIdxBestLapTime", index);
-                    lapInfo.LaptimeMS = (int) (_iRacingSDK.Data.GetFloat("CarIdxBestLapTime", index) * 1000.0);
-                    carInfo.FastestLap = lapInfo;
-
-                    lapInfo = new LapInfo();
+                    LapInfo lapInfo = new LapInfo();
                     carInfo.CurrentLap = lapInfo;
                     if (trackSurface == TrkLoc.OffTrack)
                     {
@@ -132,24 +201,24 @@ namespace RaceElement.Data.Games.iRacing
                     // "CarIdxEstTime":  Estimated time to reach current location on track
                     //    f2time is 0 until the driver has done a (valid?) lap. So we use CarIdxEstTime to get the time it should take a player
                     //    to get to the current position on a track
-                    float trackPositionTime = _iRacingSDK.Data.GetFloat("CarIdxEstTime", index);
+                    float trackPositionTime = _iRacingSDK.Data.GetFloat(carIdxEstTimeDatum, iRSDKindex);
                     if (!classLeaderTrackPositionTimeDict.ContainsKey(carInfo.CarClass) || classLeaderTrackPositionTimeDict[carInfo.CarClass] > trackPositionTime)
                     {
                         classLeaderTrackPositionTimeDict[carInfo.CarClass] = trackPositionTime;
                     }
                     carInfo.GapToRaceLeaderMs = (int)(trackPositionTime * 1000.0);                                        
                     
-                    carInfo.GapToPlayerMs = GetGapToPlayerMs(index, SessionData.Instance.PlayerCarIndex);
+                    carInfo.GapToPlayerMs = GetGapToPlayerMs(iRSDKindex, SessionData.Instance.PlayerCarIndex);
                 }
 
                 // determine the gaps for each car to the class leader
                 for (var index = 0; index < SessionData.Instance.Cars.Count; index++)
                 {
-                    var position = _iRacingSDK.Data.GetInt("CarIdxClassPosition", index);
-                    float f2Time = _iRacingSDK.Data.GetFloat("CarIdxF2Time", index);
-                    if (position <= 0) continue;
-                    
                     CarInfo carInfo = SessionData.Instance.Cars[index].Value;
+                    var position = _iRacingSDK.Data.GetInt(carIdxClassPositionDatum, carInfo.CarIndex);
+                    float f2Time = _iRacingSDK.Data.GetFloat(carIdxF2TimeDatum, carInfo.CarIndex);
+                    if (position <= 0) continue;
+                                        
                     carInfo.GapToClassLeaderMs = 0;
                     // special case for multi-class qualifying
                     if (classLeaderTrackPositionTimeDict.ContainsKey(carInfo.CarClass))
@@ -164,9 +233,9 @@ namespace RaceElement.Data.Games.iRacing
                 LocalCarData localCar = SimDataProvider.LocalCar;
                 int playerCarIdx = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarIdx;
                 CarInfo playerCarInfo = SessionData.Instance.Cars[playerCarIdx].Value;
-                localCar.Race.GlobalPosition = _iRacingSDK.Data.GetInt("PlayerCarPosition");
+                localCar.Race.GlobalPosition = _iRacingSDK.Data.GetInt(playerCarPositionDatum);
                 
-                localCar.Engine.FuelLiters = _iRacingSDK.Data.GetFloat("FuelLevel");
+                localCar.Engine.FuelLiters = _iRacingSDK.Data.GetFloat(fuelLevelDatum);
                 int lapIndex = playerCarInfo.LapIndex;
                 // check if we completed a lap
                 if ( lapIndex > lastLapIndex)
@@ -178,63 +247,31 @@ namespace RaceElement.Data.Games.iRacing
                     Debug.WriteLine("new lap lastLapFuelConsumption {0} lastLapFuelLevelLiters {1}", lastLapFuelConsumption, lastLapFuelLevelLiters);
                 }                
 
-                localCar.Engine.Rpm = (int)_iRacingSDK.Data.GetFloat("RPM");
+                localCar.Engine.Rpm = (int)_iRacingSDK.Data.GetFloat(rPMDatum);
                 // m/s -> km/h
-                localCar.Physics.Velocity = _iRacingSDK.Data.GetFloat("Speed") * 3.6f;
-                localCar.Physics.Heading = _iRacingSDK.Data.GetFloat("YawNorth");
-                localCar.Physics.Pitch = _iRacingSDK.Data.GetFloat("Pitch");
-                localCar.Physics.Roll = _iRacingSDK.Data.GetFloat("Roll");
+                localCar.Physics.Velocity = _iRacingSDK.Data.GetFloat(speedDatum) * 3.6f;
+                localCar.Physics.Heading = _iRacingSDK.Data.GetFloat(yawNorthDatum);
+                localCar.Physics.Pitch = _iRacingSDK.Data.GetFloat(pitchDatum);
+                localCar.Physics.Roll = _iRacingSDK.Data.GetFloat(rollDatum);
 
-                localCar.Race.GlobalPosition = _iRacingSDK.Data.GetInt("PlayerCarPosition");
+                localCar.Race.GlobalPosition = _iRacingSDK.Data.GetInt(playerCarPositionDatum);
 
-                localCar.Inputs.Gear = _iRacingSDK.Data.GetInt("Gear") + 1;
-                localCar.Inputs.Brake = _iRacingSDK.Data.GetFloat("Brake");
-                localCar.Inputs.Throttle = _iRacingSDK.Data.GetFloat("Throttle");
-                localCar.Inputs.Steering = _iRacingSDK.Data.GetFloat("SteeringWheelAngle");
+                localCar.Inputs.Gear = _iRacingSDK.Data.GetInt(gearDatum) + 1;
+                localCar.Inputs.Brake = _iRacingSDK.Data.GetFloat(brakeDatum);
+                localCar.Inputs.Throttle = _iRacingSDK.Data.GetFloat(throttleDatum);
+                localCar.Inputs.Steering = _iRacingSDK.Data.GetFloat(steeringWheelAngleDatum);
 
                 
-                SessionData.Instance.LapDeltaToSessionBestLapMs = _iRacingSDK.Data.GetFloat("LapDeltaToSessionBestLap");
+                SessionData.Instance.LapDeltaToSessionBestLapMs = _iRacingSDK.Data.GetFloat(lapDeltaToSessionBestLapDatum);
+                
+                SessionData.Instance.Weather.AirTemperature = _iRacingSDK.Data.GetFloat(airTempDatum);
+                SessionData.Instance.Weather.AirVelocity = _iRacingSDK.Data.GetFloat(windVelDatum) * 3.6f;
+                SessionData.Instance.Weather.AirDirection = _iRacingSDK.Data.GetFloat(windDirDatum);
 
-                /* as per https://github.com/alexanderzobnin/grafana-simracing-telemetry/blob/8c008f01003502c687aa4e5278018b000b0a5eaf/pkg/iracing/sharedmemory/models.go#L193
-                   we can add these to local car (not available for opponent cars)
-                             Lap                             int32
-                             LapCompleted                    int32
-                             LapDist                         float32
-                             LapDistPct                      float32
-                             RaceLaps                        int32
-                             LapBestLap                      int32
-                             LapBestLapTime                  float32
-                             LapLastLapTime                  float32
-                             LapCurrentLapTime               float32
-                             LapLasNLapSeq                   int32
-                             LapLastNLapTime                 float32
-                             LapBestNLapLap                  int32
-                             LapBestNLapTime                 float32
-                             LapDeltaToBestLap               float32
-                             LapDeltaToBestLap_DD            float32
-                             LapDeltaToBestLap_OK            bool
-                             LapDeltaToOptimalLap            float32
-                             LapDeltaToOptimalLap_DD         float32
-                             LapDeltaToOptimalLap_OK         bool
-                             LapDeltaToSessionBestLap        float32
-                             LapDeltaToSessionBestLap_DD     float32
-                             LapDeltaToSessionBestLap_OK     bool
-                             LapDeltaToSessionOptimalLap     float32
-                             LapDeltaToSessionOptimalLap_DD  float32
-                             LapDeltaToSessionOptimalLap_OK  bool
-                             LapDeltaToSessionLastlLap       float32
-                             LapDeltaToSessionLastlLap_DD    float32
-                             LapDeltaToSessionLastlLap_OK    bool
-                         */
-
-                SessionData.Instance.Weather.AirTemperature = _iRacingSDK.Data.GetFloat("AirTemp");
-                SessionData.Instance.Weather.AirVelocity = _iRacingSDK.Data.GetFloat("WindVel") * 3.6f;
-                SessionData.Instance.Weather.AirDirection = _iRacingSDK.Data.GetFloat("WindDir");
-
-                SessionData.Instance.Track.Temperature = _iRacingSDK.Data.GetFloat("TrackTempCrew");
+                SessionData.Instance.Track.Temperature = _iRacingSDK.Data.GetFloat(trackTempCrewDatum);
 
                 // Fuel telemetry and fuel consumption calc. This is using the last lap                
-                var fuelLevelPercent = _iRacingSDK.Data.GetFloat("FuelLevelPct");
+                var fuelLevelPercent = _iRacingSDK.Data.GetFloat(fuelLevelPctDatum);
                 localCar.Engine.MaxFuelLiters = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarFuelMaxLtr;
 
                 // TODO: iRacing gives unreasonable values for fuelUseKgPerHour. At least off by a factor 10
@@ -253,28 +290,29 @@ namespace RaceElement.Data.Games.iRacing
 
                 // ABS. We don't seem to get any other info for localCar.Electronics such as TC and engine map.
                 // There is brake bias in CarSetupModel, but it is unclear if that would be updated when the user changes it when driving.
-                localCar.Electronics.AbsActivation = _iRacingSDK.Data.GetBool("BrakeABSactive") ? 1.0F : 0.0F; 
+                localCar.Electronics.AbsActivation = _iRacingSDK.Data.GetBool(brakeABSactiveDatum) ? 1.0F : 0.0F; 
 
                 // TODO : public int DriverIncidentCount { get; set; } and other incident info (CurDriverIncidentCount , TeamIncidentCount, ..)
 
-                int sessionNumber = _iRacingSDK.Data.GetInt("SessionNum");
+                int sessionNumber = _iRacingSDK.Data.GetInt(sessionNumDatum);
                 var sessionType = _iRacingSDK.Data.SessionInfo.SessionInfo.Sessions[sessionNumber].SessionType;
                 switch (sessionType)
                 {
                     case "Race":
                         SessionData.Instance.SessionType = RaceSessionType.Race; break;
                     case "Practice":
+                    case "Warmup": // Warmup is sort of like practice. We only need to distinguish of we want different HUD behavior
                         SessionData.Instance.SessionType = RaceSessionType.Practice; break;
                     case "Qualify":
                     case "Lone Qualify":
                     case "Open Qualify":
                         SessionData.Instance.SessionType = RaceSessionType.Qualifying; break;
                     default:
-                        Debug.WriteLine("Uknown session type " + sessionType);
+                        Debug.WriteLine("Unknown session type " + sessionType);
                         SessionData.Instance.SessionType = RaceSessionType.Race; break;
                 }
                 
-                IRacingSdkEnum.SessionState sessionState = (SessionState)_iRacingSDK.Data.GetInt("SessionState");
+                IRacingSdkEnum.SessionState sessionState = (SessionState)_iRacingSDK.Data.GetInt(sessionStateDatum);
                 switch (sessionState)
                 {
                     case SessionState.GetInCar:
@@ -304,15 +342,10 @@ namespace RaceElement.Data.Games.iRacing
                     SimDataProvider.CallSessionPhaseChanged(this, SessionData.Instance.Phase);
                     lastSessionNumber = sessionNumber;
                 }
-                SessionData.Instance.SessionTimeLeftSecs = _iRacingSDK.Data.GetDouble("SessionTimeRemain");                
-                /* TODO more session info
-	                SessionLapsRemain               int32
-	                SessionLapsRemainEx             int32
-	                SessionTimeTotal                float64
-	                SessionLapsTotal                int32
-	                SessionTimeOfDay                float32 */
+                SessionData.Instance.SessionTimeLeftSecs = _iRacingSDK.Data.GetDouble(sessionTimeRemainDatum);                
+                // TODO more session info SessionLapsRemain, SessionLapsRemainEx, SessionTimeTotal, SessionLapsTotal, SessionTimeOfDay
 
-                SpotterCallout = (CarLeftRight)_iRacingSDK.Data.GetInt("CarLeftRight");
+                SpotterCallout = (CarLeftRight)_iRacingSDK.Data.GetInt(carLeftRightDatum);
 
                 hasTelemetry = true;
             } catch (Exception ex) {
@@ -337,7 +370,15 @@ namespace RaceElement.Data.Games.iRacing
         private void OnSessionInfo()
         {
             // Debug.WriteLine("OnSessionInfo\n{0}", _iRacingSDK.Data.SessionInfoYaml);
-            
+
+            int sessionNumber = _iRacingSDK.Data.GetInt("SessionNum");
+            SessionModel session = _iRacingSDK.Data.SessionInfo.SessionInfo.Sessions[sessionNumber];
+            if (session.ResultsPositions == null)
+            {
+                Debug.WriteLine("No session or results info");
+                return;
+            }
+
             int playerCarIdx = _iRacingSDK.Data.SessionInfo.DriverInfo.DriverCarIdx;
             SessionData.Instance.PlayerCarIndex = playerCarIdx;
             SessionData.Instance.FocusedCarIndex = playerCarIdx; // TODO: we don't have a mechanism yet to set the focussed driver. iRacing has https://sajax.github.io/irsdkdocs/telemetry/camcaridx.html
@@ -363,13 +404,61 @@ namespace RaceElement.Data.Games.iRacing
             SessionData.Instance.Track.GameName = _iRacingSDK.Data.SessionInfo.WeekendInfo.TrackName;
 
 
+            Dictionary<int, int> carIdToCarArrayIndex = new Dictionary<int, int>();
+            for (var index = 0; index < _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers.Count; index++)
+            {
+                driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index];
+                if (driverModel.CarIsPaceCar > 0) continue;
+                carIdToCarArrayIndex[driverModel.CarIdx] = index;
+                // Debug.WriteLine("Drivers carIdx {0} carNumber {1} name {2}", driverModel.CarIdx, driverModel.CarNumberRaw, driverModel.UserName);
+            }
+
+            // dictionary from carIdx to results index
+            Dictionary<int, int> carIndexResults = new Dictionary<int, int>();
+             
+            for (int resultsPosIndex = 0; resultsPosIndex < session.ResultsPositions.Count; resultsPosIndex++)
+            {
+                PositionModel result = session.ResultsPositions[resultsPosIndex];
+                carIndexResults.Add(result.CarIdx, resultsPosIndex);
+                /*
+                if (!carIdToCarArrayIndex.ContainsKey(result.CarIdx))
+                {
+                    Debug.WriteLine("DriverInfo does not contain carIdx {0} ", result.CarIdx);
+                }
+                Debug.WriteLine("resultinfo carIdx {0} classPosition {1}", result.CarIdx, result.ClassPosition);*/
+            }
+            /*
+            for (var index = 0; index < _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers.Count; index++)
+            {
+                driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index];
+                if (carIndexResults.ContainsKey(driverModel.CarIdx)) {
+                    Debug.WriteLine("resultModel does not contain carIdx {0} name {1}", driverModel.CarIdx, driverModel.UserName);
+                }
+            }*/
+
             for (var index = 0; index < _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers.Count; index++)
             {                
                 driverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index];
                 if (driverModel.CarIsPaceCar > 0) continue;
-
-                var carInfo = new CarInfo(index);
+                
+                CarInfo carInfo = TryAddDriver(driverModel);                                      
                 carInfo.RaceNumber = driverModel.CarNumberRaw;
+
+                if (carIndexResults.ContainsKey(index))
+                {
+                    LapInfo lapInfo = new LapInfo();
+                    PositionModel postion = session.ResultsPositions[carIndexResults[index]];
+                    lapInfo.LaptimeMS = (int?)(postion.FastestTime * 1000.0F);
+                    carInfo.FastestLap = lapInfo;
+
+                    lapInfo = new LapInfo();
+                    lapInfo.LaptimeMS = (int?)(postion.LastTime * 1000.0F);
+                    carInfo.LastLap = lapInfo;
+                } /* else
+                {
+                    Debug.WriteLine("carIndexResults does not contain carArrayINdex {0} carIdx {1}", index, driverModel.CarIdx);
+                }    */            
+
                 // For multi-make classes like GT4/GT3, we use CarClassShortName otherwise (e.g. MX5 or GR86) we use CarScreenNameShort
                 carInfo.CarClass = driverModel.CarClassShortName;
                 if (carInfo.CarClass == null)
@@ -378,24 +467,47 @@ namespace RaceElement.Data.Games.iRacing
                 }
                 carInfo.IsSpectator = driverModel.IsSpectator == 1;
 
-                string currCarClassColor = driverModel.CarClassColor;
-                AddCarClassEntry(carInfo.CarClass, Color.Aquamarine);  // TODO: need mapping from string currCarClassColor to Color
-
-                // TODO: it looks like this might change in a team race when the driver changes. We need to test this with a team race at some point.
-                // None of the currently ported HUDs do want to display the non-driving drivers in the team anyway.
-                DriverInfo driver = new DriverInfo();                                
-                DriverModel currDriverModel = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[index];
-                driver.Name = currDriverModel.UserName;
-                driver.Rating = currDriverModel.IRating;
-                // LicString is "<class> <SR>".
-                driver.Category = currDriverModel.LicString;
-                // TODO LicColor
-                carInfo.AddDriver(driver);                
-
-                SessionData.Instance.AddOrUpdateCar(index, carInfo);
+                AddCarClassEntry(carInfo.CarClass, driverModel.CarClassColor);                
 
                 // TODO: add qualifying time info
             }
+        }
+
+        private CarInfo GetCarInfo(int carIndex)
+        {
+
+            if (SessionData.Instance.Cars.Count > carIndex)
+            {
+                return SessionData.Instance.Cars[carIndex].Value;
+
+            }
+            return null;
+        }
+
+
+        private CarInfo TryAddDriver(DriverModel driverModel)
+        {
+            CarInfo carInfo;
+            if (SessionData.Instance.Cars.Count > driverModel.CarIdx)
+            {
+                carInfo = SessionData.Instance.Cars[driverModel.CarIdx].Value;
+            }
+            else
+            {
+                carInfo = new CarInfo(driverModel.CarIdx);
+                SessionData.Instance.AddOrUpdateCar(driverModel.CarIdx, carInfo);
+
+                DriverInfo driver = new DriverInfo();
+                // TODO: it looks like this might change in a team race when the driver changes. We need to test this with a team race at some point.
+                // None of the currently ported HUDs do want to display the non-driving drivers in the team anyway.
+
+                driver.Name = driverModel.UserName;
+                driver.Rating = driverModel.IRating;
+                // LicString is "<class> <SR>".
+                driver.Category = driverModel.LicString;
+                carInfo.AddDriver(driver);
+            }
+            return carInfo;
         }
 
         // for debugging
@@ -440,6 +552,7 @@ namespace RaceElement.Data.Games.iRacing
             car1.CurrentLap = lap2;
             car1.GapToClassLeaderMs = 0;
             car1.CarClass = "F1";
+            car1.Laps = 11;
             SessionData.Instance.AddOrUpdateCar(1, car1);
             var car1driver0 = new DriverInfo();
             car1driver0.Name = "Max Verstappen";
@@ -463,6 +576,8 @@ namespace RaceElement.Data.Games.iRacing
             car2.FastestLap = lap2;
             car2.CurrentLap = lap1;
             car2.GapToClassLeaderMs = 1000;
+            car2.GapToPlayerMs = 100;
+            car2.Laps = 10;
             car2.CarClass = "F1";
             SessionData.Instance.AddOrUpdateCar(2, car2);
             var car2driver0 = new DriverInfo();
@@ -470,8 +585,34 @@ namespace RaceElement.Data.Games.iRacing
             car2driver0.Rating = 8123;
             car2driver0.Category = "A 2.2";
             car2.AddDriver(car2driver0);
-            
-            AddCarClassEntry("F1", Color.Sienna);
+
+
+
+
+            CarInfo car3 = new CarInfo(3);
+            // 10 meter behind car1
+            car3.TrackPercentCompleted = car1.TrackPercentCompleted + (-10.0F / ((float)SessionData.Instance.Track.Length));
+            car3.Position = 2;
+            car3.CarLocation = CarInfo.CarLocationEnum.Track;
+            car3.CurrentDriverIndex = 0;
+            car3.Kmh = 160;
+            car3.CupPosition = 2;
+            car3.RaceNumber = 7;
+            car3.LastLap = lap2;
+            car3.FastestLap = lap2;
+            car3.CurrentLap = lap1;
+            car3.GapToClassLeaderMs = 1000;
+            car3.GapToPlayerMs = 200;
+            car3.CarClass = "F1";
+            car3.Laps = 12;
+            SessionData.Instance.AddOrUpdateCar(3, car3);
+            var car3driver0 = new DriverInfo();
+            car3driver0.Name = "Lewis Hamilton";
+            car3driver0.Rating = 6123;
+            car3driver0.Category = "B 2.7";
+            car3.AddDriver(car3driver0);
+
+            AddCarClassEntry("F1", "TODOPrevieColor");
 
             SpotterCallout = CarLeftRight.CarLeft;
             
@@ -479,9 +620,10 @@ namespace RaceElement.Data.Games.iRacing
         }
 
         // Gap calculation according to https://github.com/lespalt/iRon 
+        // TODO:  Gap should be showing in the shortest direction. e.g. -15sec instead of +50sec
         private int GetGapToPlayerMs(int index, int playerCarIdx)
         {            
-            float bestForPlayer = _iRacingSDK.Data.GetFloat("CarIdxBestLapTime", playerCarIdx);
+            float bestForPlayer = _iRacingSDK.Data.GetFloat("CarIdxBestLapTime", playerCarIdx); // TODO: this might not work if the driver is out of e.g. practice
             if (bestForPlayer == 0)
                 bestForPlayer = _iRacingSDK.Data.SessionInfo.DriverInfo.Drivers[playerCarIdx].CarClassEstLapTime;
             
@@ -543,15 +685,23 @@ namespace RaceElement.Data.Games.iRacing
             return hasTelemetry;
         }        
 
-        private void AddCarClassEntry(string carClass, System.Drawing.Color color)
-        {
-            if (carClasses == null)
-            {
-                carClasses = new HashSet<string>();
-            }                        
+        private void AddCarClassEntry(string carClass, string aCarClassColor)
+        {            
             carClasses.Add(carClass);
-            // TODO: map string->Color instead of hardcoded.  
-            carClassColor.TryAdd(carClass, Color.AliceBlue); 
+            carClassColor.TryAdd(carClass, MapCarClassColor(aCarClassColor)); 
+        }
+
+        private Color MapCarClassColor(string carClassColor)
+        {
+            // Remove the leading '0x' if present
+            if (carClassColor.StartsWith("0x"))
+            {
+                carClassColor = carClassColor.Substring(2);
+            }
+
+            // Convert hex string to Color
+            Color color = ColorTranslator.FromHtml("#" + carClassColor);
+            if (color == null) return Color.White;
         }
 
         public CarLeftRight GetSpotterCallout()
@@ -564,6 +714,36 @@ namespace RaceElement.Data.Games.iRacing
             // TODO We need to test how spotting team mates works in a multi-driver team race. 
             // E.g. what telemetry is available
             return false;
+        }
+
+        /// <summary>
+        /// iRacing license class to color mapping.
+        /// </summary>        
+        public override Color? GetColorForCategory(string category)
+        {
+            if (category.StartsWith("A"))
+            {
+                return Color.Blue;
+            }
+            else if (category.StartsWith("B"))
+            {
+                return Color.Green;
+            }
+            else if (category.StartsWith("C"))
+            {
+                return Color.Yellow;
+            }
+            else if (category.StartsWith("D"))
+            {
+                return Color.Orange;
+            } else if (category.StartsWith("R")) 
+            {
+                return Color.Red;
+            } else
+            {
+                Debug.WriteLine("Unknown license {0}", category);
+                return Color.Gray;
+            }
         }
     }
 

--- a/Race Element.Data/Games/iRacing/SDK/IRSDKSharper.cs
+++ b/Race Element.Data/Games/iRacing/SDK/IRSDKSharper.cs
@@ -384,7 +384,7 @@ namespace RaceElement.Data.Games.iRacing.SDK
 
                 while (isStarted == 1)
                 {
-                    Debug.WriteLine("Waiting for session info event.");
+                    // Debug.WriteLine("Waiting for session info event.");
 
                     sessionInfoAutoResetEvent?.WaitOne();
 
@@ -392,7 +392,7 @@ namespace RaceElement.Data.Games.iRacing.SDK
                     {
                         if (isStarted == 1)
                         {
-                            Debug.WriteLine("Updating session info.");
+                            // Debug.WriteLine("Updating session info.");
 
                             if (Data.UpdateSessionInfo())
                             {
@@ -452,7 +452,7 @@ namespace RaceElement.Data.Games.iRacing.SDK
 
                         if (lastSessionInfoUpdate != Data.SessionInfoUpdate)
                         {
-                            Debug.WriteLine("Data.SessionInfoUpdate has changed.");
+                            // Debug.WriteLine("Data.SessionInfoUpdate has changed.");
 
                             lastSessionInfoUpdate = Data.SessionInfoUpdate;
 
@@ -465,7 +465,7 @@ namespace RaceElement.Data.Games.iRacing.SDK
 
                         if (Interlocked.Exchange(ref sessionInfoUpdateReady, 0) == 1)
                         {
-                            Debug.WriteLine("Invoking OnSessionInfo.");
+                            // Debug.WriteLine("Invoking OnSessionInfo.");
 
                             OnSessionInfo?.Invoke();
                         }

--- a/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeConfiguration.cs
@@ -2,7 +2,7 @@
 
 namespace RaceElement.HUD.Common.Overlays.Driving.Relative
 {
-    internal class RelativeConfiguration : OverlayConfiguration 
+    sealed internal class RelativeConfiguration : OverlayConfiguration 
     {
         /* TODO This needs some work.
         [ConfigGrouping("Information", "Show or hide additional information in the Relative.")]

--- a/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.Relative
+{
+    internal class RelativeConfiguration : OverlayConfiguration 
+    {
+        /* TODO This needs some work.
+        [ConfigGrouping("Information", "Show or hide additional information in the Relative.")]
+        public InformationGrouping Information { get; init; } = new InformationGrouping();
+        public class InformationGrouping
+        {            
+            [ToolTip("Interval")]
+            public bool Interval { get; init; } = true;
+
+            [ToolTip("Last lap")]
+            public bool LastLap { get; init; } = true;
+
+            [ToolTip("License and Ratings")]
+            public bool LicenseRatings { get; init; } = true;
+        } */
+
+        [ConfigGrouping("Layout", "Change the layout of the Relative.")]
+        public LayoutGrouping Layout { get; init; } = new LayoutGrouping();
+        public sealed class LayoutGrouping
+        {
+            [ToolTip("Additional Rows in front and behind.")]
+            [IntRange(1, 5, 1)]
+            public int AdditionalRows { get; init; } = 2;
+        }
+
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeOverlay.cs
@@ -4,15 +4,17 @@ using System.Drawing;
 using RaceElement.Data.Common;
 using RaceElement.Data.Common.SimulatorData;
 using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using DataUtil = RaceElement.Data.Common.DataUtil;
 
 namespace RaceElement.HUD.Common.Overlays.Driving.Relative
 
-    
+
 {
     [Overlay(Name = "Relative (ALPHA)", Version = 1.00,
     Description = "Shows drivers next to player.", OverlayType = OverlayType.Drive, Authors = ["Dirk Wolf"])]
 
-    internal class RelativeOverlay : AbstractTableOverlay
+    sealed internal class RelativeOverlay : AbstractTableOverlay
     {
         private readonly RelativeConfiguration _config = new();
 

--- a/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Relative/RelativeOverlay.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.HUD.Overlay.Internal;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.Relative
+
+    
+{
+    [Overlay(Name = "Relative (ALPHA)", Version = 1.00,
+    Description = "Shows drivers next to player.", OverlayType = OverlayType.Drive, Authors = ["Dirk Wolf"])]
+
+    internal class RelativeOverlay : AbstractTableOverlay
+    {
+        private readonly RelativeConfiguration _config = new();
+
+        private const int _height = 800;
+        private const int _width = 800;
+
+        private int playerEntryListIndex = -1;
+        
+        static Color LapDownColor = Color.Blue;
+        static Color LapUpColor = Color.Red;
+        static Color InPitColor = Color.Gray;
+        static Color InPitLapDown = MixWithGray(LapDownColor);
+        static Color InPitLapUp = MixWithGray(LapUpColor);               
+
+        // we don't list the car in the relative if the interval is larger than 40 seconds
+        static int IntervalThresholdMs = 40000;
+
+        List<List<CellValue>> relativeList = [];
+
+        public RelativeOverlay(Rectangle rectangle) : base(rectangle, "Relative")
+        {
+            this.Height = _height;
+            this.Width = _width;
+            this.RefreshRateHz = 3;
+        }
+
+
+        public sealed override void Render(Graphics g)
+        {
+            List<KeyValuePair<int, CarInfo>> entryList = new List<KeyValuePair<int, CarInfo>>(SessionData.Instance.Cars);
+            SortEntryList(entryList);
+
+            base.Render(g);
+        }
+
+        private void SortEntryList(List<KeyValuePair<int, CarInfo>> cars)
+        {
+            if (cars.Count == 0) return;
+
+            // calculate live standings based on percentage of the current lap completed
+            cars.Sort((a, b) =>
+            {
+                if (a.Value == null)
+                    return -1;
+
+                if (b.Value == null)
+                    return 1;
+
+                CarInfo carCarA = a.Value;
+                CarInfo carCarb = b.Value;
+
+                if (carCarA == null) return -1;
+                if (carCarb == null) return 1;
+
+                var aSpline = carCarA.TrackPercentCompleted;
+                var bSpline = carCarb.TrackPercentCompleted;
+                
+                float aPosition = aSpline / 10;
+                float bPosition = bSpline / 10;
+                return aPosition.CompareTo(bPosition);
+            });
+            
+
+            int sortedListIndex = 0;
+            relativeList.Clear();
+            foreach (KeyValuePair<int, CarInfo> pair in cars)
+            {                
+                if (SessionData.Instance.PlayerCarIndex == pair.Key)
+                {
+                    playerEntryListIndex = sortedListIndex;
+                    break;
+                }
+                sortedListIndex++;
+            }
+
+            // Collect "additionalDrivers" in front of player and after. Limit to max 40secs difference.
+            List<CarInfo> toAdd = new List <CarInfo>();
+            var additionalDrivers = _config.Layout.AdditionalRows;            
+            int startIndex = (playerEntryListIndex - additionalDrivers + cars.Count) % cars.Count;
+            int endIndex = (playerEntryListIndex + additionalDrivers + 1 + cars.Count) % cars.Count;
+
+            //Debug.WriteLine("Add start {0} end {1}", startIndex, endIndex);
+
+            for (int index = startIndex; index < endIndex; index++) { 
+                
+                CarInfo carToAdd = cars[index].Value;
+
+                if (Math.Abs(carToAdd.GapToPlayerMs) > IntervalThresholdMs) continue;
+                
+                if (carToAdd.CarLocation != CarInfo.CarLocationEnum.NONE || carToAdd.CarLocation != CarInfo.CarLocationEnum.Garage)
+                {                    
+                    toAdd.Insert(0, carToAdd);
+                }                
+            }            
+
+            foreach (CarInfo car in toAdd)
+            {
+                AddRow(car, cars[SessionData.Instance.PlayerCarIndex].Value);
+            }
+        }
+
+        private void AddRow(CarInfo opponentCar, CarInfo PlayerCar)
+        {            
+            // use colors to show whether opponent is on a different lap. For being in pit, use gray mixed color.
+            Color? textColor = null;
+            if (opponentCar.Laps > PlayerCar.Laps)
+            {
+                if (opponentCar.CarLocation != CarInfo.CarLocationEnum.Pitlane)
+                    textColor = LapUpColor;
+                else
+                    textColor = InPitLapUp;
+            }
+            else if (opponentCar.Laps < PlayerCar.Laps)
+            {
+                if (opponentCar.CarLocation != CarInfo.CarLocationEnum.Pitlane)
+                    textColor = LapDownColor;
+                else
+                    textColor = InPitLapDown;
+            }
+            else if (opponentCar.CarLocation == CarInfo.CarLocationEnum.Pitlane)
+            {
+                textColor = InPitColor;
+            }
+
+            relativeList.Add([
+                new CellValue(opponentCar.CarIndex.ToString(), textColor , null),
+                new CellValue("#" + opponentCar.RaceNumber.ToString(), SimDataProvider.Instance.GetColorForCarClass(opponentCar.CarClass), null),
+                new CellValue(opponentCar.Drivers[0].Name, textColor, null),
+                new CellValue(opponentCar.Drivers[0].Category, null, SimDataProvider.Instance.GetColorForCategory(opponentCar.Drivers[0].Category)),
+                new CellValue(opponentCar.Drivers[0].Rating.ToString(), textColor, null),
+                new CellValue(DataUtil.GetTimeDiff(opponentCar.GapToPlayerMs), textColor, null),
+            ]);
+        }
+
+        public override List<List<CellValue>> GetCellRows(int section)
+        {
+            return relativeList;            
+        }
+
+        public override List<HeaderLabel> GetSectionHeaders()
+        {
+            // For relative we ignore car classes
+            return []; 
+        }
+
+        public override List<HeaderLabel> GetOverallHeader()
+        {
+            // TODO: interval should be alligned with the column metadata. Maybe a helper function to determine the offset?
+            return [ new HeaderLabel("Relative", 36, AbstractTableOverlay.HeaderBackground), 
+                new HeaderLabel("Int", 4, AbstractTableOverlay.HeaderBackground)];
+        }
+
+        public override List<ColumnMetaData> GetColumnMetaData()
+        {
+            return [new ColumnMetaData("Index", 2), new ColumnMetaData("CarNumber", 4), new ColumnMetaData("DriverName", 20),
+            new ColumnMetaData("Category", 5), new ColumnMetaData("Rating", 4), new ColumnMetaData("Interval", 4)];
+        }
+
+        private static Color MixWithGray(Color baseColor)
+        {
+            Color gray = Color.Gray;
+            float grayRatio = 0.5F;
+
+            // Calculate the mixed color
+            int r = (int)((baseColor.R * (1 - grayRatio)) + (gray.R * grayRatio));
+            int g = (int)((baseColor.G * (1 - grayRatio)) + (gray.G * grayRatio));
+            int b = (int)((baseColor.B * (1 - grayRatio)) + (gray.B * grayRatio));
+
+            return Color.FromArgb(r, g, b);
+        }
+    }
+
+    
+}

--- a/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
@@ -3,6 +3,7 @@ using RaceElement.Data.Common.SimulatorData;
 using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.Util;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
@@ -207,20 +208,34 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         // Interval based on the type of session:
         // - practice/qualifying: interval is gap to driver in front's BEST time (within) same class 
         // - race: interval is gap to car in front in the same class.        
-        int intervalMs = 0;        
-        if (standingsTableRows.Count > 1)
+        int intervalMs = 0;
+        if (standingsTableRows.Count > 0)
         {
             if (SessionData.Instance.SessionType != RaceSessionType.Race)
             {
-                intervalMs = ((int)(carData.FastestLap.LaptimeMS - standingsTableRows[standingsTableRows.Count - 1].FastestLapTime.LaptimeMS));
+                // TODO: maybe special case when no-one has fastest lap?
+                if (carData.FastestLap != null  && standingsTableRows[standingsTableRows.Count - 1].FastestLapTime != null )
+                    intervalMs = ((int)(carData.FastestLap.LaptimeMS - standingsTableRows[standingsTableRows.Count - 1].FastestLapTime.LaptimeMS));
+                else
+                {
+                    intervalMs = 0;
+                    // Debug.WriteLine("No interval b/c fastest lap null. curr {0} front {1}", carData.RaceNumber, standingsTableRows[standingsTableRows.Count - 1].RaceNumber);
+                }
             }
             else
             {
                 // TODO: take into account being lap down. e.g. print "1L" for 1 lap down
                 int carInFont = standingsTableRows[standingsTableRows.Count - 1].CarIdx;
-                intervalMs = ((int)(carData.GapToRaceLeaderMs - SessionData.Instance.Cars[carInFont].Value.GapToRaceLeaderMs));
+                if (carInFont >= SessionData.Instance.Cars.Count || carInFont < 0)
+                {                    
+                    Debug.WriteLine("out of range. carInFront {0} car count {1}", carInFont, SessionData.Instance.Cars.Count);                    
+                }
+                else
+                {
+                    intervalMs = ((int)(carData.GapToRaceLeaderMs - SessionData.Instance.Cars[carInFont].Value.GapToRaceLeaderMs));
+                }
             }
-        }
+        }        
 
         standingsTableRows.Add(new StandingsTableRow()
         {
@@ -233,8 +248,8 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
             IntervalMs = new LapInfo() { LaptimeMS = intervalMs },
             AdditionalInfo = additionInfo,
             FastestLapTime = carData.FastestLap,
-            // should be something like "A3.43 4.1k" for iRacing. TODO at a later point we can add color.
-            LicenseInfo = carData.Drivers[carData.CurrentDriverIndex].Category + " " + carData.Drivers[carData.CurrentDriverIndex].Rating
+            // should be something like "A3.43 4.1k" for iRacing.
+            LicenseInfo = driverInfo.Category + " " + driverInfo.Rating
         });
     }
 
@@ -267,30 +282,7 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
         return "";
     }
 
-    public static String GetTimeDiff(LapInfo lap)
-    {
-        if (lap == null || !lap.LaptimeMS.HasValue)
-        {
-            return "--:--.---";
-        }
 
-        TimeSpan lapTime = TimeSpan.FromMilliseconds(lap.LaptimeMS.Value);
-        if (lapTime.Minutes > 0)
-            return $"{lapTime:m\\:s\\.f}";
-        else
-            return $"{lapTime:s\\.f}";
-    }
-
-    public static String GetLapTime(LapInfo lap)
-    {
-        if (lap == null || !lap.LaptimeMS.HasValue || lap.LaptimeMS < 0)
-        {
-            return "--:--.---";
-        }
-
-        TimeSpan lapTime = TimeSpan.FromMilliseconds(lap.LaptimeMS.Value);
-        return $"{lapTime:mm\\:ss\\.fff}";
-    }
 
     private void SortAllEntryLists()
     {
@@ -399,7 +391,7 @@ public sealed class StandingsOverlay : CommonAbstractOverlay
 
             CarInfo carInfo = kvp.Value;
             string carClass = carInfo.CarClass;
-
+            
             GetEntryListForClass(carClass).Add(kvp);
 
         }
@@ -512,7 +504,7 @@ public class OverlayStandingsTable
 
             columnPosX += licenseInfo.Width + _columnGap;
             OverlayStandingsTableTextLabel interval = new(g, columnPosX, rowPosY, 6, FontUtil.FontSegoeMono(_fontSize));
-            String intervalString = StandingsOverlay.GetTimeDiff(tableData[i].IntervalMs);
+            String intervalString = DataUtil.GetTimeDiff(tableData[i].IntervalMs.LaptimeMS);
             if (tableData[i].IntervalMs.LaptimeMS < -100)
             {
                 interval.Draw(g, backgroundColor, (SolidBrush)Brushes.DarkGreen, Brushes.White, "-" + intervalString, true);
@@ -529,11 +521,11 @@ public class OverlayStandingsTable
             // TODO: hightling if improved or purple
             columnPosX += interval.Width + _columnGap;
             OverlayStandingsTableTextLabel lastLaptTime = new(g, columnPosX, rowPosY, 9, FontUtil.FontSegoeMono(_fontSize));
-            lastLaptTime.Draw(g, backgroundColor, (SolidBrush)Brushes.Purple, Brushes.White, StandingsOverlay.GetLapTime(tableData[i].LastLapTime), false);
+            lastLaptTime.Draw(g, backgroundColor, (SolidBrush)Brushes.Purple, Brushes.White, DataUtil.GetLapTime(tableData[i].LastLapTime), false);
 
             columnPosX += lastLaptTime.Width + _columnGap;
             OverlayStandingsTableTextLabel fastestLaptTime = new(g, columnPosX, rowPosY, 9, FontUtil.FontSegoeMono(_fontSize));
-            fastestLaptTime.Draw(g, backgroundColor, (SolidBrush)Brushes.Purple, Brushes.White, StandingsOverlay.GetLapTime(tableData[i].FastestLapTime), false);
+            fastestLaptTime.Draw(g, backgroundColor, (SolidBrush)Brushes.Purple, Brushes.White, DataUtil.GetLapTime(tableData[i].FastestLapTime), false);
 
             if (tableData[i].AdditionalInfo != "")
             {
@@ -709,7 +701,6 @@ public class OverlayStandingsTableTextLabel
 
         public void Draw(Graphics g, String number)
         {
-
             _cachedBackground.Draw(g, _x, _y);
             var numberWidth = g.MeasureString(number, _fontFamily).Width;
             var textOffset = 2;

--- a/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/Standings/StandingsOverlay.cs
@@ -10,6 +10,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Text;
 using System.Numerics;
 using static RaceElement.Data.Common.SimulatorData.CarInfo;
+using DataUtil = RaceElement.Data.Common.DataUtil;
 
 
 namespace RaceElement.HUD.Common.Overlays.Driving.Standings;

--- a/Race_Element.HUD/Overlay/Internal/AbstractTableOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/AbstractTableOverlay.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Windows.Forms;
+using RaceElement.Data.Common;
+using RaceElement.Data.Common.SimulatorData;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.Util;
+
+namespace RaceElement.HUD.Overlay.Internal
+{
+    public abstract class AbstractTableOverlay : CommonAbstractOverlay
+    {
+        private int NextX { get; set; }
+        private int NextY { get; set; }
+        
+        private readonly int _columnGap = 5;
+        // pixels between rows
+        private readonly int _rowGap = 3;
+
+        static Font DefaultFont = FontUtil.FontSegoeMono(13);
+        int fontMaxCharWidth = -1;
+
+        int TextOffset = 2;
+
+        public static readonly Color DefaultTextColor = Color.White;
+        public static readonly SolidBrush DefaultTextColorBrush = new SolidBrush(Color.FromArgb(150, DefaultTextColor));
+        public static readonly SolidBrush OddBackground = new(Color.FromArgb(100, Color.Black));
+        public static readonly SolidBrush EvenBackground = new(Color.FromArgb(180, Color.Black));
+        public static readonly SolidBrush DriversCarBackground = new(Color.FromArgb(180, Color.DarkSeaGreen));
+        public static readonly SolidBrush HeaderBackground = new(Color.FromArgb(100, Color.DarkSeaGreen));
+
+        protected AbstractTableOverlay(Rectangle rectangle, string Name) : base(rectangle, Name) {            
+        }
+
+        /// <summary>
+        /// Get the names and lenths for the overall header (e.g. race info and labels for all cells)
+        /// </summary>
+        /// <returns></returns>
+        abstract public List<HeaderLabel> GetOverallHeader();
+
+        /// <summary>
+        /// Get names and length for intermediate headers for a section (e.g. class headers)
+        /// </summary>
+        /// <returns></returns>
+        abstract public List<HeaderLabel> GetSectionHeaders();
+
+        /// <summary>
+        /// Get the row values for a 
+        /// </summary>
+        /// <param name="section"></param>
+        /// <returns></returns>
+        abstract public List<List<CellValue>> GetCellRows(int section);
+
+        /// <summary>
+        /// Get metadata for the rows in the sections
+        /// </summary>        
+        abstract public List<ColumnMetaData> GetColumnMetaData();
+
+        public override void Render(Graphics g)
+        {
+            g.TextRenderingHint = TextRenderingHint.AntiAlias;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+
+            NextX = 0;
+            NextY = 0;
+
+            if (fontMaxCharWidth < 0)
+            {
+                for (int i = 32; i < 127; i++)
+                {
+                    char character = (char)i;
+                    SizeF size = g.MeasureString(character.ToString(), DefaultFont);
+                    fontMaxCharWidth = Math.Max(fontMaxCharWidth, (int)size.Width);
+                }
+            }
+                                   
+            DrawOveralHeaders(g);
+            DrawSections(g);
+        }
+
+        public sealed override void SetupPreviewData()
+        {
+            SimDataProvider.Instance.SetupPreviewData();
+        }
+
+        private void DrawSections(Graphics g)
+        {
+            List<HeaderLabel> sectionHeaders = GetSectionHeaders();
+            if (sectionHeaders.Count == 0)
+            {
+                DrawRowSection(g, 0);
+            }
+            else
+            {
+                int section = 0;
+                foreach (HeaderLabel sectionHeader in sectionHeaders)
+                {
+                    DrawSectionHeader(g, sectionHeader);
+                    DrawRowSection(g, section++);
+                }                                
+            }
+        }
+
+        private void DrawSectionHeader(Graphics g, HeaderLabel sectionHeader)
+        {
+            int maxTextwidth = sectionHeader.ColumnLength * fontMaxCharWidth;
+            
+            g.FillRectangle(sectionHeader.BackgroundColor, NextX, NextY, maxTextwidth, DefaultFont.Height);
+            
+            TextRenderer.DrawText(g, TruncateString(sectionHeader.Name, sectionHeader.ColumnLength), DefaultFont, new Point(NextX, NextY + TextOffset), DefaultTextColor);
+
+            NextX = 0;
+            NextY += DefaultFont.Height + _rowGap;
+        }
+
+        private void DrawRowSection(Graphics g, int section)
+        {            
+            List<ColumnMetaData> columnMetaDatas = GetColumnMetaData();
+            List<List<CellValue>> rows = GetCellRows(section);
+
+
+            for (int rowNum = 0; rowNum < rows.Count; rowNum++)            
+            {
+                List<CellValue> rowValues = rows[rowNum];
+                
+                Brush backgroundColor = OddBackground;                
+                if (rowNum % 2 == 0)
+                {
+                    backgroundColor = EvenBackground;
+                }
+
+                if (rowValues[0].Value.Equals(SessionData.Instance.PlayerCarIndex.ToString()))
+                {
+                    backgroundColor = DriversCarBackground;
+                }                
+
+                for (int colNum = 0; colNum < rowValues.Count; colNum++)
+                {
+                    ColumnMetaData columnMetaData = columnMetaDatas[colNum];
+                    SolidBrush TextColor = DefaultTextColorBrush;
+                    Brush cellBackground = backgroundColor;
+                    if (rowValues[colNum].TextColor != null)
+                    {
+                        TextColor = new SolidBrush(Color.FromArgb(150, (Color)rowValues[colNum].TextColor));
+                    }
+                    if (rowValues[colNum].BackgroundColor !=  null)
+                    {
+                        cellBackground = new SolidBrush(Color.FromArgb(150, (Color)rowValues[colNum].BackgroundColor));
+                    }
+
+                    int maxTextwidth = columnMetaData.ColumnLength * fontMaxCharWidth;
+                    g.FillRectangle(cellBackground, NextX, NextY, maxTextwidth, DefaultFont.Height);
+
+                    TextRenderer.DrawText(g, TruncateString(rowValues[colNum].Value, columnMetaData.ColumnLength), DefaultFont, new Point(NextX, NextY + TextOffset), TextColor.Color);
+                    NextX += maxTextwidth + _columnGap;
+                }
+                NextY += DefaultFont.Height + _rowGap;
+                NextX = 0;
+            }                       
+        }
+
+        
+
+        private void DrawOveralHeaders(Graphics g)
+        {
+            foreach (HeaderLabel headerLabel in GetOverallHeader())
+            {
+                int maxTextwidth = headerLabel.ColumnLength * fontMaxCharWidth;
+                g.FillRectangle(headerLabel.BackgroundColor, NextX, NextY, maxTextwidth, DefaultFont.Height);
+
+                TextRenderer.DrawText(g, TruncateString(headerLabel.Name, headerLabel.ColumnLength), DefaultFont, new Point(NextX, NextY + TextOffset), DefaultTextColorBrush.Color);
+                
+                NextX += maxTextwidth + _columnGap; 
+            }
+            NextY += DefaultFont.Height + _rowGap;
+            NextX = 0;
+        }
+
+
+        private string TruncateString(String text, int maxStringLength)
+        {
+            if (text == null) return "";
+            return text.Length <= maxStringLength ? text : text.Substring(0, maxStringLength);
+        }        
+    }
+
+    public class HeaderLabel
+    {
+        public string Name;
+        public int ColumnLength;
+        public Brush BackgroundColor;
+        public HeaderLabel(string name, int labelLength, Brush backgroundColor)
+        {
+            Name = name;
+            ColumnLength = labelLength;
+            BackgroundColor = backgroundColor;
+        }
+    }
+
+    public class ColumnMetaData
+    {
+        public string Name;
+        public int ColumnLength;
+        public ColumnMetaData(string name, int columnLength) {
+            Name = name;
+            ColumnLength = columnLength;
+        }
+    }
+
+    public class CellValue
+    {
+        public String Value;
+        public Color? TextColor = null;
+        public Color? BackgroundColor = null;
+        
+        public CellValue(string v, Color? textColor, Color? backgroundColor)
+        {
+            this.Value = v;
+            this.TextColor = textColor;
+            this.BackgroundColor = backgroundColor;
+        }
+    }    
+}

--- a/Race_Element.HUD/Overlay/Internal/CommonAbstractOverlay.cs
+++ b/Race_Element.HUD/Overlay/Internal/CommonAbstractOverlay.cs
@@ -64,20 +64,26 @@ public abstract class CommonAbstractOverlay : FloatingWindow
             return true;
 
         if (IsRepositioning)
-            return true;
-
+            return true;        
+        
         
         if (!SimDataProvider.HasTelemetry())
             return false;
 
         // For show only HUDs when player is on track. 
         // TODO: Distinguish in sim data providers between pit and garage and only show in pit, but not garage or make configurable.
-        CarInfo carInfo = SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value;
-        if (carInfo.CarLocation != CarInfo.CarLocationEnum.Track) return false;
-
-        bool shouldRender = true;
-
-        return shouldRender;
+        if (SessionData.Instance.Cars.Count > SessionData.Instance.PlayerCarIndex)
+        {
+            CarInfo carInfo = SessionData.Instance.Cars[SessionData.Instance.PlayerCarIndex].Value;
+            if (carInfo.CarLocation == CarInfo.CarLocationEnum.NONE || carInfo.CarLocation == CarInfo.CarLocationEnum.Garage) return false;
+        } else
+        {
+            Debug.WriteLine("Telemetry initialized by no player data. PlayerIdx {0} Driver count {1}",
+                SessionData.Instance.PlayerCarIndex, SessionData.Instance.Cars.Count);
+            return false;
+        }        
+        
+        return true;
     }
 
     private void LoadFieldConfig()

--- a/Race_Element.HUD/Overlay/Internal/DataUtil.cs
+++ b/Race_Element.HUD/Overlay/Internal/DataUtil.cs
@@ -7,14 +7,14 @@ using RaceElement.Data.Common.SimulatorData;
 
 namespace RaceElement.HUD.Overlay.Internal
 {
-    internal static class DataUtil
+    public static class DataUtil
     {
 
         // Get the grap to the car in front.
         // Restrictions
         //   1) Does not take into account classes
         //   2) Needs the sim to provide the speed of each car (Kmh)
-        private static string GetGapToCarInFront(List<KeyValuePair<int, CarInfo>> list, int i)
+        public static string GetGapToCarInFront(List<KeyValuePair<int, CarInfo>> list, int i)
         {
             // inspired by acc bradcasting client
 
@@ -33,6 +33,37 @@ namespace RaceElement.HUD.Overlay.Internal
             }
             return $"{gabMeters / currentCar.Kmh * 3.6:F1}s ⇅";
 
+        }
+
+        /// <summary>
+        /// Format a lap time difference in milliseconds
+        /// </summary>        
+        public static String GetTimeDiff(int? LaptimeMS)
+        {
+            if (LaptimeMS == null || LaptimeMS == 0)
+            {
+                return "--:--.---";
+            }
+
+            TimeSpan lapTime = TimeSpan.FromMilliseconds((double)LaptimeMS);
+            if (lapTime.Minutes > 0)
+                return $"{lapTime:m\\:s\\.f}";
+            else
+                return $"{lapTime:s\\.f}";
+        }
+
+        /// <summary>
+        /// Format a lap time
+        /// </summary>
+        public static String GetLapTime(LapInfo lap)
+        {
+            if (lap == null || !lap.LaptimeMS.HasValue || lap.LaptimeMS < 0)
+            {
+                return "--:--.---";
+            }
+
+            TimeSpan lapTime = TimeSpan.FromMilliseconds(lap.LaptimeMS.Value);
+            return $"{lapTime:mm\\:ss\\.fff}";
         }
     }
 }

--- a/Race_Element.HUD/Overlay/OverlayUtil/AbstractTableOverlay.cs
+++ b/Race_Element.HUD/Overlay/OverlayUtil/AbstractTableOverlay.cs
@@ -8,16 +8,16 @@ using System.Drawing.Text;
 using System.Windows.Forms;
 using RaceElement.Data.Common;
 using RaceElement.Data.Common.SimulatorData;
-using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.Util;
 
-namespace RaceElement.HUD.Overlay.Internal
+namespace RaceElement.HUD.Overlay.OverlayUtil
 {
     public abstract class AbstractTableOverlay : CommonAbstractOverlay
     {
         private int NextX { get; set; }
         private int NextY { get; set; }
-        
+
         private readonly int _columnGap = 5;
         // pixels between rows
         private readonly int _rowGap = 3;
@@ -34,7 +34,8 @@ namespace RaceElement.HUD.Overlay.Internal
         public static readonly SolidBrush DriversCarBackground = new(Color.FromArgb(180, Color.DarkSeaGreen));
         public static readonly SolidBrush HeaderBackground = new(Color.FromArgb(100, Color.DarkSeaGreen));
 
-        protected AbstractTableOverlay(Rectangle rectangle, string Name) : base(rectangle, Name) {            
+        protected AbstractTableOverlay(Rectangle rectangle, string Name) : base(rectangle, Name)
+        {
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace RaceElement.HUD.Overlay.Internal
                     fontMaxCharWidth = Math.Max(fontMaxCharWidth, (int)size.Width);
                 }
             }
-                                   
+
             DrawOveralHeaders(g);
             DrawSections(g);
         }
@@ -102,16 +103,16 @@ namespace RaceElement.HUD.Overlay.Internal
                 {
                     DrawSectionHeader(g, sectionHeader);
                     DrawRowSection(g, section++);
-                }                                
+                }
             }
         }
 
         private void DrawSectionHeader(Graphics g, HeaderLabel sectionHeader)
         {
             int maxTextwidth = sectionHeader.ColumnLength * fontMaxCharWidth;
-            
+
             g.FillRectangle(sectionHeader.BackgroundColor, NextX, NextY, maxTextwidth, DefaultFont.Height);
-            
+
             TextRenderer.DrawText(g, TruncateString(sectionHeader.Name, sectionHeader.ColumnLength), DefaultFont, new Point(NextX, NextY + TextOffset), DefaultTextColor);
 
             NextX = 0;
@@ -119,16 +120,16 @@ namespace RaceElement.HUD.Overlay.Internal
         }
 
         private void DrawRowSection(Graphics g, int section)
-        {            
+        {
             List<ColumnMetaData> columnMetaDatas = GetColumnMetaData();
             List<List<CellValue>> rows = GetCellRows(section);
 
 
-            for (int rowNum = 0; rowNum < rows.Count; rowNum++)            
+            for (int rowNum = 0; rowNum < rows.Count; rowNum++)
             {
                 List<CellValue> rowValues = rows[rowNum];
-                
-                Brush backgroundColor = OddBackground;                
+
+                Brush backgroundColor = OddBackground;
                 if (rowNum % 2 == 0)
                 {
                     backgroundColor = EvenBackground;
@@ -137,7 +138,7 @@ namespace RaceElement.HUD.Overlay.Internal
                 if (rowValues[0].Value.Equals(SessionData.Instance.PlayerCarIndex.ToString()))
                 {
                     backgroundColor = DriversCarBackground;
-                }                
+                }
 
                 for (int colNum = 0; colNum < rowValues.Count; colNum++)
                 {
@@ -148,7 +149,7 @@ namespace RaceElement.HUD.Overlay.Internal
                     {
                         TextColor = new SolidBrush(Color.FromArgb(150, (Color)rowValues[colNum].TextColor));
                     }
-                    if (rowValues[colNum].BackgroundColor !=  null)
+                    if (rowValues[colNum].BackgroundColor != null)
                     {
                         cellBackground = new SolidBrush(Color.FromArgb(150, (Color)rowValues[colNum].BackgroundColor));
                     }
@@ -161,10 +162,10 @@ namespace RaceElement.HUD.Overlay.Internal
                 }
                 NextY += DefaultFont.Height + _rowGap;
                 NextX = 0;
-            }                       
+            }
         }
 
-        
+
 
         private void DrawOveralHeaders(Graphics g)
         {
@@ -174,21 +175,24 @@ namespace RaceElement.HUD.Overlay.Internal
                 g.FillRectangle(headerLabel.BackgroundColor, NextX, NextY, maxTextwidth, DefaultFont.Height);
 
                 TextRenderer.DrawText(g, TruncateString(headerLabel.Name, headerLabel.ColumnLength), DefaultFont, new Point(NextX, NextY + TextOffset), DefaultTextColorBrush.Color);
-                
-                NextX += maxTextwidth + _columnGap; 
+
+                NextX += maxTextwidth + _columnGap;
             }
             NextY += DefaultFont.Height + _rowGap;
             NextX = 0;
         }
 
 
-        private string TruncateString(String text, int maxStringLength)
+        private string TruncateString(string text, int maxStringLength)
         {
             if (text == null) return "";
             return text.Length <= maxStringLength ? text : text.Substring(0, maxStringLength);
-        }        
+        }
     }
+}
 
+namespace RaceElement.HUD.Overlay.Internal
+{
     public class HeaderLabel
     {
         public string Name;
@@ -206,7 +210,8 @@ namespace RaceElement.HUD.Overlay.Internal
     {
         public string Name;
         public int ColumnLength;
-        public ColumnMetaData(string name, int columnLength) {
+        public ColumnMetaData(string name, int columnLength)
+        {
             Name = name;
             ColumnLength = columnLength;
         }
@@ -214,15 +219,15 @@ namespace RaceElement.HUD.Overlay.Internal
 
     public class CellValue
     {
-        public String Value;
+        public string Value;
         public Color? TextColor = null;
         public Color? BackgroundColor = null;
-        
+
         public CellValue(string v, Color? textColor, Color? backgroundColor)
         {
-            this.Value = v;
-            this.TextColor = textColor;
-            this.BackgroundColor = backgroundColor;
+            Value = v;
+            TextColor = textColor;
+            BackgroundColor = backgroundColor;
         }
-    }    
+    }
 }


### PR DESCRIPTION
- Fix iRacing Provider and Standings HUDs. This should show correct data 
- New Relative HUD showing cars next to player's car regardless of class. Uses new common table HUD code to be used for the Standings HUD next. 
   - There are some issues here, especially no cars in Relative displayed next to the start and finish line.  