### PR TITLE
2.2.6.0

### DIFF
--- a/Race Element.Data/Games/GameManager.cs
+++ b/Race Element.Data/Games/GameManager.cs
@@ -6,15 +6,21 @@ namespace RaceElement.Data.Games;
 public static class GameManager
 {
     public static Game CurrentGame { get; private set; } = Game.Any;
+    private static Game _runningGame = Game.Any;
     public static bool IsGameRunning { get => _isGameRunning; set => _isGameRunning = value; }
 
     private static bool _isGameRunning = false;
 
     public static event EventHandler<(Game previous, Game next)>? OnGameChanged;
+    public static event EventHandler<Game>? OnAutoGameRequest;
 
     private static SimpleLoopJob? _dataUpdaterJob;
 
     private static SimpleLoopJob? _gameMonitorJob;
+
+    private static SimpleLoopJob? _autoSwitchJob;
+
+    public static bool AutoSwitch = true;
 
     public static void SetCurrentGame(Game nextGame)
     {
@@ -24,6 +30,28 @@ public static class GameManager
         Game previousGame = CurrentGame;
         CurrentGame = nextGame;
         OnGameChanged?.Invoke(null, (previousGame, nextGame));
+
+        _gameMonitorJob = new()
+        {
+            Action = () =>
+            {
+                _runningGame = GameExtensions.GetRunningGame();
+                _isGameRunning = CurrentGame == _runningGame;
+            },
+            IntervalMillis = 500
+        };
+        _gameMonitorJob.Run();
+
+        _autoSwitchJob = new()
+        {
+            Action = () =>
+            {
+                if (AutoSwitch && !_isGameRunning && _runningGame != Game.Any)
+                    OnAutoGameRequest?.Invoke(null, _runningGame);
+            },
+            IntervalMillis = 1000,
+        };
+        _autoSwitchJob.Run();
 
         SimDataProvider.Update(true);
         if (SimDataProvider.Instance != null)
@@ -37,16 +65,6 @@ public static class GameManager
             };
             _dataUpdaterJob.Run();
         }
-
-        _gameMonitorJob = new()
-        {
-            Action = () =>
-            {
-                _isGameRunning = CurrentGame == GameExtensions.GetRunningGame();
-            },
-            IntervalMillis = 500
-        };
-        _gameMonitorJob.Run();
     }
 
     /// <summary>
