### PR TITLE
Fix bug: Pit lane prediction for pitstop with damage

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapPitPrediction.cs
@@ -24,7 +24,7 @@ public static class TrackMapPitPrediction
         }
 
         var info = TrackData.GetCurrentTrack(ACCSharedMemory.Instance.PageFileStatic.Track);
-        time = time * 1000 + pitTimeMs + info.PitLaneTime;
+        time = time * 1000 + pitTimeMs + info.PitLaneTime * 1000;
         var pitStop = ComputePitStop(track, time);
 
         if (pitStop != null)


### PR DESCRIPTION
Translate pit lane time to milliseconds from seconds