### PR TITLE
SlipAngle support for Assetto Corsa Evo

### DIFF
--- a/Race Element.Data/Games/AssettoCorsaEvo/DataMapper/LocalCarMapper.cs
+++ b/Race Element.Data/Games/AssettoCorsaEvo/DataMapper/LocalCarMapper.cs
@@ -29,6 +29,7 @@ internal static partial class LocalCarMapper
         commonData.Tyres.CoreTemperature = pagePhysics.TyreCoreTemperature;
         commonData.Tyres.Pressure = pagePhysics.WheelPressure;
         commonData.Tyres.SlipRatio = pagePhysics.WheelSlip;
+        commonData.Tyres.SlipAngle = pagePhysics.SlipAngle;
         commonData.Tyres.Velocity = pagePhysics.Velocity;
 
         commonData.Brakes.DiscTemperature = pagePhysics.BrakeTemperature;

--- a/Race Element.Data/Games/Forza/ForzaDataProvider.cs
+++ b/Race Element.Data/Games/Forza/ForzaDataProvider.cs
@@ -136,7 +136,7 @@ public sealed class ForzaDataProvider(Game Game) : AbstractSimDataProvider
         localCar.Physics.Velocity = (float)Math.Sqrt(sled.VelocityX * sled.VelocityX + sled.VelocityY * sled.VelocityY + sled.VelocityZ * sled.VelocityZ) * 3.6f;
         localCar.Physics.Location = new Vector3(dash.PositionX, dash.PositionY, dash.PositionZ);
         localCar.Physics.Rotation = Quaternion.CreateFromYawPitchRoll(sled.Yaw, sled.Pitch, sled.Roll);
-        localCar.Tyres.SlipAngle = [sled.TireSlipAngleFr / -2f, sled.TireSlipAngleFl / -2f, sled.TireSlipAngleRr / -2f, sled.TireSlipAngleRl / -2f];
+        localCar.Tyres.SlipAngle = [sled.TireSlipAngleFr / -8f, sled.TireSlipAngleFl / -8f, sled.TireSlipAngleRr / -8f, sled.TireSlipAngleRl / -8f];
         localCar.Tyres.SlipRatio =
         [
             NegateIfNegative(sled.TireCombinedSlipFr),

--- a/Race Element.HUD.Common/Overlays/Driving/WheelSlip/WheelSlipOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/WheelSlip/WheelSlipOverlay.cs
@@ -58,7 +58,7 @@ internal sealed class WheelSlipOverlay : CommonAbstractOverlay
 
     private WheelSlipModel _wheelSlipModel;
 
-    private const Game GamesWithSlipAngle = Game.ForzaHorizon5;
+    private const Game GamesWithSlipAngle = Game.ForzaHorizon5 | Game.AssettoCorsaEvo;
     private readonly struct WheelSlipModel(float[] slipRatios, float[] slipAngles)
     {
         public readonly float[] SlipRatios = slipRatios;
@@ -166,7 +166,7 @@ internal sealed class WheelSlipOverlay : CommonAbstractOverlay
 
         if (GamesWithSlipAngle.HasFlag(this.GameWhenStarted))
         {
-            float slipAngle = (float)(_wheelSlipModel.SlipAngles[(int)wheel] * 180d / Math.PI / 4) - 90;
+            float slipAngle = (float)(_wheelSlipModel.SlipAngles[(int)wheel] * 180d / Math.PI) - 90;
             g.DrawArc(_wheelPen, wheelRect, slipAngle - 10, 20);
         }
     }


### PR DESCRIPTION
## Description
ACE provides the correct slip angle in radians, so WheelSlipOverlay can use it directly. However, the drawing code converts the angle to degrees and then downscales it by a factor of four. That downscaling is only used for Forza Horizon 5. The slip value provided by Forza Horizon 5 is not in radians; according to deepwiki.com, the reported value uses 0.0 = 100% grip and values >1.0 indicate loss of grip. This suggests the game’s value is not a physically meaningful angle and should be treated empirically (estimated by eye). I tested the current scaling with Forza Horizon 4 and it produces sensible results, so I preserved the existing scaling. If we move the slip-angle scaling from the overlay into ForzaDataProvider, the overlay can display the raw angle from LocalCar.Tyres.SlipAngle directly.

ACC probably can be supported too just by adding flag to GamesWithSlipAngle, but I don't have game to test

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] My code follows the project's coding style.
- [x] I have tested my changes thoroughly.
- [x] I have updated any necessary documentation.
- [x] My changes introduce no new warnings.