@@ -55,6 +73,7 @@ public static class GameManager
     /// <param name="game"></param>
     private static void ExitGameData(Game game)
     {
+        _autoSwitchJob?.CancelJoin();
         _gameMonitorJob?.CancelJoin();
         _isGameRunning = false;
 

--- a/Race Element.Data/Games/GameManager.cs
+++ b/Race Element.Data/Games/GameManager.cs
@@ -12,17 +12,9 @@ public static class GameManager
 
     public static event EventHandler<(Game previous, Game next)>? OnGameChanged;
 
-    private static readonly SimpleLoopJob _dataUpdaterJob = new()
-    {
-        Action = () => SimDataProvider.Update(),
-        IntervalMillis = 1000 / SimDataProvider.Instance.PollingRate()
-    };
+    private static SimpleLoopJob? _dataUpdaterJob;
 
-    private static readonly SimpleLoopJob _gameMonitorJob = new()
-    {
-        Action = () => _isGameRunning = CurrentGame == GameExtensions.GetRunningGame(),
-        IntervalMillis = 500
-    };
+    private static SimpleLoopJob? _gameMonitorJob;
 
     public static void SetCurrentGame(Game nextGame)
     {
@@ -37,9 +29,24 @@ public static class GameManager
         if (SimDataProvider.Instance != null)
         {
             SimDataProvider.Instance.Start();
+
+            _dataUpdaterJob = new()
+            {
+                Action = () => SimDataProvider.Update(),
+                IntervalMillis = 1000 / SimDataProvider.Instance.PollingRate()
+            };
             _dataUpdaterJob.Run();
-            _gameMonitorJob.Run();
         }
+
+        _gameMonitorJob = new()
+        {
+            Action = () =>
+            {
+                _isGameRunning = CurrentGame == GameExtensions.GetRunningGame();
+            },
+            IntervalMillis = 500
+        };
+        _gameMonitorJob.Run();
     }
 
     /// <summary>
@@ -48,7 +55,9 @@ public static class GameManager
     /// <param name="game"></param>
     private static void ExitGameData(Game game)
     {
-        _gameMonitorJob.CancelJoin();
+        _gameMonitorJob?.CancelJoin();
+        _isGameRunning = false;
+
         SimDataProvider.Stop();
         _dataUpdaterJob?.CancelJoin();
     }

--- a/Race Element.Data/Games/GameManager.cs
+++ b/Race Element.Data/Games/GameManager.cs
@@ -5,11 +5,25 @@ namespace RaceElement.Data.Games;
 
 public static class GameManager
 {
-    private static SimpleLoopJob _dataUpdaterJob;
     public static Game CurrentGame { get; private set; } = Game.Any;
+    public static bool IsGameRunning { get => _isGameRunning; set => _isGameRunning = value; }
 
+    private static bool _isGameRunning = false;
 
     public static event EventHandler<(Game previous, Game next)>? OnGameChanged;
+
+    private static readonly SimpleLoopJob _dataUpdaterJob = new()
+    {
+        Action = () => SimDataProvider.Update(),
+        IntervalMillis = 1000 / SimDataProvider.Instance.PollingRate()
+    };
+
+    private static readonly SimpleLoopJob _gameMonitorJob = new()
+    {
+        Action = () => _isGameRunning = CurrentGame == GameExtensions.GetRunningGame(),
+        IntervalMillis = 500
+    };
+
     public static void SetCurrentGame(Game nextGame)
     {
         ExitGameData(CurrentGame);
@@ -22,13 +36,9 @@ public static class GameManager
         SimDataProvider.Update(true);
         if (SimDataProvider.Instance != null)
         {
-            _dataUpdaterJob = new()
-            {
-                Action = () => SimDataProvider.Update(),
-                IntervalMillis = 1000 / SimDataProvider.Instance.PollingRate()
-            };
             SimDataProvider.Instance.Start();
             _dataUpdaterJob.Run();
+            _gameMonitorJob.Run();
         }
     }
 
@@ -38,6 +48,7 @@ public static class GameManager
     /// <param name="game"></param>
     private static void ExitGameData(Game game)
     {
+        _gameMonitorJob.CancelJoin();
         SimDataProvider.Stop();
         _dataUpdaterJob?.CancelJoin();
     }

--- a/Race Element.Data/Games/GameManager.cs
+++ b/Race Element.Data/Games/GameManager.cs
@@ -49,7 +49,7 @@ public static class GameManager
                 if (AutoSwitch && !_isGameRunning && _runningGame != Game.Any)
                     OnAutoGameRequest?.Invoke(null, _runningGame);
             },
-            IntervalMillis = 1000,
+            IntervalMillis = 2000,
         };
         _autoSwitchJob.Run();
 

