### PR TITLE
2.1.0.2

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Driving/BrakeHistory/BrakeTempHistoryConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/BrakeHistory/BrakeTempHistoryConfiguration.cs
@@ -12,6 +12,9 @@ internal class BrakeTempHistoryConfiguration : OverlayConfiguration
     {
         [ToolTip("Whilst the setup screen is visible, the HUD will also be visible.")]
         public bool ShowInSetupScreen { get; init; } = true;
+
+        [ToolTip("Hides this HUD in race sessions.")]
+        public bool HideInRace { get; init; } = false;
     }
 
     [ConfigGrouping("Table", "Adjust settings for the sector data table")]

--- a/Race_Element.HUD.ACC/Overlays/Driving/BrakeHistory/BrakeTempHistoryOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/BrakeHistory/BrakeTempHistoryOverlay.cs
@@ -187,6 +187,9 @@ internal sealed class BrakeTempHistoryOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
+        if (_config.Behavior.HideInRace && pageGraphics.SessionType == ACCSharedMemory.AcSessionType.AC_RACE)
+            return false;
+
         if (_config.Behavior.ShowInSetupScreen && pageGraphics.IsSetupMenuVisible)
             return true;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapInfo/LapInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapInfo/LapInfoOverlay.cs
@@ -36,6 +36,13 @@ internal sealed class LapInfoOverlay : AbstractOverlay
             [ToolTip("Displays the estimated lap time.")]
             public bool EstimatedTime { get; init; } = true;
         }
+
+        [ConfigGrouping("Behavior", "Adjust behavorial settings")]
+        public BehaviorGrouping Behavior { get; init; } = new();
+        public sealed class BehaviorGrouping
+        {
+            public bool HideInRace { get; init; } = false;
+        }
     }
 
     private const int _overlayWidth = 205;
@@ -78,7 +85,13 @@ internal sealed class LapInfoOverlay : AbstractOverlay
         if (newLap.Sector1 != -1 && newLap.Sector2 != -1 && newLap.Sector3 != -1)
             _lastLap = newLap;
     }
+    public override bool ShouldRender()
+    {
+        if (_config.Behavior.HideInRace && pageGraphics.SessionType == ACCSharedMemory.AcSessionType.AC_RACE)
+            return false;
 
+        return base.ShouldRender();
+    }
     public sealed override void Render(Graphics g)
     {
         g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTableOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTableOverlay.cs
@@ -203,6 +203,14 @@ internal sealed class LapTableOverlay : AbstractOverlay
             _columnBackgroundsValid[i].Dispose();
     }
 
+
+    public override bool ShouldRender()
+    {
+        if (_config.Behavior.HideInRace && pageGraphics.SessionType == ACCSharedMemory.AcSessionType.AC_RACE)
+            return false;
+
+        return base.ShouldRender();
+    }
     public sealed override void Render(Graphics g)
     {
         if (!_dataIsPreview)

--- a/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTimeTableConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/LapTable/LapTimeTableConfiguration.cs
@@ -20,5 +20,12 @@ internal sealed class LapTimeTableConfiguration : OverlayConfiguration
         public int Roundness { get; init; } = 2;
     }
 
+    [ConfigGrouping("Behavior", "Adjust behavorial settings")]
+    public BehaviorGrouping Behavior { get; init; } = new();
+    public sealed class BehaviorGrouping
+    {
+        public bool HideInRace { get; init; } = false;
+    }
+
     public LapTimeTableConfiguration() => GenericConfiguration.AllowRescale = true;
 }

--- a/Race_Element.HUD.ACC/Overlays/Driving/PressureHistory/PressureHistoryConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/PressureHistory/PressureHistoryConfiguration.cs
@@ -17,6 +17,9 @@ internal sealed class PressureHistoryConfiguration : OverlayConfiguration
     {
         [ToolTip("Whilst the setup screen is visible, the HUD will also be visible.")]
         public bool ShowInSetupScreen { get; init; } = true;
+
+        [ToolTip("Hides this HUD in race sessions.")]
+        public bool HideInRace { get; init; } = false;
     }
 
     [ConfigGrouping("Table", "Adjust settings for the sector data table")]

--- a/Race_Element.HUD.ACC/Overlays/Driving/PressureHistory/PressureHistoryOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/PressureHistory/PressureHistoryOverlay.cs
@@ -188,6 +188,9 @@ internal sealed class PressureHistoryOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
+        if (_config.Behavior.HideInRace && pageGraphics.SessionType == ACCSharedMemory.AcSessionType.AC_RACE)
+            return false;
+
         if (_config.Behavior.ShowInSetupScreen && pageGraphics.IsSetupMenuVisible)
             return true;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TrackMap/TrackMapOverlay.cs
