### PR TITLE
Add a Car electronics Overlay for AMS2 + Small change at the AMS2 Datamapper

### DIFF
--- a/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
+++ b/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
@@ -109,7 +109,7 @@ internal static class Ams2Mapper
 
         // Car electronics
         local.Electronics.TractionControlLevel = shared.mTractionControlSetting;
-        local.Electronics.BrakeBias = shared.mBrakeBias;
+        local.Electronics.BrakeBias = 1 - shared.mBrakeBias;
 
         local.Electronics.AbsActivation = shared.mAntiLockActive ? 1.0f : 0.0f;
         local.Electronics.AbsLevel = shared.mAntiLockSetting;

--- a/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
+++ b/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
@@ -108,11 +108,22 @@ internal static class Ams2Mapper
         local.Engine.Rpm = (int)shared.mRpm;
 
         // Car electronics
+        // AMS 2 is reporting -1 if the current car has no TC
         local.Electronics.TractionControlLevel = shared.mTractionControlSetting;
+        if (local.Electronics.TractionControlLevel == -1)
+        {
+            local.Electronics.TractionControlActivation = 0;
+        }
+        
         local.Electronics.BrakeBias = 1 - shared.mBrakeBias;
 
         local.Electronics.AbsActivation = shared.mAntiLockActive ? 1.0f : 0.0f;
         local.Electronics.AbsLevel = shared.mAntiLockSetting;
+        // AMS 2 is reporting -1 if the current car has no ABS
+        if (local.Electronics.AbsLevel == -1)
+        {
+            local.Electronics.AbsLevel = 0;
+        }
 
         // Car inputs
         local.Inputs.HandBrake = shared.mHandBrake;

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -13,7 +13,7 @@ namespace RaceElement.HUD.Common.Overlays.Driving.CarElectronics;
 
 [Overlay(
     Name = "Car Electronics",
-    Description = "This Overlay is used to display track information, basic weather information and the current waved flag.",
+    Description = "Shows current Brake Bias, ABS and TC settings.",
     Game = Game.Automobilista2,
     Authors = ["Connor Molz"]
 )]

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -34,6 +34,10 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
             
             [ToolTip("Dispose Traction Control if it is off.")]
             public bool ShowTcIfOff { get; init; } = true;
+            
+            [ToolTip("Refresh rate in Hz of the HUD.")]
+            [IntRange(1, 10, 2)]
+            public int RefreshRate { get; init; } = 10;
         }
         
         public CarElectronicsConfig()
