### PR TITLE
Add LFM elo computation

### DIFF
--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
@@ -82,11 +82,4 @@ public readonly record struct SplitEntry(int RaceNumber, int Elo, bool IsPlayer)
 /// Information about the race.
 /// ELO multiplier and split entry list.
 /// </summary>
-public struct RaceInfo
-{
-    /// <summary>ELO multiplayer.</summary>
-    public float kFactor;
-
-    /// <summary>Player split entry list.</summary>
-    public List<SplitEntry> entries;
-}
+public readonly record struct RaceInfo(float KFactor, List<SplitEntry> Entries);

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
@@ -70,3 +70,20 @@ internal readonly record struct User
     [JsonProperty("fav_sim")] public int FavSim { get; init; }
     [JsonProperty("sr_license")] public string SrLicense { get; init; }
 }
+
+/// <summary>
+/// LFM entry for the entry list. This is just the basic
+/// information used for compute the ELO and the position
+/// threshold where the player wins/losses ELO.
+/// </summary>
+public struct SplitEntry
+{
+    /// <summary>Car race number (give by LFM based on ELO).</summary>
+    public int RaceNumber;
+
+    /// <summary>Current driver ELO.</summary>
+    public int Elo;
+
+    /// <summary>This entry is the player itself? Based on steam id.</summary>
+    public bool IsPlayer;
+}

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
@@ -76,17 +76,7 @@ internal readonly record struct User
 /// information used for compute the ELO and the position
 /// threshold where the player wins/losses ELO.
 /// </summary>
-public struct SplitEntry
-{
-    /// <summary>Car race number (give by LFM based on ELO).</summary>
-    public int RaceNumber;
-
-    /// <summary>Current driver ELO.</summary>
-    public int Elo;
-
-    /// <summary>Is this entry the player? Based on steam id.</summary>
-    public bool IsPlayer;
-}
+public readonly record struct SplitEntry(int RaceNumber, int Elo, bool IsPlayer);
 
 /// <summary>
 /// Information about the race. ELO multiplayer and split entry list.

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
@@ -84,6 +84,18 @@ public struct SplitEntry
     /// <summary>Current driver ELO.</summary>
     public int Elo;
 
-    /// <summary>This entry is the player itself? Based on steam id.</summary>
+    /// <summary>Is this entry the player? Based on steam id.</summary>
     public bool IsPlayer;