--- a/Race Element.HUD.Common/Overlays/Pitwall/Clock/ClockOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Pitwall/Clock/ClockOverlay.cs
@@ -43,7 +43,7 @@ internal sealed class ClockOverlay(Rectangle rectangle) : CommonAbstractOverlay(
             [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
             public TimeFormat Format { get; init; } = TimeFormat.Full;
 
-            [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
+            [ToolTip("Default means the clock will only show when the engine is running.\nAlways means always.\nAlways when game is running hides once you exit the game.")]
             public VisibilityOption Visibility { get; init; } = VisibilityOption.Always;
         }
     }

--- a/Race Element.HUD.Common/Overlays/Pitwall/Clock/ClockOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Pitwall/Clock/ClockOverlay.cs
@@ -1,4 +1,5 @@
-﻿using RaceElement.HUD.Overlay.Configuration;
+﻿using RaceElement.Data.Games;
+using RaceElement.HUD.Overlay.Configuration;
 using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.OverlayUtil.InfoPanel;
@@ -28,6 +29,13 @@ internal sealed class ClockOverlay(Rectangle rectangle) : CommonAbstractOverlay(
             AmPm
         }
 
+        public enum VisibilityOption
+        {
+            Default,
+            AlwaysWhenGameRuns,
+            Always,
+        }
+
         [ConfigGrouping("Clock", "Change settings that alter the presentation of the time.")]
         public InfoPanelGrouping InfoPanel { get; init; } = new();
         public sealed class InfoPanelGrouping
@@ -35,8 +43,8 @@ internal sealed class ClockOverlay(Rectangle rectangle) : CommonAbstractOverlay(
             [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
             public TimeFormat Format { get; init; } = TimeFormat.Full;
 
-            [ToolTip("Renders this HUD regardless of the whether the engine is running or not.")]
-            public bool AlwaysShow { get; init; } = true;
+            [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
+            public VisibilityOption Visibility { get; init; } = VisibilityOption.Always;
         }
     }
 
@@ -49,7 +57,7 @@ internal sealed class ClockOverlay(Rectangle rectangle) : CommonAbstractOverlay(
     private const string FullTimeFormat = "HH\\:mm\\:ss";
     private const string AmpPmTimeFormat = "hh\\:mm\\:ss tt";
 
-    public override void BeforeStart()
+    public sealed override void BeforeStart()
     {
         _timeFormat = _config.InfoPanel.Format switch
         {
@@ -104,22 +112,24 @@ internal sealed class ClockOverlay(Rectangle rectangle) : CommonAbstractOverlay(
         RefreshRateHz = 1;
     }
 
-    public override void BeforeStop()
+    public sealed override void BeforeStop()
     {
         _font?.Dispose();
         _timeHeader?.Dispose();
         _timeValue?.Dispose();
     }
 
-    public override bool ShouldRender()
+    public sealed override bool ShouldRender()
     {
-        if (_config.InfoPanel.AlwaysShow)
-            return true;
-
-        return base.ShouldRender();
+        return _config.InfoPanel.Visibility switch
+        {
+            SystemTimeConfig.VisibilityOption.Always => true,
+            SystemTimeConfig.VisibilityOption.AlwaysWhenGameRuns => GameManager.IsGameRunning,
+            _ => base.ShouldRender(),
+        };
     }
 
-    public override void Render(Graphics g)
+    public sealed override void Render(Graphics g)
     {
         _timeHeader.Draw(g, "Clock", Scale);
         _timeValue.Draw(g, $"{DateTime.Now.ToString(_timeFormat)}", Scale);

--- a/Race_Element.Data.ACC/Database/Telemetry/TelemetryRecorder.cs
+++ b/Race_Element.Data.ACC/Database/Telemetry/TelemetryRecorder.cs
@@ -97,10 +97,11 @@ internal class TelemetryRecorder
             return;
         }
 
-        LogWriter.WriteToLog("TelemetryRecorder: Record()");
-
         if (!new AccManagerSettings().Get().TelemetryRecordDetailed)
             return;
+
+        LogWriter.WriteToLog("TelemetryRecorder: Record()");
+       
 
         _isRunning = true;
         new Thread(x =>

--- a/Race_Element.Data.ACC/Session/RaceSessionTracker.cs
+++ b/Race_Element.Data.ACC/Session/RaceSessionTracker.cs
@@ -8,6 +8,7 @@ using RaceElement.Data.ACC.Database.RaceWeekend;
 using RaceElement.Data.ACC.Database.SessionData;
 using RaceElement.Data.ACC.Database.Telemetry;
 using RaceElement.Data.ACC.Tracker;
+using RaceElement.Util.Settings;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -117,7 +118,8 @@ public sealed class RaceSessionTracker
             RaceSessionCollection.Insert(CurrentSession);
             OnNewSessionStarted?.Invoke(this, CurrentSession);
 
-            TelemetryRecorder.Instance.Record();
+            if (new AccManagerSettings().Get().TelemetryRecordDetailed)
+                TelemetryRecorder.Instance.Record();
         }
     }
 

--- a/Race_Element.Data.ACC/Tracks/Data/Nurburgring.cs
+++ b/Race_Element.Data.ACC/Tracks/Data/Nurburgring.cs
@@ -20,7 +20,7 @@ internal sealed class Nurburgring : AbstractTrackData
     // https://www.paradigmshiftracing.com/uploads/4/8/2/6/48261497/nurburgring-map_orig.png
     public override Dictionary<FloatRangeStruct, (int, string)> CornerNames => new()
     {
-        { new FloatRangeStruct(0.09318506f, 0.1456866f), (1, "Yohohama Kurve")},
+        { new FloatRangeStruct(0.09318506f, 0.1456866f), (1, "Yokohama Kurve")},
         { new FloatRangeStruct(0.1456867f, 0.184711f), (2, "Mercedes Arena")},
         { new FloatRangeStruct(0.1969276f, 0.2212936f), (3, "Mercedes Arena")},
         { new FloatRangeStruct(0.2212937f, 0.255046f), (4, "")},

--- a/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoConfiguration.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoConfiguration.cs
@@ -5,10 +5,18 @@ internal sealed class TyreInfoConfiguration : OverlayConfiguration
 {
     public TyreInfoConfiguration() => GenericConfiguration.AllowRescale = true;
 
+    public enum TyreTempPositionOption
+    {
+        ClampedToMiddle,
+        CenterOfTyre,
+    }
+
     [ConfigGrouping("Info", "Show additional information about the condition of the tyres.")]
     public InfoGrouping Information { get; init; } = new InfoGrouping();
     public sealed class InfoGrouping
     {
+        public TyreTempPositionOption TyreTempPosition { get; init; } = TyreTempPositionOption.CenterOfTyre;
+
         [ToolTip("Displays the percentage of brake pad life above the brake pads.")]
         public bool PadLife { get; init; } = true;
 

--- a/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/TyreInfo/TyreInfoOverlay.cs
@@ -99,10 +99,13 @@ internal sealed class TyreInfoOverlay : AbstractOverlay
             DrawTyrePressureLoss(g, 110, 206, Wheel.RearRight);
         }
 
-        DrawTyreTemp(g, 27, 80, Wheel.FrontLeft);
-        DrawTyreTemp(g, 106, 80, Wheel.FrontRight);
-        DrawTyreTemp(g, 27, 122, Wheel.RearLeft);
-        DrawTyreTemp(g, 106, 122, Wheel.RearRight);
+
+        int yFronts = _config.Information.TyreTempPosition == TyreInfoConfiguration.TyreTempPositionOption.ClampedToMiddle ? 80 : 46;
+        int yRears = _config.Information.TyreTempPosition == TyreInfoConfiguration.TyreTempPositionOption.ClampedToMiddle ? 122 : 160;  
+        DrawTyreTemp(g, 27, yFronts, Wheel.FrontLeft);
+        DrawTyreTemp(g, 106, yFronts, Wheel.FrontRight);
+        DrawTyreTemp(g, 27, yRears, Wheel.RearLeft);
+        DrawTyreTemp(g, 106, yRears, Wheel.RearRight);
     }
 
     private void DrawTyrePressures(Graphics g)

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
@@ -1,4 +1,5 @@
-﻿using RaceElement.HUD.Overlay.Configuration;
+﻿using RaceElement.Data.Games;
+using RaceElement.HUD.Overlay.Configuration;
 using RaceElement.HUD.Overlay.Internal;
 using RaceElement.HUD.Overlay.OverlayUtil;
 using RaceElement.HUD.Overlay.OverlayUtil.InfoPanel;
@@ -29,6 +30,13 @@ internal sealed class ClockOverlay(Rectangle rectangle) : AbstractOverlay(rectan
             AmPm
         }
 
+        public enum VisibilityOption
+        {
+            Default,
+            AlwaysWhenGameRuns,
+            Always,
+        }
+
         [ConfigGrouping("Clock", "Change settings that alter the presentation of the time.")]
         public InfoPanelGrouping InfoPanel { get; init; } = new();
         public sealed class InfoPanelGrouping
@@ -36,8 +44,8 @@ internal sealed class ClockOverlay(Rectangle rectangle) : AbstractOverlay(rectan
             [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
             public TimeFormat Format { get; init; } = TimeFormat.Full;
 
-            [ToolTip("Renders this HUD regardless of the whether the engine is running or not.")]
-            public bool AlwaysShow { get; init; } = true;
+            [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
+            public VisibilityOption Visibility { get; init; } = VisibilityOption.Always;
         }
     }
 
@@ -50,7 +58,7 @@ internal sealed class ClockOverlay(Rectangle rectangle) : AbstractOverlay(rectan
     private const string FullTimeFormat = "HH\\:mm\\:ss";
     private const string AmpPmTimeFormat = "hh\\:mm\\:ss tt";
 
-    public override void BeforeStart()
+    public sealed override void BeforeStart()
     {
         _timeFormat = _config.InfoPanel.Format switch
         {
@@ -105,22 +113,24 @@ internal sealed class ClockOverlay(Rectangle rectangle) : AbstractOverlay(rectan
         RefreshRateHz = 1;
     }
 
-    public override void BeforeStop()
+    public sealed override void BeforeStop()
     {
         _font?.Dispose();
         _timeHeader?.Dispose();
         _timeValue?.Dispose();
     }
 
-    public override bool ShouldRender()
+    public sealed override bool ShouldRender()
     {
-        if (_config.InfoPanel.AlwaysShow)
-            return true;
-
-        return base.ShouldRender();
+        return _config.InfoPanel.Visibility switch
+        {
+            SystemTimeConfig.VisibilityOption.Always => true,
+            SystemTimeConfig.VisibilityOption.AlwaysWhenGameRuns => GameManager.IsGameRunning,
+            _ => base.ShouldRender(),
+        };
     }
 
-    public override void Render(Graphics g)
+    public sealed override void Render(Graphics g)
     {
         _timeHeader.Draw(g, "Clock", Scale);
         _timeValue.Draw(g, $"{DateTime.Now.ToString(_timeFormat)}", Scale);

--- a/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
+++ b/Race_Element.HUD.ACC/Overlays/Pitwall/OverlayClock/ClockOverlay.cs
@@ -44,7 +44,7 @@ internal sealed class ClockOverlay(Rectangle rectangle) : AbstractOverlay(rectan
             [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
             public TimeFormat Format { get; init; } = TimeFormat.Full;
 
-            [ToolTip("Change between Full(24h) and AM/PM notation of time.")]
+            [ToolTip("Default means the clock will only show when the engine is running.\nAlways means always.\nAlways when game is running hides once you exit the game.")]
             public VisibilityOption Visibility { get; init; } = VisibilityOption.Always;
         }
     }

--- a/Race_Element.Util/Settings/AccManagerSettings.cs
+++ b/Race_Element.Util/Settings/AccManagerSettings.cs
@@ -3,6 +3,7 @@
 public sealed class AccManagerSettingsJson : IGenericSettingsJson
 {
     public bool MinimizeToSystemTray { get; set; }
+    public bool AutoSwitchGames { get; set; }
     public bool TelemetryRecordDetailed { get; set; }
     public int TelemetryDetailedHerz { get; set; }
     public bool Generate4kDDS { get; set; }
@@ -20,6 +21,7 @@ public sealed class AccManagerSettings : AbstractSettingsJson<AccManagerSettings
         TelemetryRecordDetailed = false,
         TelemetryDetailedHerz = 20,
         Generate4kDDS = false,
+        AutoSwitchGames = true,
     };
 
 }

--- a/Race_Element/Controls/GamePicker.xaml.cs
+++ b/Race_Element/Controls/GamePicker.xaml.cs
@@ -48,8 +48,8 @@ public partial class GamePicker : UserControl
             {
                 var list = comboGamePicker.ItemsSource.Cast<GamePickerModel>();
                 var nextItem = list.FirstOrDefault(x => x.Game == requested);
-                ;
                 comboGamePicker.SelectedItem = nextItem;
+                MainWindow.Instance.EnqueueSnackbarMessage($"Automatically switched to {nextItem.FriendlyName}");
             }
         });
     }

--- a/Race_Element/Controls/GamePicker.xaml.cs
+++ b/Race_Element/Controls/GamePicker.xaml.cs
@@ -33,8 +33,25 @@ public partial class GamePicker : UserControl
 
             SetToolTip(currentGame);
         };
+        GameManager.OnAutoGameRequest += GameManager_OnAutoGameRequest;
+
         ToolTipService.SetInitialShowDelay(this, 0);
         ToolTipService.SetPlacement(this, System.Windows.Controls.Primitives.PlacementMode.Right);
+    }
+
+    private void GameManager_OnAutoGameRequest(object sender, Game requested)
+    {
+        comboGamePicker.Dispatcher.BeginInvoke(() =>
+        {
+            var selected = comboGamePicker.SelectedItem as GamePickerModel;
+            if (selected.Game != requested)
+            {
+                var list = comboGamePicker.ItemsSource.Cast<GamePickerModel>();
+                var nextItem = list.FirstOrDefault(x => x.Game == requested);
+                ;
+                comboGamePicker.SelectedItem = nextItem;
+            }
+        });
     }
 
     private void SetToolTip(Game game)
@@ -94,11 +111,11 @@ public partial class GamePicker : UserControl
         comboGamePicker.ItemsSource = availableGames;
 
         var uiSettings = new UiSettings();
-        Game selectedGame = GameExtensions.GetRunningGame();
+        Game selectedGame = Game.Any;//  GameExtensions.GetRunningGame();
 
         if (selectedGame == Game.Any)
         {
-            selectedGame = uiSettings.Get().SelectedGame;;
+            selectedGame = uiSettings.Get().SelectedGame; ;
         }
 
         var model = availableGames.FirstOrDefault(x => x.Game == selectedGame);

--- a/Race_Element/Controls/HUD/HudOptions.xaml.cs
+++ b/Race_Element/Controls/HUD/HudOptions.xaml.cs
@@ -182,6 +182,14 @@ public partial class HudOptions : UserControl
                     m_GlobalHook = Hook.GlobalEvents();
                     m_GlobalHook.OnCombination(new Dictionary<Combination, Action> {
                         { Combination.FromString("Control+Home"), () => {
+
+                            // prevent hotkey from working when the game is not running, in this case it will only work when the app is the active window.
+                            if (!GameManager.IsGameRunning)
+                            {
+                                if (MainWindow.Instance.WindowState == WindowState.Minimized || !MainWindow.Instance.IsActive)
+                                    return;
+                            }
+
                             if (_lastMovementModeChange.AddMilliseconds(MovementModeDebounce) < DateTime.Now) {
                                 Dispatcher.BeginInvoke(new Action(() => {
                                     this.listBoxItemToggleMovementMode.IsSelected = !this.listBoxItemToggleMovementMode.IsSelected;

--- a/Race_Element/Controls/Info/Info.xaml
+++ b/Race_Element/Controls/Info/Info.xaml
@@ -305,11 +305,9 @@
                         </Grid.RowDefinitions>
 
                         <ScrollViewer Style="{StaticResource MaterialDesignScrollViewer}" Grid.Row="1" Margin="0,5,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible">
-                            <materialDesign:Card Margin="6,0,3,0">
-                                <StackPanel x:Name="stackPanelReleaseNotes" Orientation="Vertical" Margin="5,0,0,10">
+                            <StackPanel x:Name="stackPanelReleaseNotes" Orientation="Vertical" Margin="11,0,3,10" RenderOptions.ClearTypeHint="Enabled">
 
-                                </StackPanel>
-                            </materialDesign:Card>
+                            </StackPanel>
                         </ScrollViewer>
 
                     </Grid>

--- a/Race_Element/Controls/Info/Info.xaml.cs
+++ b/Race_Element/Controls/Info/Info.xaml.cs
@@ -184,7 +184,7 @@ public partial class Info : UserControl
                     Text = note.Key,
                     Style = Resources["MaterialDesignBody1TextBlock"] as Style,
                     FontWeight = FontWeights.Bold,
-                    FontStyle = FontStyles.Oblique
+                    FontStyle = FontStyles.Italic
                 };
                 TextBlock noteDescription = new()
                 {
@@ -193,7 +193,7 @@ public partial class Info : UserControl
                     Style = Resources["MaterialDesignDataGridTextColumnStyle"] as Style
                 };
 
-                StackPanel changePanel = new() { Margin = new Thickness(0, 10, 0, 0) };
+                StackPanel changePanel = new() { Margin = new Thickness(0, 10, 0, 0), Orientation = Orientation.Vertical };
                 changePanel.Children.Add(noteTitle);
                 changePanel.Children.Add(noteDescription);
 

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -8,7 +8,7 @@ public static class ReleaseNotes
     {
         {"2.2.5.6", "Race Element:"+
                     "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
-                    "This should prevent unwwanted activation of the HUD Movement Mode."+
+                    "This should prevent unwanted activation of the HUD Movement Mode."+
                     "\n- Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running."
                     },
         {"2.2.5.4", "Race Element:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -7,7 +7,7 @@ public static class ReleaseNotes
     internal static readonly Dictionary<string, string> Notes = new()
     {
         {"2.2.5.9", "Race Element:"+
-                    "\nRace Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element."+
+                    "\n- Race Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element."+
                     "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
                     "This should prevent unwanted activation of the HUD Movement Mode."+
                     "\n- Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running."

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,8 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
-        {"2.2.5.6", "Race Element:"+
+        {"2.2.5.9", "Race Element:"+
+                    "\nRace Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element."+
                     "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
                     "This should prevent unwanted activation of the HUD Movement Mode."+
                     "\n- Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running."

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,6 +6,7 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
+        {"2.2.5.6", "Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running." },
         {"2.2.5.4", "Race Element:"+
                     "\n- Info Tab: added button to open guides on the website."+
                     "\n\nMulti-Sim:"+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -10,7 +10,7 @@ public static class ReleaseNotes
                     "\n- Race Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element."+
                     "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
                     "This should prevent unwanted activation of the HUD Movement Mode."+
-                    "\n- Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running."
+                    "\n- Clock HUD: Added a visibility option with 3 options: default, always and always when game is running."
                     },
         {"2.2.5.4", "Race Element:"+
                     "\n- Info Tab: added button to open guides on the website."+

--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,11 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
-        {"2.2.5.6", "Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running." },
+        {"2.2.5.6", "Race Element:"+
+                    "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
+                    "This should prevent unwwanted activation of the HUD Movement Mode."+
+                    "\n- Clock HUD: Added a visiblity option with 3 options: default, always and always when game is running."
+                    },
         {"2.2.5.4", "Race Element:"+
                     "\n- Info Tab: added button to open guides on the website."+
                     "\n\nMulti-Sim:"+

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml
@@ -15,6 +15,11 @@
             <Label VerticalAlignment="Center">Minimize Race Element to system tray</Label>
         </StackPanel>
 
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="If any of the supported games is running and Race Element isn't set to this game, it will automatically switch for you.">
+            <ToggleButton x:Name="toggleAutoSwitchGames" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
+            <Label VerticalAlignment="Center">Automatically switch to supported running games.</Label>
+        </StackPanel>
+
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" ToolTip="Usually dds_1 files are downscaled to 2K, this forces it to be 4k. Useful if you want to make screenshots of your custom livery whilst driving.">
             <ToggleButton x:Name="toggleGenerate4kDDS" Width="50" Height="35" VerticalAlignment="Center" Cursor="Hand"/>
             <Label VerticalAlignment="Center">DDS Generator: generate 4K dds_1 files.</Label>

--- a/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml.cs
+++ b/Race_Element/Controls/Settings/AccManagerSettings/AccManagerSettingsTab.xaml.cs
@@ -35,6 +35,9 @@ public partial class AccManagerSettingsTab : UserControl
 
             sliderTelemetryHerz.ValueChanged += (s, e) => SaveSettings();
 
+            toggleAutoSwitchGames.Checked += (s, e) => SaveSettings();
+            toggleAutoSwitchGames.Unchecked += (s, e) => SaveSettings();
+
             buttonOpenAccManagerFolder.Click += ButtonOpenAccManagerFolder_Click;
             buttonMigrateAccHudsToV2.Click += ButtonMigrateAccHudsToV2_Click;
         }));
@@ -58,7 +61,8 @@ public partial class AccManagerSettingsTab : UserControl
                 continue;
             }
             filesCopied++;
-        };
+        }
+        ;
 
         RunRaceElement(FileUtil.AppFullName + ".exe");
     }
@@ -93,6 +97,8 @@ public partial class AccManagerSettingsTab : UserControl
         labelTelemetryHerz.Content = $"Telemetry: Extended Data Herz: {_settings.Get().TelemetryDetailedHerz}";
         toggleMinimizeToSystemTray.IsChecked = _settings.Get().MinimizeToSystemTray;
         toggleGenerate4kDDS.IsChecked = _settings.Get().Generate4kDDS;
+        toggleAutoSwitchGames.IsChecked = _settings.Get().AutoSwitchGames;
+        GameManager.AutoSwitch = _settings.Get().AutoSwitchGames;
     }
 
     private void ButtonOpenAccManagerFolder_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -110,6 +116,8 @@ public partial class AccManagerSettingsTab : UserControl
         settings.TelemetryRecordDetailed = toggleRecordLapTelemetry.IsChecked.Value;
         settings.TelemetryDetailedHerz = (int)sliderTelemetryHerz.Value;
         settings.Generate4kDDS = toggleGenerate4kDDS.IsChecked.Value;
+        settings.AutoSwitchGames = toggleAutoSwitchGames.IsChecked.Value;
+        GameManager.AutoSwitch = settings.AutoSwitchGames;
 
         labelTelemetryHerz.Content = $"Telemetry: Extended Data Herz: {settings.TelemetryDetailedHerz}";
 

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.2.5.5</ApplicationVersion>
-        <AssemblyVersion>2.2.5.5</AssemblyVersion>
-        <Version>2.2.5.5</Version>
+        <ApplicationVersion>2.2.5.9</ApplicationVersion>
+        <AssemblyVersion>2.2.5.9</AssemblyVersion>
+        <Version>2.2.5.9</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.2.5.4</ApplicationVersion>
-        <AssemblyVersion>2.2.5.4</AssemblyVersion>
-        <Version>2.2.5.4</Version>
+        <ApplicationVersion>2.2.5.5</ApplicationVersion>
+        <AssemblyVersion>2.2.5.5</AssemblyVersion>
+        <Version>2.2.5.5</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>

--- a/Race_Element/Race Element.csproj
+++ b/Race_Element/Race Element.csproj
@@ -12,9 +12,9 @@
         <SuiteName>Race Element</SuiteName>
         <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
         <DisallowUrlActivation>true</DisallowUrlActivation>
-        <ApplicationVersion>2.2.5.9</ApplicationVersion>
-        <AssemblyVersion>2.2.5.9</AssemblyVersion>
-        <Version>2.2.5.9</Version>
+        <ApplicationVersion>2.2.6.0</ApplicationVersion>
+        <AssemblyVersion>2.2.6.0</AssemblyVersion>
+        <Version>2.2.6.0</Version>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>


### PR DESCRIPTION
Race Element:
- Race Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element.
- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. This should prevent unwanted activation of the HUD Movement Mode.
- Clock HUD: Added a visibility option with 3 options: default, always and always when game is running.