@@ -44,7 +48,7 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
     
     public CarElectronicsOverlay(Rectangle rectangle) : base(rectangle, "Car Electronics")
     {
-        RefreshRateHz = 1;
+        RefreshRateHz = _config.InfoPanel.RefreshRate;
     }
 
     // Window Components

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -1,0 +1,153 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using RaceElement.Data.Common;
+using RaceElement.Data.Games;
+using RaceElement.HUD.Overlay.Configuration;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.OverlayUtil.InfoPanel;
+using RaceElement.HUD.Overlay.Util;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.CarElectronics;
+
+
+[Overlay(
+    Name = "Car Electronics",
+    Description = "This Overlay is used to display track information, basic weather information and the current waved flag.",
+    Game = Game.Automobilista2,
+    Authors = ["Connor Molz"]
+)]
+public class CarElectronicsOverlay: CommonAbstractOverlay
+{
+    // Configuration
+    private readonly CarElectronicsConfig _config = new();
+
+    private sealed class CarElectronicsConfig : OverlayConfiguration
+    {
+        [ConfigGrouping("Info Panel", "Show or hide additional information in the panel.")]
+        public InfoPanelGrouping InfoPanel { get; init; } = new InfoPanelGrouping();
+
+        public sealed class InfoPanelGrouping
+        {
+            [ToolTip("Dispose ABS if it is off.")]
+            public bool ShowAbsIfOff { get; init; } = true;
+            
+            [ToolTip("Dispose Traction Control if it is off.")]
+            public bool ShowTcIfOff { get; init; } = true;
+        }
+        
+        public CarElectronicsConfig()
+        {
+            this.GenericConfiguration.AllowRescale = true;
+        }
+    }
+    
+    public CarElectronicsOverlay(Rectangle rectangle) : base(rectangle, "Car Electronics")
+    {
+        RefreshRateHz = 1;
+    }
+
+    // Window Components
+    private Font _font;
+    
+    private PanelText _absHeader;
+    private PanelText _absValue;
+    private PanelText _tcHeader;
+    private PanelText _tcValue;
+    private PanelText _bbHeader;
+    private PanelText _bbValue;
+    
+    // Before render function to setup the window and size
+    public sealed override void BeforeStart()
+    {
+        _font = FontUtil.FontSegoeMono(10f * this.Scale);
+
+        int lineHeight = _font.Height;
+
+        int unscaledHeaderWidth = 40;
+        int unscaledValueWidth = 58;
+
+        int headerWidth = (int)(unscaledHeaderWidth * this.Scale);
+        int valueWidth = (int)(unscaledValueWidth * this.Scale);
+        int roundingRadius = (int)(6 * this.Scale);
+
+        RectangleF headerRect = new(0, 0, headerWidth, lineHeight);
+        RectangleF valueRect = new(headerWidth, 0, valueWidth, lineHeight);
+        StringFormat headerFormat = new() { Alignment = StringAlignment.Near };
+        StringFormat valueFormat = new() { Alignment = StringAlignment.Far };
+
+        Color accentColor = Color.FromArgb(25, 255, 0, 0);
+        CachedBitmap headerBackground = new(headerWidth, lineHeight, g =>
+        {
+            Rectangle panelRect = new(0, 0, headerWidth, lineHeight);
+            using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(panelRect, 0, 0, 0, roundingRadius);
+            using LinearGradientBrush brush = new(panelRect, Color.FromArgb(185, 0, 0, 0),
+                Color.FromArgb(255, 10, 10, 10), LinearGradientMode.BackwardDiagonal);
+            g.FillPath(brush, path);
+            using Pen underlinePen = new(accentColor);
+            g.DrawLine(underlinePen, 0 + roundingRadius / 2, lineHeight, headerWidth, lineHeight - 1);
+        });
+
+        CachedBitmap valueBackground = new(valueWidth, lineHeight, g =>
+        {
+            Rectangle panelRect = new(0, 0, valueWidth, lineHeight);
+            using GraphicsPath path = GraphicsExtensions.CreateRoundedRectangle(panelRect, 0, roundingRadius, 0, 0);
+            using LinearGradientBrush brush = new(panelRect, Color.FromArgb(255, 0, 0, 0), Color.FromArgb(185, 0, 0, 0),
+                LinearGradientMode.ForwardDiagonal);
+            g.FillPath(brush, path);
+            using Pen underlinePen = new(accentColor);
+            g.DrawLine(underlinePen, 0, lineHeight - 1, valueWidth, lineHeight - 1);
+        });
+        
+        // Init ABS, TC and BB headers and values
+        _absHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+        _absValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+        headerRect.Offset(0, lineHeight);
+        valueRect.Offset(0, lineHeight);
+        
+        _tcHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+        _tcValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+        headerRect.Offset(0, lineHeight);
+        valueRect.Offset(0, lineHeight);
+        
+        _bbHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+        _bbValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+        headerRect.Offset(0, lineHeight);
+        valueRect.Offset(0, lineHeight);
+        
+    }
+
+    public override void Render(Graphics g)
+    {
+        string abs = SimDataProvider.LocalCar.Electronics.AbsLevel.ToString();
+        string tc = SimDataProvider.LocalCar.Electronics.TractionControlLevel.ToString();
+        string bb = SimDataProvider.LocalCar.Electronics.BrakeBias.ToString("F1");
+        
+        if (abs != "0" || _config.InfoPanel.ShowAbsIfOff)
+        {
+            _absHeader.Draw(g, "ABS", this.Scale);
+            _absValue.Draw(g, abs, this.Scale);
+        }
+
+        if (tc != "0" || _config.InfoPanel.ShowTcIfOff)
+        {
+            _tcHeader.Draw(g, "TC", this.Scale);
+            _tcValue.Draw(g, tc, this.Scale);
+        }
+        
+        _bbHeader.Draw(g, "BB", this.Scale);
+        _bbValue.Draw(g, bb, this.Scale);
+        
+    }
+    
+    public override void BeforeStop()
+    {
+        _font.Dispose();
+        _absHeader.Dispose();
+        _absValue.Dispose();
+        _tcHeader.Dispose();
+        _tcValue.Dispose();
+        _bbHeader.Dispose();
+        _bbValue.Dispose();
+    }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -123,6 +123,17 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
         string tc = SimDataProvider.LocalCar.Electronics.TractionControlLevel.ToString();
         string bb = SimDataProvider.LocalCar.Electronics.BrakeBias.ToString("F2");
         
+        // AMS2 is reporting -1 for ABS and TC when they are not existing in the current car
+        if (abs == "-1")
+        {
+            abs = "0";
+        }
+        
+        if (tc == "-1")
+        {
+            tc = "0";
+        }
+        
         if (abs != "0" || _config.InfoPanel.ShowAbsIfOff)
         {
             _absHeader.Draw(g, "ABS", this.Scale);

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -104,6 +104,11 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
         });
         
         // Init ABS, TC and BB headers and values