+}
+
+/// <summary>
+/// Information about the race. ELO multiplayer and split entry list.
+/// </summary>
+public struct RaceInfo
+{
+    /// <summary>ELO multiplayer.</summary>
+    public float kFactor;
+
+    /// <summary>Player split entry list.</summary>
+    public List<SplitEntry> entries;
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/API/ApiObjects.cs
@@ -79,7 +79,8 @@ internal readonly record struct User
 public readonly record struct SplitEntry(int RaceNumber, int Elo, bool IsPlayer);
 
 /// <summary>
-/// Information about the race. ELO multiplayer and split entry list.
+/// Information about the race.
+/// ELO multiplier and split entry list.
 /// </summary>
 public struct RaceInfo
 {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
@@ -5,8 +5,8 @@ namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
 
 public class LowFuelMotorsportElo
 {
-    static readonly float LN2 = 0.69314718056f;
-    static readonly float E   = 2.71828182845f;
+    const float LN2 = 0.69314718056f;
+    const float E   = 2.71828182845f;
 
     private RaceInfo _raceInfo;
     private float _magic;

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
@@ -8,30 +8,29 @@ public class LowFuelMotorsportElo
     static readonly float LN2 = 0.69314718056f;
     static readonly float E   = 2.71828182845f;
 
-    private List<SplitEntry> _entries;
-    private SplitEntry _player;
+    private RaceInfo _raceInfo;
     private float _magic;
 
-    public LowFuelMotorsportElo(List<SplitEntry> entries)
+    public LowFuelMotorsportElo(RaceInfo raceInfo)
     {
-        _entries = entries;
-        _magic = ComputeMagic(_entries);
+        _raceInfo = raceInfo;
+        _magic = ComputeMagic(_raceInfo.entries);
     }
 
     public int GetPositionThreshold()
     {
-        return (int)Math.Floor(_entries.Count - _magic);
+        return (int)Math.Floor(_raceInfo.entries.Count - _magic);
     }
 
     public int GetElo(int position)
     {
-        float elo = (_entries.Count - position - _magic - ((_entries.Count / 2.0f) - position) / 100.0f) * 200.0f / _entries.Count * 0.8f;
+        float elo = (_raceInfo.entries.Count - position - _magic - ((_raceInfo.entries.Count / 2.0f) - position) / 100.0f) * 200.0f / _raceInfo.entries.Count * _raceInfo.kFactor;
         return (int)Math.Round(elo);
     }
 
     public int GetCarNumber()
     {
-        SplitEntry player = _entries.Find(x => x.IsPlayer);
+        SplitEntry player = _raceInfo.entries.Find(x => x.IsPlayer);
         return player.RaceNumber;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
+
+public class LowFuelMotorsportElo
+{
+    static readonly float LN2 = 0.69314718056f;
+    static readonly float E   = 2.71828182845f;
+
+    private List<SplitEntry> _entries;
+    private SplitEntry _player;
+    private float _magic;
+
+    public LowFuelMotorsportElo(List<SplitEntry> entries)
+    {
+        _entries = entries;
+        _magic = ComputeMagic(_entries);
+    }
+
+    public int GetPositionThreshold()
+    {
+        return (int)Math.Floor(_entries.Count - _magic);
+    }
+
+    public int GetElo(int position)
+    {
+        float elo = (_entries.Count - position - _magic - ((_entries.Count / 2.0f) - position) / 100.0f) * 200.0f / _entries.Count * 0.8f;
+        return (int)Math.Round(elo);
+    }
+
+    public int GetCarNumber()
+    {
+        SplitEntry player = _entries.Find(x => x.IsPlayer);
+        return player.RaceNumber;
+    }
+
+    private float ComputeMagic(int selfElo, int otherElo)
+    {
+        float e = (1600.0f / LN2);
+        float youExp   = (-selfElo / e);
+        float otherExp = (-otherElo / e);
+
+        double you   = Math.Pow(E, youExp);
+        double other = Math.Pow(E, otherExp);
+
+        double result = ((1 - you) * other)/((1 - other) * you + (1 - you) * other);
+        return (float)result;
+    }
+
+    private float ComputeMagic(List<SplitEntry> entries)
+    {
+        float magic = 0;
+        SplitEntry player = entries.Find(x => x.IsPlayer);
+
+        foreach (SplitEntry e in entries)
+        {
+            if (e.IsPlayer) continue;
+            magic += ComputeMagic(player.Elo, e.Elo);
+        }
+
+        return magic;
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
@@ -14,23 +14,23 @@ public class LowFuelMotorsportElo
     public LowFuelMotorsportElo(RaceInfo raceInfo)
     {
         _raceInfo = raceInfo;
-        _magic = ComputeMagic(_raceInfo.entries);
+        _magic = ComputeMagic(_raceInfo.Entries);
     }
 
     public int GetPositionThreshold()
     {
-        return (int)Math.Floor(_raceInfo.entries.Count - _magic);
+        return (int)Math.Floor(_raceInfo.Entries.Count - _magic);
     }
 
     public int GetElo(int position)
     {
-        float elo = (_raceInfo.entries.Count - position - _magic - ((_raceInfo.entries.Count / 2.0f) - position) / 100.0f) * 200.0f / _raceInfo.entries.Count * _raceInfo.kFactor;
+        float elo = (_raceInfo.Entries.Count - position - _magic - ((_raceInfo.Entries.Count / 2.0f) - position) / 100.0f) * 200.0f / _raceInfo.Entries.Count * _raceInfo.KFactor;
         return (int)Math.Round(elo);
     }
 
     public int GetCarNumber()
     {
-        SplitEntry player = _raceInfo.entries.Find(x => x.IsPlayer);
+        SplitEntry player = _raceInfo.Entries.Find(x => x.IsPlayer);
         return player.RaceNumber;
     }
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportElo.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
 
-public class LowFuelMotorsportElo
+internal sealed class LowFuelMotorsportElo
 {
-    const float LN2 = 0.69314718056f;
-    const float E   = 2.71828182845f;
+    private const float LN2 = 0.69314718056f;
+    private const float E = 2.71828182845f;
 
-    private RaceInfo _raceInfo;
-    private float _magic;
+    private readonly RaceInfo _raceInfo;
+    private readonly float _magic;
 
     public LowFuelMotorsportElo(RaceInfo raceInfo)
     {
@@ -17,10 +17,7 @@ public class LowFuelMotorsportElo
         _magic = ComputeMagic(_raceInfo.Entries);
     }
 
-    public int GetPositionThreshold()
-    {
-        return (int)Math.Floor(_raceInfo.Entries.Count - _magic);
-    }
+    public int GetPositionThreshold() => (int)Math.Floor(_raceInfo.Entries.Count - _magic);
 
     public int GetElo(int position)
     {
@@ -34,20 +31,20 @@ public class LowFuelMotorsportElo
         return player.RaceNumber;
     }
 
-    private float ComputeMagic(int selfElo, int otherElo)
+    private static float ComputeMagic(int selfElo, int otherElo)
     {
         float e = (1600.0f / LN2);
-        float youExp   = (-selfElo / e);
+        float youExp = (-selfElo / e);
         float otherExp = (-otherElo / e);
 
-        double you   = Math.Pow(E, youExp);
+        double you = Math.Pow(E, youExp);
         double other = Math.Pow(E, otherExp);
 
-        double result = ((1 - you) * other)/((1 - other) * you + (1 - you) * other);
+        double result = ((1 - you) * other) / ((1 - other) * you + (1 - you) * other);
         return (float)result;
     }
 
-    private float ComputeMagic(List<SplitEntry> entries)
+    private static float ComputeMagic(List<SplitEntry> entries)
     {
         float magic = 0;
         SplitEntry player = entries.Find(x => x.IsPlayer);

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
@@ -14,7 +14,7 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
     public static readonly string RACE_API_URL = "https://api3.lowfuelmotorsport.com/api/race/{0}";
 
     public EventHandler<ApiObject> OnNewApiObject;
-    public EventHandler<List<SplitEntry>> OnNewSplitObject;
+    public EventHandler<RaceInfo> OnNewSplitObject;
 
     public override void RunAction()
     {
@@ -59,7 +59,10 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
     {
         var json = JObject.Parse(GetContents(string.Format(RACE_API_URL, race)));
         var entries = json["splits"]["participants"][(split - 1)]["entries"];
-        var list = new List<SplitEntry>();
+
+        var raceInfo = new RaceInfo();
+        raceInfo.entries = new List<SplitEntry>();
+        raceInfo.kFactor = json["event"]["k_factor"].ToObject<float>();
 
         foreach (var e in entries)
         {
@@ -69,10 +72,9 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
             entry.RaceNumber = (int)e["raceNumber"];
             entry.Elo = (int)e["elo"];
 
-
-            list.Add(entry);
+            raceInfo.entries.Add(entry);
         }
 
-        OnNewSplitObject?.Invoke(null, list);
+        OnNewSplitObject?.Invoke(null, raceInfo);
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
@@ -60,9 +60,8 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
         var json = JObject.Parse(GetContents(string.Format(RACE_API_URL, race)));
         var entries = json["splits"]["participants"][(split - 1)]["entries"];
 
-        var raceInfo = new RaceInfo();
-        raceInfo.entries = new List<SplitEntry>();
-        raceInfo.kFactor = json["event"]["k_factor"].ToObject<float>();
+        var list = new List<SplitEntry>();
+        float kFactor = json["event"]["k_factor"].ToObject<float>();
 
         foreach (var e in entries)
         {
@@ -73,9 +72,9 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
                 Elo = (int)e["elo"]
             };
 
-            raceInfo.entries.Add(entry);
+            list.Add(entry);
         }
 
-        OnNewSplitObject?.Invoke(null, raceInfo);
+        OnNewSplitObject?.Invoke(null, new RaceInfo(kFactor, list));
     }
 }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
@@ -66,11 +66,12 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
 
         foreach (var e in entries)
         {
-            var entry = new SplitEntry();
-            entry.IsPlayer = id == (string)e["steam_id"];
-
-            entry.RaceNumber = (int)e["raceNumber"];
-            entry.Elo = (int)e["elo"];
+            var entry = new SplitEntry
+            {
+                IsPlayer = id == (string)e["steam_id"],
+                RaceNumber = (int)e["raceNumber"],
+                Elo = (int)e["elo"]
+            };
 
             raceInfo.entries.Add(entry);
         }

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportJob.cs
@@ -33,7 +33,7 @@ internal sealed class LowFuelMotorsportJob(string userId) : AbstractLoopJob
         }
     }
 
-    private string GetContents(string url)
+    private static string GetContents(string url)
     {
         using HttpClient client = new();
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
@@ -11,6 +11,7 @@ using RaceElement.HUD.Overlay.Util;
 using RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport.API;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Concurrent;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport;
 
@@ -30,7 +31,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
     private LowFuelMotorsportElo _elo;
     private LowFuelMotorsportJob _lfmJob;
 
-    internal readonly List<Guid> _speechJobIds = [];
+    internal readonly ConcurrentBag<Guid> _speechJobIds = [];
 
     private SizeF _previousTextBounds = Size.Empty;
 
@@ -237,11 +238,10 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
                 }
             }
         }
-        else if (_speechJobIds.Count > 0)
+        else if (!_speechJobIds.IsEmpty)
         {
-            Guid toRemove = _speechJobIds.FirstOrDefault();
-            JobTimerExecutor.Instance().Remove(toRemove);
-            _speechJobIds.Remove(toRemove);
+            if (_speechJobIds.TryTake(out Guid toRemove))
+                JobTimerExecutor.Instance().Remove(toRemove);
         }
 
         return licenseText;

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
@@ -39,7 +39,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
         this.RefreshRateHz = 2f;
     }
 
-    public override void SetupPreviewData()
+    public sealed override void SetupPreviewData()
     {
         _apiObject = new()
         {
@@ -68,7 +68,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
         };
     }
 
-    public override void BeforeStart()
+    public sealed override void BeforeStart()
     {
         _fontFamily = _config.Font.FontFamily switch
         {
@@ -120,7 +120,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
         return _config.Others.ShowAlways || base.ShouldRender();
     }
 
-    public override void Render(Graphics g)
+    public sealed override void Render(Graphics g)
     {
         string licenseText = GenerateLicense();
 

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportOverlay.cs
@@ -99,7 +99,7 @@ internal sealed class LowFuelMotorsportOverlay : AbstractOverlay
     }
 
     private void OnNewApiObject(object sender, ApiObject apiObject) => _apiObject = apiObject;
-    private void OnNewSplitInfo(object sender, List<SplitEntry> entries) => _elo = new(entries);
+    private void OnNewSplitInfo(object sender, RaceInfo raceInfo) => _elo = new(raceInfo);
 
     public sealed override void BeforeStop()
     {

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportSpeechSynthesizer.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportSpeechSynthesizer.cs
@@ -41,20 +41,13 @@ internal sealed class LowFuelMotorsportSpeechSynthesizer(DateTime RaceStartTimeU
 
     private void NextMessage(int remainingTimeSeconds)
     {
-        DateTime time = RaceStartTimeUtc;
-
-        if (remainingTimeSeconds > (5 * 60))
+        DateTime time = remainingTimeSeconds switch
         {
-            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 5, 0));
-        }
-        else if (remainingTimeSeconds > (3 * 60))
-        {
-            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 3, 0));
-        }
-        else if (remainingTimeSeconds > 60)
-        {
-            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 1, 0));
-        }
+            > (5 * 60) => RaceStartTimeUtc.Subtract(TimeSpan.FromMinutes(5)),
+            > (3 * 60) => RaceStartTimeUtc.Subtract(TimeSpan.FromMinutes(3)),
+            > (1 * 60) => RaceStartTimeUtc.Subtract(TimeSpan.FromMinutes(1)),
+            _ => RaceStartTimeUtc,
+        };
 
         LowFuelMotorsportSpeechSynthesizer speech = new(RaceStartTimeUtc, LfmOverlay);
         if (JobTimerExecutor.Instance().Add(speech, time, out Guid jobId))

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportSpeechSynthesizer.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayLowFuelMotorsport/LowFuelMotorsportSpeechSynthesizer.cs
@@ -5,17 +5,8 @@ using RaceElement.Core.Jobs.Timer;
 
 namespace RaceElement.HUD.ACC.Overlays.Pitwall.LowFuelMotorsport;
 
