### PR TITLE
2.2.0.0

### DIFF
--- a/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Trailer.cs
+++ b/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Trailer.cs
@@ -7,7 +7,7 @@ public partial class SCSTelemetry {
     /// <summary>
     ///     Trailer Values
     /// </summary>
-    public class Trailer {
+    public sealed class Trailer {
 
         /// <summary>
         ///     Initialise a trailer object
@@ -83,7 +83,7 @@ public partial class SCSTelemetry {
         /// </summary>
         public Wheels Wheelvalues { get; internal set; }
 
-        public class Acceleration {
+        public sealed class Acceleration {
 
             /// <summary>
             ///     Represents vehicle space angular acceleration of the trailer measured in rotations/s^2
@@ -106,7 +106,7 @@ public partial class SCSTelemetry {
             public FVector LinearVelocity { get; internal set; }
         }
 
-        public class Damage {
+        public sealed class Damage {
             public float Body { get; internal set; }
             public float Cargo { get; internal set; }
             public float Chassis { get; internal set; }
@@ -116,7 +116,7 @@ public partial class SCSTelemetry {
         /// <summary>
         ///     States of the Wheels
         /// </summary>
-        public class Wheels {
+        public sealed class Wheels {
             /// About: Velocity
             /// Positive velocity corresponds to forward movement
 

--- a/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Truck.Constants.cs
+++ b/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Truck.Constants.cs
@@ -4,7 +4,7 @@ public partial class SCSTelemetry {
         /// <summary>
         ///     Config values
         /// </summary>
-        public class Constants {
+        public sealed class Constants {
             /// <summary>
             ///     Initialise a constants object
             /// </summary>
@@ -68,7 +68,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     Gear, Retarder, etc.
             /// </summary>
-            public class Motor {
+            public sealed class Motor {
                 /// About: RetarderStepCount
                 /// Set to zero if retarder is not mounted on the truck
                 
@@ -148,7 +148,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     Fuel, Adblue, etc.
             /// </summary>
-            public class Capacity {
+            public sealed class Capacity {
                 /// <summary>
                 ///     Fuel tank capacity in litres.
                 /// </summary>
@@ -163,7 +163,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     At which value X give a warning?
             /// </summary>
-            public class WarningFactor {
+            public sealed class WarningFactor {
                 /// <summary>
                 ///     Fraction of the fuel capacity bellow which is activated the fuel warning.
                 /// </summary>

--- a/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Truck.Current.cs
+++ b/Race Element.Data/Games/SCS2/SharedMemory/Object/SCSTelemetry.Truck.Current.cs
@@ -5,7 +5,7 @@ public partial class SCSTelemetry {
         /// <summary>
         ///     Values that are changing a lot oftener
         /// </summary>
-        public class Current {
+        public sealed class Current {
             /// <summary>
             ///     Initialise a current truck object
             /// </summary>
@@ -98,7 +98,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     Gear, Retarder, etc.
             /// </summary>
-            public class Motor {
+            public sealed class Motor {
                 /// <summary>
                 ///     Initialise a motor object
                 /// </summary>
@@ -120,7 +120,7 @@ public partial class SCSTelemetry {
                 /// <summary>
                 ///     Slected Gear, HShifter... etc.
                 /// </summary>
-                public class Gear {
+                public sealed class Gear {
                     /// About: HShifterSlot
                     /// 0 means that no slot is selected
                     ///  
@@ -157,7 +157,7 @@ public partial class SCSTelemetry {
                 /// <summary>
                 ///     Brake Values
                 /// </summary>
-                public class Brakes {
+                public sealed class Brakes {
                     /// About: RetarderLevel
                     /// <0;max>
                     ///     where 0 is disabled retarder and max is maximal value found in Truck configuration
@@ -197,7 +197,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     Speed, RPM, Pressures, Temperatures
             /// </summary>
-            public class Dashboard {
+            public sealed class Dashboard {
                 /// <summary>
                 ///     Initialise a dashboard object
                 /// </summary>
@@ -306,7 +306,7 @@ public partial class SCSTelemetry {
                 /// <summary>
                 ///     Contains Fuel values
                 /// </summary>
-                public class Fuel {
+                public sealed class Fuel {
                     /// <summary>
                     ///     Amount of fuel in liters
                     /// </summary>
@@ -326,7 +326,7 @@ public partial class SCSTelemetry {
                 /// <summary>
                 ///     Warnings
                 /// </summary>
-                public class Warnings {
+                public sealed class Warnings {
                     /// <summary>
                     ///     Is the air pressure warning active?
                     /// </summary>
@@ -367,7 +367,7 @@ public partial class SCSTelemetry {
             /// <summary>
             ///     Lightlevel and state of Lights
             /// </summary>
-            public class Lights {
+            public sealed class Lights {
                 /// About: Blinker Avtive
                 /// This represents the logical enable state of the blinker. It
                 /// it is true as long the blinker is enabled regardless of the

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftBar/ShiftBarOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftBar/ShiftBarOverlay.cs
@@ -10,13 +10,11 @@ using System.Runtime.InteropServices;
 
 namespace RaceElement.HUD.Common.Overlays.Driving.ShiftBar;
 
-//#if DEBUG
 [Overlay(
     Name = "Shift Bar",
-    Description = "(Beta) A lightweight RPM Bar. Can render up to 200 Hz for some simulators.",
+    Description = "A lightweight RPM Bar. Can render up to 200 Hz for some simulators.",
     Authors = ["Reinier Klarenberg"]
 )]
-//#endif
 internal sealed class ShiftBarOverlay : CommonAbstractOverlay
 {
     private readonly ShiftBarConfiguration _config = new();

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftIndicator/ShiftIndicatorOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftIndicator/ShiftIndicatorOverlay.cs
@@ -11,12 +11,14 @@ using Unglide;
 
 namespace RaceElement.HUD.Common.Overlays.Driving.ShiftIndicator;
 
+#if DEBUG
 [Overlay(Name = "Shift Indicator",
     Description = "Shift Bar with RPM Text. Adjustable colors and percentages. (BETA)",
     Version = 1.00,
     OverlayType = OverlayType.Drive,
     OverlayCategory = OverlayCategory.Driving,
 Authors = ["Reinier Klarenberg, Dirk Wolf"])]
+#endif
 internal sealed class ShiftIndicatorOverlay : CommonAbstractOverlay
 {
     private readonly ShiftIndicatorConfiguration _config = new();

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using RaceElement.HUD.Overlay.Configuration;
+using System.Drawing;
 
 namespace RaceElement.HUD.Common.Overlays.Driving.ShiftRpm;
 internal sealed class ShiftRpmConfiguration : OverlayConfiguration
@@ -11,13 +12,30 @@ internal sealed class ShiftRpmConfiguration : OverlayConfiguration
     {
         [ToolTip("Size of the font")]
         [FloatRange(12.0f, 90.0f, 0.5f, 1)]
-        public float FontSize { get; init; } = 12.0f;
+        public float FontSize { get; init; } = 20;
 
         [ToolTip("Change the Font")]
-        public RpmTextFont Font { get; init; } = RpmTextFont.Conthrax;
+        public RpmTextFont Font { get; init; } = RpmTextFont.Obitron;
 
         [IntRange(0, 30, 1)]
-        public int ExtraDigitSpacing { get; init; } = 0;
+        public int ExtraDigitSpacing { get; init; } = 2;
+
+        [IntRange(0, 100, 1)]
+        public int RefreshRate { get; init; } = 50;
+    }
+
+
+    [ConfigGrouping("Colors", "Adjust colors")]
+    public ColorsGrouping Colors { get; init; } = new ColorsGrouping();
+    public class ColorsGrouping
+    {
+        public Color TextColor { get; init; } = Color.FromArgb(255, 255, 255, 255);
+        [IntRange(75, 255, 1)]
+        public int TextOpacity { get; init; } = 255;
+
+        public Color BackgroundColor { get; init; } = Color.FromArgb(255, 0, 0, 0);
+        [IntRange(75, 255, 1)]
+        public int BackgroundOpacity { get; init; } = 175;
     }
 
     public enum RpmTextFont { Roboto, Conthrax, Obitron }

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using RaceElement.HUD.Overlay.Configuration;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.ShiftRpm;
+internal sealed class ShiftRpmConfiguration : OverlayConfiguration
+{
+    public ShiftRpmConfiguration() => GenericConfiguration.AllowRescale = false;
+
+    [ConfigGrouping("General", "General options")]
+    public GeneralGrouping General { get; init; } = new();
+    public sealed class GeneralGrouping
+    {
+        [ToolTip("Size of the font")]
+        [FloatRange(12.0f, 90.0f, 0.5f, 1)]
+        public float FontSize { get; init; } = 12.0f;
+
+        [ToolTip("Change the Font")]
+        public RpmTextFont Font { get; init; } = RpmTextFont.Conthrax;
+
+        [IntRange(0, 30, 1)]
+        public int ExtraDigitSpacing { get; init; } = 0;
+    }
+
+    public enum RpmTextFont { Roboto, Conthrax, Obitron }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
@@ -1,0 +1,34 @@
+﻿using RaceElement.HUD.Overlay.Internal;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.ShiftRpm;
+[Overlay(
+Name = "Shift RPM",
+Description = "The current engine RPM as text")]
+internal sealed class ShiftRpmOverlay : CommonAbstractOverlay
+{
+
+    public ShiftRpmOverlay(Rectangle rectangle) : base(rectangle, "Shift RPM")
+    {
+    }
+
+    public override void Render(Graphics g)
+    {
+
+    }
+}
+internal class RpmBitmaps
+{
+    public CachedBitmap? GetForNumber(byte number)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(number, 9);
+
+        return null;
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
@@ -1,8 +1,11 @@
-﻿using RaceElement.HUD.Overlay.Internal;
+﻿using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.Util;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
+using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,22 +16,99 @@ Name = "Shift RPM",
 Description = "The current engine RPM as text")]
 internal sealed class ShiftRpmOverlay : CommonAbstractOverlay
 {
+    private readonly ShiftRpmConfiguration _config = new();
 
+    private CachedBitmap _cachedBackground;
+
+    private RpmBitmaps _bitmaps;
     public ShiftRpmOverlay(Rectangle rectangle) : base(rectangle, "Shift RPM")
     {
+        RefreshRateHz = 20;
+    }
+
+    public override void BeforeStart()
+    {
+        _bitmaps = new RpmBitmaps(_config.General.Font, _config.General.FontSize);
+        Width = 5 * _bitmaps.Dimension.Width + _config.General.ExtraDigitSpacing * 4;
+        Height = _bitmaps.Dimension.Height;
+
+        _cachedBackground = new(Width, Height, g =>
+        {
+            RectangleF barArea = new(0, 0, Width - 1, Height - 1);
+
+            g.CompositingQuality = CompositingQuality.HighQuality;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            using SolidBrush darkBrush = new(Color.FromArgb(90, Color.Black));
+            g.FillRoundedRectangle(darkBrush, Rectangle.Round(barArea), 3);
+            using Pen darkPen = new(darkBrush, 1);
+            g.DrawRoundedRectangle(darkPen, Rectangle.Round(barArea), 3);
+        });
+    }
+
+    public override void BeforeStop()
+    {
+        _cachedBackground?.Dispose();
+        _bitmaps?.Dispose();
     }
 
     public override void Render(Graphics g)
     {
+        _cachedBackground?.Draw(g);
 
+        int x = 0;
+        for (int i = 0; i < 5; i++)
+        {
+            _bitmaps.GetForNumber((byte)Random.Shared.Next(0, 9)).Draw(g, new(x, 0));
+            x += _bitmaps.Dimension.Width + _config.General.ExtraDigitSpacing;
+        }
     }
 }
-internal class RpmBitmaps
+
+internal sealed class RpmBitmaps : IDisposable
 {
-    public CachedBitmap? GetForNumber(byte number)
+    private readonly CachedBitmap[] _rpmBitmaps = new CachedBitmap[10];
+    public readonly (int Width, int Height) Dimension;
+    public RpmBitmaps(ShiftRpmConfiguration.RpmTextFont font, float fontSize)
+    {
+        GenerateBitMaps(font, fontSize);
+        Dimension = (_rpmBitmaps[0].Width, _rpmBitmaps[0].Height);
+    }
+
+    private void GenerateBitMaps(ShiftRpmConfiguration.RpmTextFont fontType, float fontSize)
+    {
+        Font font = fontType switch
+        {
+            ShiftRpmConfiguration.RpmTextFont.Conthrax => FontUtil.FontConthrax(fontSize),
+            ShiftRpmConfiguration.RpmTextFont.Obitron => FontUtil.FontOrbitron(fontSize),
+            ShiftRpmConfiguration.RpmTextFont.Roboto => FontUtil.FontRoboto(fontSize),
+            _ => FontUtil.FontConthrax(fontSize),
+        };
+
+        StringFormat format = StringFormat.GenericDefault;
+        format.Alignment = StringAlignment.Center;
+        format.LineAlignment = StringAlignment.Center;
+        format.FormatFlags = StringFormatFlags.NoClip;
+
+        int bitmapWidth = (int)(fontSize + 4);
+        int bitmapHeight = bitmapWidth + 4;
+        for (int i = 0; i <= 9; i++)
+        {
+            _rpmBitmaps[i] = new(bitmapWidth, bitmapHeight, g =>
+            {
+                g.DrawStringWithShadow($"{i}", font, Color.White, new RectangleF(0, 2, bitmapWidth, bitmapHeight - 2), format);
+            });
+        }
+    }
+    public CachedBitmap GetForNumber(byte number)
     {
         ArgumentOutOfRangeException.ThrowIfGreaterThan(number, 9);
+        return _rpmBitmaps.AsSpan()[number];
+    }
 
-        return null;
+    public void Dispose()
+    {
+        foreach (CachedBitmap cachedBitmap in _rpmBitmaps)
+            cachedBitmap?.Dispose();
     }
 }
+

--- a/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
@@ -1,6 +1,8 @@
-﻿using RaceElement.HUD.Overlay.Internal;
+﻿using RaceElement.Data.Common;
+using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.Util;
+using RaceElement.Util.SystemExtensions;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -48,9 +50,18 @@ internal sealed class ShiftRpmOverlay(Rectangle rectangle) : CommonAbstractOverl
         _cachedBackground?.Draw(g);
 
         int x = 0;
+
+        int currentRpm = SimDataProvider.LocalCar.Engine.Rpm;
+        currentRpm.Clip(0, 99_999);
+
+
+        string s = $"{currentRpm}".FillStart(5, '0');
+
         for (int i = 0; i < 5; i++)
         {
-            _bitmaps.GetForNumber((byte)Random.Shared.Next(0, 9)).Draw(g, new(x, 0));
+            if (byte.TryParse(s.AsSpan(i, 1), out byte number))
+                _bitmaps.GetForNumber(number).Draw(g, new(x, 0));
+
             x += _bitmaps.Dimension.Width + _config.General.ExtraDigitSpacing;
         }
     }
@@ -76,10 +87,10 @@ internal sealed class RpmBitmaps : IDisposable
             _ => FontUtil.FontConthrax(config.General.FontSize),
         };
 
-        StringFormat format = StringFormat.GenericDefault;
+        using StringFormat format = StringFormat.GenericDefault;
         format.Alignment = StringAlignment.Center;
         format.LineAlignment = StringAlignment.Center;
-        format.FormatFlags = StringFormatFlags.NoClip;
+        //format.FormatFlags = StringFormatFlags.NoClip;
 
         int bitmapWidth = (int)(config.General.FontSize + 4);
         int bitmapHeight = bitmapWidth + 4;

--- a/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
+++ b/Race_Element.Data.ACC/EntryList/EntryListTracker.cs
@@ -34,7 +34,7 @@ public sealed class EntryListTracker
     {
         get
         {
-            if (_entryListCars.Count > 1)
+            if (_entryListCars.Count > 0)
                 return [.. _entryListCars];
             else return [];
         }

--- a/Race_Element.HUD.ACC/Overlays/Driving/ShiftBar/ShiftBarOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/ShiftBar/ShiftBarOverlay.cs
@@ -13,13 +13,11 @@ using System.Runtime.InteropServices;
 
 namespace RaceElement.HUD.ACC.Overlays.Driving.ShiftBar;
 
-//#if DEBUG
 [Overlay(
     Name = "Shift Bar",
-    Description = "(Beta) A lightweight RPM Bar. Can render up to 200 Hz.",
+    Description = "A lightweight RPM Bar. Can render up to 200 Hz.",
     Authors = ["Reinier Klarenberg"]
 )]
-//#endif
 internal sealed class ShiftBarOverlay : AbstractOverlay
 {
     private readonly ShiftBarConfiguration _config = new();

--- a/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using RaceElement.HUD.Overlay.Configuration;
 using System.Drawing;
 
-namespace RaceElement.HUD.Common.Overlays.Driving.ShiftRpm;
+namespace RaceElement.HUD.ACC.Overlays.Driving.ShiftRpm;
 internal sealed class ShiftRpmConfiguration : OverlayConfiguration
 {
     public ShiftRpmConfiguration() => GenericConfiguration.AllowRescale = false;

--- a/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
@@ -23,7 +23,7 @@ internal sealed class ShiftRpmOverlay(Rectangle rectangle) : AbstractOverlay(rec
         RefreshRateHz = _config.General.RefreshRate;
 
         _bitmaps = new RpmBitmaps(_config);
-        Width = 5 * _bitmaps.Dimension.Width + _config.General.ExtraDigitSpacing * 4;
+        Width = 4 * _bitmaps.Dimension.Width + _config.General.ExtraDigitSpacing * 3;
         Height = _bitmaps.Dimension.Height;
 
         _cachedBackground = new(Width, Height, g =>

--- a/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/ShiftRpm/ShiftRpmOverlay.cs
@@ -3,14 +3,15 @@ using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.Util;
 using RaceElement.Util.SystemExtensions;
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
-namespace RaceElement.HUD.Common.Overlays.Driving.ShiftRpm;
+namespace RaceElement.HUD.ACC.Overlays.Driving.ShiftRpm;
 [Overlay(
 Name = "Shift RPM",
 Description = "The current engine RPM as text")]
-internal sealed class ShiftRpmOverlay(Rectangle rectangle) : CommonAbstractOverlay(rectangle, "Shift RPM")
+internal sealed class ShiftRpmOverlay(Rectangle rectangle) : AbstractOverlay(rectangle, "Shift RPM")
 {
     private readonly ShiftRpmConfiguration _config = new();
 
@@ -51,13 +52,12 @@ internal sealed class ShiftRpmOverlay(Rectangle rectangle) : CommonAbstractOverl
 
         int x = 0;
 
-        int currentRpm = SimDataProvider.LocalCar.Engine.Rpm;
-        currentRpm.Clip(0, 99_999);
+        int currentRpm = pagePhysics.Rpms;
+        currentRpm.Clip(0, 9_999);
 
+        string s = $"{currentRpm}".FillStart(4, '0');
 
-        string s = $"{currentRpm}".FillStart(5, '0');
-
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 4; i++)
         {
             if (byte.TryParse(s.AsSpan(i, 1), out byte number))
                 _bitmaps.GetForNumber(number).Draw(g, new(x, 0));

--- a/Race_Element.HUD/Overlay/OverlayUtil/FontUtil.cs
+++ b/Race_Element.HUD/Overlay/OverlayUtil/FontUtil.cs
@@ -38,7 +38,6 @@ public sealed class FontUtil
         return GetSpecialFont(size, "RaceElement.HUD.Fonts.ConthraxSb.ttf", "Conthrax Sb");
     }
 
-
     public static Font FontRoboto(float size)
     {
         return GetSpecialFont(size, "RaceElement.HUD.Fonts.Roboto-Regular.ttf", "Roboto");

--- a/Race_Element.HUD/Overlay/OverlayUtil/FontUtil.cs
+++ b/Race_Element.HUD/Overlay/OverlayUtil/FontUtil.cs
@@ -44,18 +44,24 @@ public sealed class FontUtil
         return GetSpecialFont(size, "RaceElement.HUD.Fonts.Roboto-Regular.ttf", "Roboto");
     }
 
-    public static float MeasureWidth(Font font, string text)
+
+    public static float MeasureWidth(Font font, string text) => MeasureString(font, text).Width;
+    public static float MeasureHeight(Font font, string text) => MeasureString(font, text).Height;
+
+    public static SizeF MeasureString(Font font, string text)
     {
-        float width = 0;
+        SizeF size = new();
 
         CachedBitmap c = new(1, 1, g =>
         {
-            width = g.MeasureString(text, font).Width;
+            size = g.MeasureString(text, font);
         });
         c.Dispose();
 
-        return width;
+        return size;
     }
+
+
 
     private static Font GetSpecialFont(float size, string resourceName, string fontName)
     {

--- a/Race_Element.HUD/Overlay/OverlayUtil/GraphicsExtensions.cs
+++ b/Race_Element.HUD/Overlay/OverlayUtil/GraphicsExtensions.cs
@@ -29,7 +29,13 @@ public static class GraphicsExtensions
 
     public static void DrawStringWithShadow(this Graphics g, string text, Font font, Brush brush, Color shadowColor, PointF location, float shadowDistance, StringFormat format = null)
     {
-        format ??= StringFormat.GenericDefault;
+        if (format == null)
+        {
+            format ??= StringFormat.GenericDefault;
+            format.Alignment = StringAlignment.Near;
+            format.LineAlignment = StringAlignment.Near;
+        }
+
         using SolidBrush shadowBrush = new(shadowColor);
         g.DrawString(text, font, shadowBrush, new PointF(location.X + shadowDistance, location.Y + shadowDistance), format);
         g.DrawString(text, font, brush, location, format);
@@ -37,7 +43,12 @@ public static class GraphicsExtensions
 
     public static void DrawStringWithShadow(this Graphics g, string text, Font font, Color color, Color shadowColor, PointF location, float shadowDistance, StringFormat format = null)
     {
-        format ??= StringFormat.GenericDefault;
+        if (format == null)
+        {
+            format ??= StringFormat.GenericDefault;
+            format.Alignment = StringAlignment.Near;
+            format.LineAlignment = StringAlignment.Near;
+        }
 
         using SolidBrush shadowBrush = new(shadowColor);
         using SolidBrush foregroundBrush = new(color);
@@ -61,7 +72,12 @@ public static class GraphicsExtensions
 
     public static void DrawStringWithShadow(this Graphics g, string text, Font font, Color color, Color shadowColor, RectangleF rectangle, float shadowDistance, StringFormat format = null)
     {
-        format ??= StringFormat.GenericDefault;
+        if (format == null)
+        {
+            format ??= StringFormat.GenericDefault;
+            format.Alignment = StringAlignment.Near;
+            format.LineAlignment = StringAlignment.Near;
+        }
 
         rectangle.Y += shadowDistance;
         using SolidBrush shadowBrush = new(shadowColor);
@@ -74,7 +90,12 @@ public static class GraphicsExtensions
 
     public static void DrawStringWithShadow(this Graphics g, string text, Font font, Brush color, Brush shadowColor, RectangleF rectangle, float shadowDistance, StringFormat format = null)
     {
-        format ??= StringFormat.GenericDefault;
+        if (format == null)
+        {
+            format ??= StringFormat.GenericDefault;
+            format.Alignment = StringAlignment.Near;
+            format.LineAlignment = StringAlignment.Near;
+        }
 
         rectangle.Y += shadowDistance;
         g.DrawString(text, font, shadowColor, rectangle, format);
@@ -156,7 +177,7 @@ public static class GraphicsExtensions
         // top right arc
         if (radiusTopRight != radiusTopLeft)
         {
-            size = new Size(radiusTopRight , radiusTopRight);
+            size = new Size(radiusTopRight, radiusTopRight);
             arc.Size = size;
         }
 

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -9,9 +9,10 @@ public static class ReleaseNotes
         {"2.1.1.0", "Updated to .NET 9"+
                     "\nnMulti-Sim:"+
                     "\n- Added support for Euro Truck Simulator 2(ETS2) and American Truck Simulator(ATS)."+
-                    "\n- Shift Bar: Added option for Pit Limiter."+
+                    "\n- Shift Bar HUD: Added option for Pit Limiter."+
                     "\n\nAssetto Corsa Competizione:"+
-                    "\n- Shift Bar: Added option for Pit Limiter."
+                    "\n- Shift Bar HUD: Added option for Pit Limiter."+
+                    "\n- Acc Livery Settings should now load and save correctly in the settings tab."
                     },
         {"2.1.0.2", "Assetto Corsa Competizione:"+
                     "\n- Tyre Temp History HUD can now be automatically hidden in race sessions."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,12 +6,14 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
-        {"2.1.1.0", "Updated to .NET 9"+
-                    "\nnMulti-Sim:"+
-                    "\n- Added support for Euro Truck Simulator 2(ETS2) and American Truck Simulator(ATS)."+
+        {"2.2.0.0", "Updated to .NET 9"+
+                    "\n\nMulti-Sim:"+
+                    "\n- Added support for Euro Truck Simulator 2(ETS2) and American Truck Simulator(ATS). See Multi-Sim guide on the website how to set it up."+
                     "\n- Shift Bar HUD: Added option for Pit Limiter."+
+                    "\n- Added new Shift RPM HUD: You can use this with the shift bar to replace the shift indicator hud."+
                     "\n\nAssetto Corsa Competizione:"+
                     "\n- Shift Bar HUD: Added option for Pit Limiter."+
+                    "\n- Added new Shift RPM HUD: You can use this with the shift bar to replace the shift indicator hud."+
                     "\n- Acc Livery Settings should now load and save correctly in the settings tab."
                     },
         {"2.1.0.2", "Assetto Corsa Competizione:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -10,7 +10,7 @@ public static class ReleaseNotes
                     "\nnMulti-Sim:"+
                     "\n- Added support for Euro Truck Simulator 2(ETS2) and American Truck Simulator(ATS)."+
                     "\n- Shift Bar: Added option for Pit Limiter."+
-                    "\n\nnAssetto Corsa Competizione:"+
+                    "\n\nAssetto Corsa Competizione:"+
                     "\n- Shift Bar: Added option for Pit Limiter."
                     },
         {"2.1.0.2", "Assetto Corsa Competizione:"+

--- a/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
+++ b/Race_Element/Controls/Settings/AccSettings/AccLiverySettings.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using RaceElement.Data.ACC.Config;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 
@@ -27,24 +28,30 @@ public partial class AccLiverySettings : UserControl
 
     private void AddToggleListener(ToggleButton button)
     {
-        button.Checked += (s, e) => SaveSettings();
-        button.Unchecked += (s, e) => SaveSettings();
+        button.Checked += (s, e) => SaveSettings(s, e);
+        button.Unchecked += (s, e) => SaveSettings(s, e);
     }
 
     private void LoadSettings()
     {
         var settings = menu.Settings().Get(false);
 
-        toggleTexDDS.IsChecked = settings.TexCap == 1;
-        toggleTexCap.IsChecked = settings.TexDDS == 0;
+        toggleTexDDS.IsChecked = settings.TexDDS == 1;
+        toggleTexCap.IsChecked = settings.TexCap == 0;
     }
 
-    private void SaveSettings()
+    private void SaveSettings(object sender, RoutedEventArgs e)
     {
         var settings = menu.Settings().Get(false);
 
-        settings.TexCap = toggleTexDDS.IsChecked.Value ? 1 : 0;
-        settings.TexDDS = toggleTexCap.IsChecked.Value ? 0 : 1;
+        if (e.Source is ToggleButton toggle)
+        {
+            if (toggle == toggleTexCap)
+                settings.TexCap = toggle.IsChecked.Value ? 0 : 1;
+
+            if (toggle == toggleTexDDS)
+                settings.TexDDS = toggle.IsChecked.Value ? 1 : 0;
+        }
 
         menu.Settings().Save(settings);
     }

--- a/Race_Element/Controls/Util/Updater/HttpClientExtensions.cs
+++ b/Race_Element/Controls/Util/Updater/HttpClientExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaceElement.Controls.Util.Updater;
+internal static class HttpClientExtensions
+{
+    public static async Task DownloadFileTaskAsync(this HttpClient client, Uri uri, string FileName)
+    {
+        using (var s = await client.GetStreamAsync(uri))
+        {
+            using (var fs = new FileStream(FileName, FileMode.CreateNew))
+            {
+                await s.CopyToAsync(fs);
+            }
+        }
+    }
+}

--- a/Race_Element/Controls/Util/Updater/Updater.cs
+++ b/Race_Element/Controls/Util/Updater/Updater.cs
@@ -4,6 +4,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace RaceElement.Controls.Util.Updater;
 
@@ -24,7 +26,7 @@ internal sealed class AppUpdater
 
         MoveCurrentExecutableToDocumentsPath(currentAssemblyFile.FullName);
 
-        if (!DownloadNewVersion(asset.BrowserDownloadUrl, currentAssemblyFile.FullName))
+        if (!DownloadNewVersion(asset.BrowserDownloadUrl, currentAssemblyFile.FullName).GetAwaiter().GetResult())
         {
             RevertVersion(assemblyStart);
             return;
@@ -80,12 +82,12 @@ internal sealed class AppUpdater
         return true;
     }
 
-    private bool DownloadNewVersion(string downloadUrl, string targetFile)
+    private static async Task<bool> DownloadNewVersion(string downloadUrl, string targetFile)
     {
         try
         {
-            using var client = new WebClient();
-            client.DownloadFile(downloadUrl, targetFile);
+            using var client = new HttpClient();
+            await client.DownloadFileTaskAsync(new(downloadUrl), targetFile);
 
             LogWriter.WriteToLog($"AutoUpdater: Downloaded latest version from {downloadUrl} to file:\n{targetFile}");
 

--- a/Race_Element/MainWindow.xaml.cs
+++ b/Race_Element/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -286,9 +287,9 @@ public partial class MainWindow : Window
             try
             {
                 string hitCounter = "https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FRiddleTime%2FRace-Element";
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(hitCounter);
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                response.Close();
+
+                using HttpClient client = new();
+                client.GetAsync(hitCounter).Wait();
             }
             catch (Exception) { }
     }

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.1.0.7</ApplicationVersion>
-        <AssemblyVersion>2.1.0.7</AssemblyVersion>
-        <Version>2.1.0.7</Version>
+        <ApplicationVersion>2.2.0.0</ApplicationVersion>
+        <AssemblyVersion>2.2.0.0</AssemblyVersion>
+        <Version>2.2.0.0</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.1.0.3</ApplicationVersion>
-        <AssemblyVersion>2.1.0.3</AssemblyVersion>
-        <Version>2.1.0.3</Version>
+        <ApplicationVersion>2.1.0.5</ApplicationVersion>
+        <AssemblyVersion>2.1.0.5</AssemblyVersion>
+        <Version>2.1.0.5</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.1.0.5</ApplicationVersion>
-        <AssemblyVersion>2.1.0.5</AssemblyVersion>
-        <Version>2.1.0.5</Version>
+        <ApplicationVersion>2.1.0.7</ApplicationVersion>
+        <AssemblyVersion>2.1.0.7</AssemblyVersion>
+        <Version>2.1.0.7</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>


### PR DESCRIPTION
Updated to .NET 9

Multi-Sim:
- Added support for Euro Truck Simulator 2(ETS2) and American Truck Simulator(ATS). See Multi-Sim guide on the website how to set it up.
- Shift Bar HUD: Added option for Pit Limiter.
- Added new Shift RPM HUD: You can use this with the shift bar to replace the shift indicator hud.

Assetto Corsa Competizione:
- Shift Bar HUD: Added option for Pit Limiter.
- Added new Shift RPM HUD: You can use this with the shift bar to replace the shift indicator hud.
- Acc Livery Settings should now load and save correctly in the settings tab.