+        _bbHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+        _bbValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+        headerRect.Offset(0, lineHeight);
+        valueRect.Offset(0, lineHeight);
+        
         _absHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
         _absValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
         headerRect.Offset(0, lineHeight);
@@ -111,11 +116,6 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
         
         _tcHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
         _tcValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
-        headerRect.Offset(0, lineHeight);
-        valueRect.Offset(0, lineHeight);
-        
-        _bbHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
-        _bbValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
         headerRect.Offset(0, lineHeight);
         valueRect.Offset(0, lineHeight);
         
@@ -138,6 +138,10 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
             tc = "0";
         }
         
+        // Drawing the UI
+        _bbHeader.Draw(g, "BB", this.Scale);
+        _bbValue.Draw(g, bb, this.Scale);
+        
         if (abs != "0" || _config.InfoPanel.ShowAbsIfOff)
         {
             _absHeader.Draw(g, "ABS", this.Scale);
@@ -150,8 +154,6 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
             _tcValue.Draw(g, tc, this.Scale);
         }
         
-        _bbHeader.Draw(g, "BB", this.Scale);
-        _bbValue.Draw(g, bb, this.Scale);
         
     }
     

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -17,9 +17,8 @@ namespace RaceElement.HUD.Common.Overlays.Driving.CarElectronics;
     Game = Game.Automobilista2,
     Authors = ["Connor Molz"]
 )]