@@ -61,7 +61,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
         _miniMapCreationJob = new TrackMapCreationJob()
         {
-            IntervalMillis = 1,
+            IntervalMillis = 2,
         };
 
         _miniMapCreationJob.OnMapPositionsCallback += OnMapPositionsCallback;
@@ -144,7 +144,7 @@ internal sealed class TrackMapOverlay : AbstractOverlay
 
         _miniMapCreationJob = new TrackMapCreationJob()
         {
-            IntervalMillis = 1,
+            IntervalMillis = 2,
         };
 
         _miniMapCreationJob.OnMapPositionsCallback += OnMapPositionsCallback;

--- a/Race_Element.HUD.ACC/Overlays/Driving/TyreTempHistory/TyreTempHistoryConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TyreTempHistory/TyreTempHistoryConfiguration.cs
@@ -12,6 +12,9 @@ internal sealed class TyreTempHistoryConfiguration : OverlayConfiguration
     {
         [ToolTip("Whilst the setup screen is visible, the HUD will also be visible.")]
         public bool ShowInSetupScreen { get; init; } = true;
+
+        [ToolTip("Hides this HUD in race sessions.")]
+        public bool HideInRace { get; init; } = false;
     }
 
     [ConfigGrouping("Table", "Adjust settings for the sector data table")]

--- a/Race_Element.HUD.ACC/Overlays/Driving/TyreTempHistory/TyreTempHistoryOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TyreTempHistory/TyreTempHistoryOverlay.cs
@@ -187,6 +187,9 @@ internal sealed class TyreTempHistoryOverlay : AbstractOverlay
 
     public override bool ShouldRender()
     {
+        if (_config.Behavior.HideInRace && pageGraphics.SessionType == ACCSharedMemory.AcSessionType.AC_RACE)
+            return false;
+
         if (_config.Behavior.ShowInSetupScreen && pageGraphics.IsSetupMenuVisible)
             return true;
 

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,12 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
-        {"2.1.0.2", "- Fixed Track Map HUD (ACC)." },
+        {"2.1.0.2", "Assetto Corsa Competizione:"+
+                    "\n- Tyre Temp History HUD can now be automatically hidden in race sessions."+
+                    "\n- Brake Temp History HUD can now be automatically hidden in race sessions."+
+                    "\n- Tyre Pressure History HUD can now be automatically hidden in race sessions."+
+                    "\n- Lap Table HUD can now be automatically hidden in race sessions."+
+                    "\n- Fixed Track Map HUD (ACC)." },
         {"2.1.0.0", "Race Element:"+
                     "\n- When dragging titlebar when maximized, the app now returns to normal mode."+
                     "\n\nAll HUDs:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -11,6 +11,7 @@ public static class ReleaseNotes
                     "\n- Brake Temp History HUD can now be automatically hidden in race sessions."+
                     "\n- Tyre Pressure History HUD can now be automatically hidden in race sessions."+
                     "\n- Lap Table HUD can now be automatically hidden in race sessions."+
+                    "\n- Lap Info HUD can now be automatically hidden in race sessions."+
                     "\n- Fixed Track Map HUD (ACC)." },
         {"2.1.0.0", "Race Element:"+
                     "\n- When dragging titlebar when maximized, the app now returns to normal mode."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
+        {"2.1.0.2", "- Fixed Track Map HUD (ACC)." },
         {"2.1.0.0", "Race Element:"+
                     "\n- When dragging titlebar when maximized, the app now returns to normal mode."+
                     "\n\nAll HUDs:"+

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.1.0.0</ApplicationVersion>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-        <Version>2.1.0.0</Version>
+        <ApplicationVersion>2.1.0.1</ApplicationVersion>
+        <AssemblyVersion>2.1.0.1</AssemblyVersion>
+        <Version>2.1.0.1</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.1.0.1</ApplicationVersion>
-        <AssemblyVersion>2.1.0.1</AssemblyVersion>
-        <Version>2.1.0.1</Version>
+        <ApplicationVersion>2.1.0.2</ApplicationVersion>
+        <AssemblyVersion>2.1.0.2</AssemblyVersion>
+        <Version>2.1.0.2</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>


### PR DESCRIPTION
- Tyre Temp History HUD can now be automatically hidden in race sessions.
- Brake Temp History HUD can now be automatically hidden in race sessions.
- Tyre Pressure History HUD can now be automatically hidden in race sessions.
- Lap Table HUD can now be automatically hidden in race sessions.
- Lap Info HUD can now be automatically hidden in race sessions.
- Fixed Track Map HUD (ACC).