### PR TITLE
Add missing Suspension data to LocalCarData overlay

### DIFF
--- a/Race Element.HUD.Common/Overlays/Pitwall/LocalCarData/LocalCarDataOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Pitwall/LocalCarData/LocalCarDataOverlay.cs
@@ -33,6 +33,7 @@ internal sealed class GameDataOverlay : CommonAbstractOverlay
             public bool Inputs { get; init; } = true;
             public bool Tyres { get; init; } = true;
             public bool Brakes { get; init; } = true;
+            public bool Suspension { get; init; } = true;
             public bool Electronics { get; init; } = true;
             public bool RaceData { get; init; } = true;
             public bool TimingData { get; init; } = true;
@@ -83,6 +84,9 @@ internal sealed class GameDataOverlay : CommonAbstractOverlay
 
         if (_config.VisibleMember.Brakes)
             currentY += DrawObject(SimDataProvider.LocalCar.Brakes, "Brakes", currentY, g).Height;
+
+        if (_config.VisibleMember.Suspension)
+            currentY += DrawObject(SimDataProvider.LocalCar.Suspension, "Suspension", currentY, g).Height;
 
         if (_config.VisibleMember.Electronics)
             currentY += DrawObject(SimDataProvider.LocalCar.Electronics, "Electronics", currentY, g).Height;


### PR DESCRIPTION
### Changes
- Added `Suspension` toggle to `VisibleMemberGrouping` config
- Added `Suspension` rendering block in `Render` method

### Context
The `Suspension` property exists in `LocalCarData` but was not being displayed in the overlay. This adds it between `Brakes` and `Electronics` to maintain the same property order as defined in `LocalCarData.cs`.

Follows existing code patterns and maintains consistency with other data categories.
