### PR TITLE
iRacing Data getting bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Free code signing provided by [SignPath.io](https://signpath.io?utm_source=found
 - [dirkaw](https://github.com/dirkaw)
 - [Mominon](https://github.com/Mominon)
 - [RST](https://github.com/RST)
+- [Connor-Molz](https://github.com/Connor-Molz)
 - [Marco-De-Fanti](https://github.com/Marco-De-Fanti)
 - [Glen-Germaine](https://github.com/Glen-Germaine)
 - [Balzs-Fehr](https://github.com/Balzs-Fehr)
 - [mreininger23](https://github.com/mreininger23)
 - [Kris](https://github.com/Kris)
 - [Dirk-W](https://github.com/Dirk-W)
-- [Connor-Molz](https://github.com/Connor-Molz)
 - [Andreas-Willich](https://github.com/Andreas-Willich)
 <!-- END_CONTRIBUTORS -->

--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ Free code signing provided by [SignPath.io](https://signpath.io?utm_source=found
 - [mreininger23](https://github.com/mreininger23)
 - [Kris](https://github.com/Kris)
 - [Dirk-W](https://github.com/Dirk-W)
+- [Connor-Molz](https://github.com/Connor-Molz)
 - [Andreas-Willich](https://github.com/Andreas-Willich)
 <!-- END_CONTRIBUTORS -->

--- a/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
+++ b/Race Element.Data/Games/iRacing/IRacingDataProvider.cs
@@ -160,7 +160,14 @@ public sealed class IRacingDataProvider : AbstractSimDataProvider
         isInGarageDatum = _iRacingSDK.Data.TelemetryDataProperties["IsInGarage"];
         isReplayPlayingDatum = _iRacingSDK.Data.TelemetryDataProperties["IsReplayPlaying"];
         playerCarIdxDatum = _iRacingSDK.Data.TelemetryDataProperties["PlayerCarIdx"];
-        pushToPassLevelDatum = _iRacingSDK.Data.TelemetryDataProperties["EnergyERSBatteryPct"];
+        try
+        {
+            pushToPassLevelDatum = _iRacingSDK.Data.TelemetryDataProperties["EnergyERSBatteryPct"];
+        }
+        catch (Exception ex)
+        {
+            // Can be ignored because its thrown if the car has no hybrid System
+        }
 
         datumsInitialized = true;
     }
@@ -314,8 +321,11 @@ public sealed class IRacingDataProvider : AbstractSimDataProvider
             float steeringRadians = -_iRacingSDK.Data.GetFloat(steeringWheelAngleDatum) * 2;
             float steeringPercentage = Single.RadiansToDegrees(steeringRadians) / localCar.Inputs.MaxSteeringAngle;
             localCar.Inputs.Steering = Math.Clamp(steeringPercentage, -1, 1);
-            localCar.Electronics.PushToPassLevel = _iRacingSDK.Data.GetFloat(pushToPassLevelDatum) * 100f; // 0-1 to 0-100%
+            if (pushToPassLevelDatum != null)
+            {
 
+                localCar.Electronics.PushToPassLevel = _iRacingSDK.Data.GetFloat(pushToPassLevelDatum) * 100f; // 0-1 to 0-100%
+            }
 
             SessionData.Instance.LapDeltaToSessionBestLapMs = _iRacingSDK.Data.GetFloat(lapDeltaToSessionBestLapDatum);
             SessionData.Instance.LapDeltaToLastLapMs = _iRacingSDK.Data.GetFloat(lapDeltaToSessionLastLapDatum);


### PR DESCRIPTION
I fixed the bug which throws an Null Point Exception in the iRacing data-getter because of the non existence of the "EnergyERSBatteryPct" Datum in some/most cars.

This bug came with my Hybrid info overlay in version 2.5.4.0