-internal class LowFuelMotorsportSpeechSynthesizer : IJob
+internal sealed class LowFuelMotorsportSpeechSynthesizer(DateTime RaceStartTimeUtc, LowFuelMotorsportOverlay LfmOverlay) : IJob
 {
-    private readonly DateTime _raceStartTimeUtc;
-    private readonly LowFuelMotorsportOverlay _lfmOverlay;
-
-    public LowFuelMotorsportSpeechSynthesizer(DateTime raceStartTimeUtc, LowFuelMotorsportOverlay lfmOverlay)
-    {
-        _raceStartTimeUtc = raceStartTimeUtc;
-        _lfmOverlay = lfmOverlay;
-    }
-
     public bool IsRunning { get; private set; } = false;
 
     private readonly Guid _id = Guid.NewGuid();
@@ -25,7 +16,7 @@ internal class LowFuelMotorsportSpeechSynthesizer : IJob
 
     public void Run()
     {
-        var timeDiff = (_raceStartTimeUtc - DateTime.UtcNow);
+        var timeDiff = (RaceStartTimeUtc - DateTime.UtcNow);
         string message = $"{timeDiff.Minutes} minutes until race starts";
         int minTimeRaceStartSec = 5;
 
@@ -50,23 +41,23 @@ internal class LowFuelMotorsportSpeechSynthesizer : IJob
 
     private void NextMessage(int remainingTimeSeconds)
     {
-        DateTime time = _raceStartTimeUtc;
+        DateTime time = RaceStartTimeUtc;
 
         if (remainingTimeSeconds > (5 * 60))
         {
-            time = _raceStartTimeUtc.Subtract(new TimeSpan(0, 0, 5, 0));
+            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 5, 0));
         }
         else if (remainingTimeSeconds > (3 * 60))
         {
-            time = _raceStartTimeUtc.Subtract(new TimeSpan(0, 0, 3, 0));
+            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 3, 0));
         }
         else if (remainingTimeSeconds > 60)
         {
-            time = _raceStartTimeUtc.Subtract(new TimeSpan(0, 0, 1, 0));
+            time = RaceStartTimeUtc.Subtract(new TimeSpan(0, 0, 1, 0));
         }
 
-        LowFuelMotorsportSpeechSynthesizer speech = new(_raceStartTimeUtc, _lfmOverlay);
+        LowFuelMotorsportSpeechSynthesizer speech = new(RaceStartTimeUtc, LfmOverlay);
         if (JobTimerExecutor.Instance().Add(speech, time, out Guid jobId))
-            _lfmOverlay._speechJobIds.Add(jobId);
+            LfmOverlay._speechJobIds.Add(jobId);
     }
 }


### PR DESCRIPTION
- Get the entry list based on the player split
- Compute "magic" number used to compute the ELO win/loss threshold
- Get player car number
- Get ELO win/loss threshold
- Get current ELO win/loss based on position

NOTE: Needs to be tested
Based on: https://discord.com/channels/710171166601379881/1243706178589036605