### PR TITLE
2.2.6.0

### DIFF
--- a/Race_Element/Controls/Info/ReleaseNotes.cs
+++ b/Race_Element/Controls/Info/ReleaseNotes.cs
@@ -6,7 +6,7 @@ public static class ReleaseNotes
 {
     internal static readonly Dictionary<string, string> Notes = new()
     {
-        {"2.2.5.9", "Race Element:"+
+        {"2.2.6.0", "Race Element:"+
                     "\n- Race Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element."+
                     "\n- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. " +
                     "This should prevent unwanted activation of the HUD Movement Mode."+


### PR DESCRIPTION
Race Element:
- Race Element can now automatically switch itself between supported games, this option can be found in the Main Settings of Race Element.
- HUD Tab: the Control + Home hotkey to activate movement mode will be automatically disabled if the game is not running. In this case the hotkey will only work if Race Element is the active window. This should prevent unwanted activation of the HUD Movement Mode.
- Clock HUD: Added a visibility option with 3 options: default, always and always when game is running.