-public class CarElectronicsOverlay: CommonAbstractOverlay
+public sealed class CarElectronicsOverlay: CommonAbstractOverlay
 {
-    // Configuration
     private readonly CarElectronicsConfig _config = new();
 
     private sealed class CarElectronicsConfig : OverlayConfiguration
@@ -29,11 +28,11 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
 
         public sealed class InfoPanelGrouping
         {
-            [ToolTip("Dispose ABS if it is off.")]
-            public bool ShowAbsIfOff { get; init; } = true;
+            [ToolTip("Toggle ABS in overlay")]
+            public bool ShowAbs { get; init; } = true;
             
-            [ToolTip("Dispose Traction Control if it is off.")]
-            public bool ShowTcIfOff { get; init; } = true;
+            [ToolTip("Toggle TC in overlay")]
+            public bool ShowTc { get; init; } = true;
             
             [ToolTip("Refresh rate in Hz of the HUD.")]
             [IntRange(1, 10, 2)]
@@ -108,50 +107,44 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
         _bbValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
         headerRect.Offset(0, lineHeight);
         valueRect.Offset(0, lineHeight);
-        
-        _absHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
-        _absValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
-        headerRect.Offset(0, lineHeight);
-        valueRect.Offset(0, lineHeight);
-        
-        _tcHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
-        _tcValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
-        headerRect.Offset(0, lineHeight);
-        valueRect.Offset(0, lineHeight);
-        
+
+        if (_config.InfoPanel.ShowTc)
+        {
+            _absHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+            _absValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+            headerRect.Offset(0, lineHeight);
+            valueRect.Offset(0, lineHeight);
+        }
+
+        if (_config.InfoPanel.ShowTc)
+        {
+            _tcHeader = new PanelText(_font, headerBackground, headerRect) { StringFormat = headerFormat };
+            _tcValue = new PanelText(_font, valueBackground, valueRect) { StringFormat = valueFormat };
+            headerRect.Offset(0, lineHeight);
+            valueRect.Offset(0, lineHeight);
+        }
     }
 
     public override void Render(Graphics g)
     {
-        string abs = SimDataProvider.LocalCar.Electronics.AbsLevel.ToString();
-        string tc = SimDataProvider.LocalCar.Electronics.TractionControlLevel.ToString();
+        int abs = SimDataProvider.LocalCar.Electronics.AbsLevel;
+        int tc = SimDataProvider.LocalCar.Electronics.TractionControlLevel;
         string bb = SimDataProvider.LocalCar.Electronics.BrakeBias.ToString("F2");
-        
-        // AMS2 is reporting -1 for ABS and TC when they are not existing in the current car
-        if (abs == "-1")
-        {
-            abs = "0";
-        }
-        
-        if (tc == "-1")
-        {
-            tc = "0";
-        }
         
         // Drawing the UI
         _bbHeader.Draw(g, "BB", this.Scale);
         _bbValue.Draw(g, bb, this.Scale);
         
-        if (abs != "0" || _config.InfoPanel.ShowAbsIfOff)
+        if (_config.InfoPanel.ShowAbs)
         {
             _absHeader.Draw(g, "ABS", this.Scale);
-            _absValue.Draw(g, abs, this.Scale);
+            _absValue.Draw(g, abs.ToString(), this.Scale);
         }
 
-        if (tc != "0" || _config.InfoPanel.ShowTcIfOff)
+        if ( _config.InfoPanel.ShowTc)
         {
             _tcHeader.Draw(g, "TC", this.Scale);
-            _tcValue.Draw(g, tc, this.Scale);
+            _tcValue.Draw(g, tc.ToString(), this.Scale);
         }
         
         
@@ -159,12 +152,19 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
     
     public override void BeforeStop()
     {
-        _font.Dispose();
-        _absHeader.Dispose();
-        _absValue.Dispose();
-        _tcHeader.Dispose();
-        _tcValue.Dispose();
+        _font?.Dispose();
         _bbHeader.Dispose();
         _bbValue.Dispose();
+        if (_config.InfoPanel.ShowAbs)
+        {
+            _absHeader.Dispose();
+            _absValue.Dispose();
+        }
+        
+        if (_config.InfoPanel.ShowTc)
+        {
+            _tcHeader.Dispose();
+            _tcValue.Dispose();
+        }
     }
 }

--- a/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/CarElectronics/CarElectronicsOverlay.cs
@@ -121,7 +121,7 @@ public class CarElectronicsOverlay: CommonAbstractOverlay
     {
         string abs = SimDataProvider.LocalCar.Electronics.AbsLevel.ToString();
         string tc = SimDataProvider.LocalCar.Electronics.TractionControlLevel.ToString();
-        string bb = SimDataProvider.LocalCar.Electronics.BrakeBias.ToString("F1");
+        string bb = SimDataProvider.LocalCar.Electronics.BrakeBias.ToString("F2");
         
         if (abs != "0" || _config.InfoPanel.ShowAbsIfOff)
         {

--- a/Race Element.HUD.Common/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
@@ -168,7 +168,7 @@ public class TrackInfoOverlay : CommonAbstractOverlay
             _sessionTypeValue.Draw(g, $"{sessionName}", this.Scale);
         }
 
-        string airTemp = SimDataProvider.Session.Weather.AirTemperature.ToString("F1");
+        string airTemp = SimDataProvider.Session.Weather.AirTemperature.ToString("F2");
         _airTempLabel.Draw(g, "Air", this.Scale);
         _airTempValue.Draw(g, $"{airTemp} °C", this.Scale);
 

--- a/Race Element.HUD.Common/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/TrackInfo/TrackInfoOverlay.cs
@@ -168,7 +168,7 @@ public class TrackInfoOverlay : CommonAbstractOverlay
             _sessionTypeValue.Draw(g, $"{sessionName}", this.Scale);
         }
 
-        string airTemp = SimDataProvider.Session.Weather.AirTemperature.ToString("F2");
+        string airTemp = SimDataProvider.Session.Weather.AirTemperature.ToString("F1");
         _airTempLabel.Draw(g, "Air", this.Scale);
         _airTempValue.Draw(g, $"{airTemp} °C", this.Scale);
 


### PR DESCRIPTION
I implemented a small Overlay which report the TC, ABS and Brake Bias

ABS and TC can be toggled of, if they are Off or not implemented in the car
Additional Feature is that the user can choose the refresh rate because it feels sometimes a bit slow if the refresh rate is 1hz so the user can choose its favorite between 1hz and 10hz.

I also make a small change to the AMS2 Data Mapper, which before inverted the BB value so that if I had 100% BB at front he shows 0 and if I had 0% at the front he shows 1 so I inverted it