### PR TITLE
Water temperature HUD in LocalCarData, AMS2 DSX/mapper support, DSX and ACC fixes

### DIFF
--- a/Race Element.Data/Common/SimulatorData/LocalCar/LocalCarData.cs
+++ b/Race Element.Data/Common/SimulatorData/LocalCar/LocalCarData.cs
@@ -81,6 +81,16 @@ public sealed record EngineData
     /// </summary>
     public int ShiftUpRpm { get; internal set; }
 
+    /// <summary>
+    /// Engine coolant (water) temperature in Celsius
+    /// </summary>
+    public float WaterTemperature { get; internal set; }
+
+    /// <summary>
+    /// Engine oil temperature in Celsius
+    /// </summary>
+    public float OilTemperature { get; internal set; }
+
     // Fuel info
     public float FuelLiters { get; internal set; }
     public float MaxFuelLiters { get; internal set; }

--- a/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
+++ b/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
@@ -165,12 +165,12 @@ internal static class Ams2Mapper
         local.Brakes.DiscTemperature[2] = shared.mBrakeTempCelsius.RL;
         local.Brakes.DiscTemperature[3] = shared.mBrakeTempCelsius.RR;
 
-        // Tyre slip ratio calculation
+        // Tyre slip ratio calculation (absolute values for HUD compatibility)
         local.Tyres.SlipRatio = [
-            CalculateWheelSlipRatio(shared.mTyreRPS.FL, shared.mTyreY.FL, shared.mLocalVelocity.Z),
-            CalculateWheelSlipRatio(shared.mTyreRPS.FR, shared.mTyreY.FR, shared.mLocalVelocity.Z),
-            CalculateWheelSlipRatio(shared.mTyreRPS.RL, shared.mTyreY.RL, shared.mLocalVelocity.Z),
-            CalculateWheelSlipRatio(shared.mTyreRPS.RR, shared.mTyreY.RR, shared.mLocalVelocity.Z)
+            Math.Abs(CalculateWheelSlipRatio(shared.mTyreRPS.FL, shared.mTyreY.FL, shared.mLocalVelocity.Z)),
+            Math.Abs(CalculateWheelSlipRatio(shared.mTyreRPS.FR, shared.mTyreY.FR, shared.mLocalVelocity.Z)),
+            Math.Abs(CalculateWheelSlipRatio(shared.mTyreRPS.RL, shared.mTyreY.RL, shared.mLocalVelocity.Z)),
+            Math.Abs(CalculateWheelSlipRatio(shared.mTyreRPS.RR, shared.mTyreY.RR, shared.mLocalVelocity.Z))
         ];
 
         // Lap info

--- a/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
+++ b/Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
@@ -99,7 +99,11 @@ internal static class Ams2Mapper
         // Car physics
         local.Physics.Rotation = System.Numerics.Quaternion.CreateFromYawPitchRoll(shared.mOrientation.Y, shared.mOrientation.X, shared.mOrientation.Z);
         local.Physics.Location = shared.mParticipantInfo[shared.mViewedParticipantIndex].mWorldPosition;
-        local.Physics.Acceleration = shared.mLocalAcceleration;
+        // Convert acceleration from m/s² to G-force (1G = 9.80665 m/s²)
+        local.Physics.Acceleration = new System.Numerics.Vector3(
+            shared.mLocalAcceleration.X / 9.80665f,
+            shared.mLocalAcceleration.Y / 9.80665f,
+            shared.mLocalAcceleration.Z / 9.80665f);
         local.Physics.Velocity = shared.mSpeed * 3.6f;
 
         // Car engine
@@ -161,6 +165,14 @@ internal static class Ams2Mapper
         local.Brakes.DiscTemperature[2] = shared.mBrakeTempCelsius.RL;
         local.Brakes.DiscTemperature[3] = shared.mBrakeTempCelsius.RR;
 
+        // Tyre slip ratio calculation
+        local.Tyres.SlipRatio = [
+            CalculateWheelSlipRatio(shared.mTyreRPS.FL, shared.mTyreY.FL, shared.mLocalVelocity.Z),
+            CalculateWheelSlipRatio(shared.mTyreRPS.FR, shared.mTyreY.FR, shared.mLocalVelocity.Z),
+            CalculateWheelSlipRatio(shared.mTyreRPS.RL, shared.mTyreY.RL, shared.mLocalVelocity.Z),
+            CalculateWheelSlipRatio(shared.mTyreRPS.RR, shared.mTyreY.RR, shared.mLocalVelocity.Z)
+        ];
+
         // Lap info
         local.Timing.CurrentLaptimeMS = (int)shared.mCurrentTime;
         local.Timing.LapTimeBestMs = (int)shared.mBestLapTime;
@@ -219,5 +231,55 @@ internal static class Ams2Mapper
         Constants.RaceState.RACESTATE_MAX => SessionPhase.ResultUI,
         _ => SessionPhase.NONE
     };
+
+    /// <summary>
+    /// Calculates wheel slip ratio from tire RPS and ground speed with sign preservation.
+    /// Uses tire effective radius calculated from tire Y position (height above ground).
+    /// </summary>
+    /// <param name="tyreRPS">Tire rotational speed (in radians per second)</param>
+    /// <param name="tyreY">Tire Y position (height in local space)</param>
+    /// <param name="groundSpeed">Longitudinal ground speed in m/s</param>
+    /// <returns>Signed slip ratio: positive = wheel spin (throttle), negative = wheel lock (brake), scaled by 10</returns>
+    private static float CalculateWheelSlipRatio(float tyreRPS, float tyreY, float groundSpeed)
+    {
+        // Ground speed and tire RPS might be negative depending on game coordinates or driving backward.
+        // Convert to absolute scalars first so we compare pure speed magnitudes.
+        float absGroundSpeed = Math.Abs(groundSpeed);
+        float absTyreRPS = Math.Abs(tyreRPS);
+
+        // Below speed threshold, no meaningful slip can be measured
+        const float minSpeedThreshold = 1.0f; // 1 m/s = 3.6 km/h
+        if (absGroundSpeed < minSpeedThreshold)
+            return 0f;
+
+        // Estimate tire radius from tire Y position (typical values range 0.3-0.35m)
+        // Using absolute value as a safety measure
+        float tireRadius = Math.Abs(tyreY);
+        
+        // If radius is unrealistic, use a default (0.33m is typical for most race cars)
+        if (tireRadius < 0.2f || tireRadius > 0.5f)
+            tireRadius = 0.33f;
+
+        // Calculate wheel tangential velocity magnitude (Vw = ω * r)
+        // mTyreRPS in Madness engine is typically radians per second, so no 2*PI is needed.
+        float wheelVelocity = absTyreRPS * tireRadius;
+
+        // Calculate SIGNED slip ratio to distinguish brake lock from wheel spin
+        // Positive: wheelVelocity > groundSpeed (wheel spin / throttle slip)
+        // Negative: wheelVelocity < groundSpeed (wheel lock / brake slip)
+        float velocityDifference = wheelVelocity - absGroundSpeed;
+        float maxVelocity = Math.Max(wheelVelocity, absGroundSpeed);
+        
+        // Avoid division by zero (should not happen due to speed threshold check above)
+        if (maxVelocity < 0.1f)
+            return 0f;
+
+        // Calculate slip ratio: (Vw - Vg) / max(|Vw|, |Vg|)
+        // Positive = wheel spin (oil/throttle), Negative = wheel lock (brake)
+        // Multiply by 10 to give a healthy range for haptics (real physical slip is around 0.05-0.15)
+        float slipRatio = (velocityDifference / maxVelocity) * 10f;
+        
+        return slipRatio;
+    }
 
 }

--- a/Race Element.Data/Games/RichardBurnsRally/RBRDataProvider.cs
+++ b/Race Element.Data/Games/RichardBurnsRally/RBRDataProvider.cs
@@ -79,6 +79,9 @@ internal sealed class RBRDataProvider : AbstractSimDataProvider
         localCar.Engine.Rpm = (int)data.EngineRpm;
         localCar.Engine.MaxRpm = 8000;
         localCar.Engine.IsRunning = data.EngineRpm > 500;
+        // RBR NGP temperatures are in Kelvin, convert to Celsius
+        localCar.Engine.WaterTemperature = data.EngineCoolantTemp - 273.15f;
+        localCar.Engine.OilTemperature = data.EngineTemp - 273.15f;
 
 
         // SlipRatio - Use memory reading for accurate wheel speeds (based on Adaptive_Trigger_RBR.py)

--- a/Race Element.HUD.Common/Overlays/Driving/DSX/DsxConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/DSX/DsxConfiguration.cs
@@ -45,6 +45,9 @@ internal sealed class DsxConfiguration : OverlayConfiguration
         [ToolTip("Sets the max frequency of the vibration effect in the trigger.")]
         [IntRange(20, 150, 1)]
         public int MaxFrequency { get; init; } = 85;
+
+        [ToolTip("When enabled, higher slip produces lower frequency vibration instead of higher.")]
+        public bool InvertFrequency { get; init; } = false;
     }
 
     [ConfigGrouping("Throttle Slip", "Adjust the slip effect whilst applying the throttle.\nModify the threshold to increase or decrease sensitivity in different situations.")]
@@ -81,6 +84,9 @@ internal sealed class DsxConfiguration : OverlayConfiguration
         [ToolTip("Sets the max frequency of the vibration effect in the trigger.")]
         [IntRange(20, 150, 1)]
         public int MaxFrequency { get; init; } = 96;
+
+        [ToolTip("When enabled, higher slip produces lower frequency vibration instead of higher.")]
+        public bool InvertFrequency { get; init; } = false;
     }
 
     [ConfigGrouping("DSX UDP", "Adjust the port DSX uses, 6969 is default.")]

--- a/Race Element.HUD.Common/Overlays/Driving/DSX/DsxOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/DSX/DsxOverlay.cs
@@ -15,7 +15,7 @@ namespace RaceElement.HUD.Common.Overlays.Driving.DSX;
     OverlayCategory = OverlayCategory.Inputs,
     OverlayType = OverlayType.Drive,
     SupportedGames = Game.RaceRoom | Game.AssettoCorsa1 | Game.AssettoCorsaEvo | Game.ForzaHorizon5 | Game.LeMansUltimate | Game.rFactor2 | Game.WRC_Generations
-            | Game.ForzaMotorsport | Game.AssettoCorsaRally | Game.ProjectMotorRacing | Game.DirtRally2 | Game.RichardBurnsRally | Game.ForzaHorizon4,
+            | Game.ForzaMotorsport | Game.AssettoCorsaRally | Game.ProjectMotorRacing | Game.DirtRally2 | Game.RichardBurnsRally | Game.ForzaHorizon4 | Game.Automobilista2,
     Authors = ["Reinier Klarenberg"]
 )]
 internal sealed class DsxOverlay : CommonAbstractOverlay

--- a/Race Element.HUD.Common/Overlays/Driving/DSX/DsxPacketExtensions.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/DSX/DsxPacketExtensions.cs
@@ -1,4 +1,4 @@
-﻿using static RaceElement.HUD.Common.Overlays.Driving.DSX.Resources;
+using static RaceElement.HUD.Common.Overlays.Driving.DSX.Resources;
 
 namespace RaceElement.HUD.Common.Overlays.Driving.DSX;
 internal static class DsxPacketExtensions
@@ -85,10 +85,10 @@ internal static class DsxPacketExtensions
         combinedParameters[2] = triggerMode;
         combinedParameters[3] = valueMode;
 
-        // Copy the List<int> parameters into the combinedParameters array
+        // Copy the List<int> parameters into the combinedParameters array (starts at index 4, after valueMode)
         for (int i = 0; i < parameters.Count; i++)
         {
-            combinedParameters[3 + i] = parameters[i];
+            combinedParameters[4 + i] = parameters[i];
         }
 
         packet.Instructions[instCount] = new Instruction

--- a/Race Element.HUD.Common/Overlays/Driving/DSX/TriggerHaptics.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/DSX/TriggerHaptics.cs
@@ -1,4 +1,4 @@
-﻿using RaceElement.Data.Common;
+using RaceElement.Data.Common;
 using RaceElement.Data.Games;
 using RaceElement.Util.SystemExtensions;
 using static RaceElement.HUD.Common.Overlays.Driving.DSX.Resources;
@@ -31,8 +31,39 @@ internal static class TriggerHaptics
 
             if (slipRatios.Length == 4)
             {
-                float slipRatioFront = Math.Max(slipRatios[0], slipRatios[1]);
-                float slipRatioRear = Math.Max(slipRatios[2], slipRatios[3]);
+                // Game-specific handling: Some games (like AMS2, rFactor2) use signed slip ratios,
+                // while others (like AC, ACC) provide unsigned absolute values.
+                // For signed games: negative = brake lock, positive = wheel spin
+                // For unsigned games: we rely on brake input to confirm this is brake slip
+                // rFactor2/LMU: the mapper already takes Math.Abs() before returning,
+                // so values are always unsigned — do NOT treat them as signed here.
+                bool useSignedSlip = GameManager.CurrentGame switch
+                {
+                    Game.Automobilista2 => true,
+                    _ => false
+                };
+
+                float slipRatioFrontLeft, slipRatioFrontRight, slipRatioRearLeft, slipRatioRearRight;
+
+                if (useSignedSlip)
+                {
+                    // For signed slip games: only use negative values (brake lock)
+                    slipRatioFrontLeft = slipRatios[0] < 0 ? Math.Abs(slipRatios[0]) : 0f;
+                    slipRatioFrontRight = slipRatios[1] < 0 ? Math.Abs(slipRatios[1]) : 0f;
+                    slipRatioRearLeft = slipRatios[2] < 0 ? Math.Abs(slipRatios[2]) : 0f;
+                    slipRatioRearRight = slipRatios[3] < 0 ? Math.Abs(slipRatios[3]) : 0f;
+                }
+                else
+                {
+                    // For unsigned slip games: use absolute values directly (already positive)
+                    slipRatioFrontLeft = Math.Abs(slipRatios[0]);
+                    slipRatioFrontRight = Math.Abs(slipRatios[1]);
+                    slipRatioRearLeft = Math.Abs(slipRatios[2]);
+                    slipRatioRearRight = Math.Abs(slipRatios[3]);
+                }
+
+                float slipRatioFront = Math.Max(slipRatioFrontLeft, slipRatioFrontRight);
+                float slipRatioRear = Math.Max(slipRatioRearLeft, slipRatioRearRight);
 
                 // TODO: add option for front and rear ratio threshold.
                 if (slipRatioFront > config.BrakeSlip.FrontSlipThreshold || slipRatioRear > config.BrakeSlip.RearSlipThreshold)
@@ -49,8 +80,7 @@ internal static class TriggerHaptics
                     if (percentage >= 0.05f)
                         p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Left, TriggerMode.FEEDBACK, [1, (int)(config.BrakeSlip.FeedbackStrength * percentage)]);
 
-                    int freq = (int)(config.BrakeSlip.MaxFrequency * percentage);
-                    freq.ClipMin(config.BrakeSlip.MinFrequency);
+                    int freq = CalculateFrequency(percentage, config.BrakeSlip.MinFrequency, config.BrakeSlip.MaxFrequency, config.BrakeSlip.InvertFrequency);
                     p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Left, TriggerMode.VIBRATION, [0, config.BrakeSlip.Amplitude, freq]);
                 }
             }
@@ -71,8 +101,39 @@ internal static class TriggerHaptics
             float[] slipRatios = SimDataProvider.LocalCar.Tyres.SlipRatio;
             if (slipRatios.Length == 4)
             {
-                float slipRatioFront = Math.Max(slipRatios[0], slipRatios[1]);
-                float slipRatioRear = Math.Max(slipRatios[2], slipRatios[3]);
+                // Game-specific handling: Some games (like AMS2, rFactor2) use signed slip ratios,
+                // while others (like AC, ACC) provide unsigned absolute values.
+                // For signed games: positive = wheel spin, negative = brake lock
+                // For unsigned games: we rely on throttle input to confirm this is throttle slip
+                // rFactor2/LMU: the mapper already takes Math.Abs() before returning,
+                // so values are always unsigned — do NOT treat them as signed here.
+                bool useSignedSlip = GameManager.CurrentGame switch
+                {
+                    Game.Automobilista2 => true,
+                    _ => false
+                };
+
+                float slipRatioFrontLeft, slipRatioFrontRight, slipRatioRearLeft, slipRatioRearRight;
+
+                if (useSignedSlip)
+                {
+                    // For signed slip games: only use positive values (wheel spin)
+                    slipRatioFrontLeft = slipRatios[0] > 0 ? slipRatios[0] : 0f;
+                    slipRatioFrontRight = slipRatios[1] > 0 ? slipRatios[1] : 0f;
+                    slipRatioRearLeft = slipRatios[2] > 0 ? slipRatios[2] : 0f;
+                    slipRatioRearRight = slipRatios[3] > 0 ? slipRatios[3] : 0f;
+                }
+                else
+                {
+                    // For unsigned slip games: use absolute values directly
+                    slipRatioFrontLeft = Math.Abs(slipRatios[0]);
+                    slipRatioFrontRight = Math.Abs(slipRatios[1]);
+                    slipRatioRearLeft = Math.Abs(slipRatios[2]);
+                    slipRatioRearRight = Math.Abs(slipRatios[3]);
+                }
+
+                float slipRatioFront = Math.Max(slipRatioFrontLeft, slipRatioFrontRight);
+                float slipRatioRear = Math.Max(slipRatioRearLeft, slipRatioRearRight);
 
                 if (slipRatioFront > config.ThrottleSlip.FrontSlipThreshold || slipRatioRear > config.ThrottleSlip.RearSlipThreshold)
                 {
@@ -87,8 +148,7 @@ internal static class TriggerHaptics
                     if (percentage >= 0.05f)
                         p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Right, TriggerMode.FEEDBACK, [1, (int)(config.ThrottleSlip.FeedbackStrength * percentage)]);
 
-                    int freq = (int)(config.ThrottleSlip.MaxFrequency * percentage);
-                    freq.ClipMin(config.ThrottleSlip.MinFrequency);
+                    int freq = CalculateFrequency(percentage, config.ThrottleSlip.MinFrequency, config.ThrottleSlip.MaxFrequency, config.ThrottleSlip.InvertFrequency);
                     p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Right, TriggerMode.VIBRATION, [0, config.ThrottleSlip.Amplitude, freq]);
                 }
             }
@@ -159,8 +219,7 @@ internal static class TriggerHaptics
                         if (percentage >= 0.05f)
                             p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Left, TriggerMode.FEEDBACK, [1, (int)(config.BrakeSlip.FeedbackStrength * percentage)]);
 
-                        int freq = (int)(config.BrakeSlip.MaxFrequency * percentage);
-                        freq.ClipMin(config.BrakeSlip.MinFrequency);
+                        int freq = CalculateFrequency(percentage, config.BrakeSlip.MinFrequency, config.BrakeSlip.MaxFrequency, config.BrakeSlip.InvertFrequency);
                         p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Left, TriggerMode.VIBRATION, [0, config.BrakeSlip.Amplitude, freq]);
                     }
                 }
@@ -228,8 +287,7 @@ internal static class TriggerHaptics
                         if (percentage >= 0.05f)
                             p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Right, TriggerMode.FEEDBACK, [1, (int)(config.ThrottleSlip.FeedbackStrength * percentage)]);
 
-                        int freq = (int)(config.ThrottleSlip.MaxFrequency * percentage);
-                        freq.ClipMin(config.ThrottleSlip.MinFrequency);
+                        int freq = CalculateFrequency(percentage, config.ThrottleSlip.MinFrequency, config.ThrottleSlip.MaxFrequency, config.ThrottleSlip.InvertFrequency);
                         p.AddAdaptiveTriggerToPacket(controllerIndex, Trigger.Right, TriggerMode.VIBRATION, [0, config.ThrottleSlip.Amplitude, freq]);
                     }
                 }
@@ -265,5 +323,27 @@ internal static class TriggerHaptics
         if (p.Instructions == null) p.AddAdaptiveTriggerToPacket(0, Trigger.Right, TriggerMode.Normal, []);
 
         return p;
+    }
+
+    /// <summary>
+    /// Calculates vibration frequency based on slip percentage with optional inversion.
+    /// When inverted, high slip produces low frequency; when normal, high slip produces high frequency.
+    /// </summary>
+    /// <param name="percentage">Slip ratio percentage (0.0 to 1.0)</param>
+    /// <param name="minFrequency">Minimum frequency value</param>
+    /// <param name="maxFrequency">Maximum frequency value</param>
+    /// <param name="invert">If true, high slip maps to low frequency; if false, high slip maps to high frequency</param>
+    /// <returns>Calculated frequency value clamped between minFrequency and maxFrequency</returns>
+    private static int CalculateFrequency(float percentage, int minFrequency, int maxFrequency, bool invert)
+    {
+        int freq;
+        if (invert)
+            freq = (int)(maxFrequency - (maxFrequency - minFrequency) * percentage);
+        else
+            freq = (int)(minFrequency + (maxFrequency - minFrequency) * percentage);
+
+        freq.ClipMin(minFrequency);
+        freq.ClipMax(maxFrequency);
+        return freq;
     }
 }

--- a/Race Element.HUD.Common/Overlays/Driving/DSX/TriggerHaptics.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/DSX/TriggerHaptics.cs
@@ -31,39 +31,9 @@ internal static class TriggerHaptics
 
             if (slipRatios.Length == 4)
             {
-                // Game-specific handling: Some games (like AMS2, rFactor2) use signed slip ratios,
-                // while others (like AC, ACC) provide unsigned absolute values.
-                // For signed games: negative = brake lock, positive = wheel spin
-                // For unsigned games: we rely on brake input to confirm this is brake slip
-                // rFactor2/LMU: the mapper already takes Math.Abs() before returning,
-                // so values are always unsigned — do NOT treat them as signed here.
-                bool useSignedSlip = GameManager.CurrentGame switch
-                {
-                    Game.Automobilista2 => true,
-                    _ => false
-                };
-
-                float slipRatioFrontLeft, slipRatioFrontRight, slipRatioRearLeft, slipRatioRearRight;
-
-                if (useSignedSlip)
-                {
-                    // For signed slip games: only use negative values (brake lock)
-                    slipRatioFrontLeft = slipRatios[0] < 0 ? Math.Abs(slipRatios[0]) : 0f;
-                    slipRatioFrontRight = slipRatios[1] < 0 ? Math.Abs(slipRatios[1]) : 0f;
-                    slipRatioRearLeft = slipRatios[2] < 0 ? Math.Abs(slipRatios[2]) : 0f;
-                    slipRatioRearRight = slipRatios[3] < 0 ? Math.Abs(slipRatios[3]) : 0f;
-                }
-                else
-                {
-                    // For unsigned slip games: use absolute values directly (already positive)
-                    slipRatioFrontLeft = Math.Abs(slipRatios[0]);
-                    slipRatioFrontRight = Math.Abs(slipRatios[1]);
-                    slipRatioRearLeft = Math.Abs(slipRatios[2]);
-                    slipRatioRearRight = Math.Abs(slipRatios[3]);
-                }
-
-                float slipRatioFront = Math.Max(slipRatioFrontLeft, slipRatioFrontRight);
-                float slipRatioRear = Math.Max(slipRatioRearLeft, slipRatioRearRight);
+                // All data providers should return absolute slip values
+                float slipRatioFront = Math.Max(Math.Abs(slipRatios[0]), Math.Abs(slipRatios[1]));
+                float slipRatioRear = Math.Max(Math.Abs(slipRatios[2]), Math.Abs(slipRatios[3]));
 
                 // TODO: add option for front and rear ratio threshold.
                 if (slipRatioFront > config.BrakeSlip.FrontSlipThreshold || slipRatioRear > config.BrakeSlip.RearSlipThreshold)
@@ -101,39 +71,9 @@ internal static class TriggerHaptics
             float[] slipRatios = SimDataProvider.LocalCar.Tyres.SlipRatio;
             if (slipRatios.Length == 4)
             {
-                // Game-specific handling: Some games (like AMS2, rFactor2) use signed slip ratios,
-                // while others (like AC, ACC) provide unsigned absolute values.
-                // For signed games: positive = wheel spin, negative = brake lock
-                // For unsigned games: we rely on throttle input to confirm this is throttle slip
-                // rFactor2/LMU: the mapper already takes Math.Abs() before returning,
-                // so values are always unsigned — do NOT treat them as signed here.
-                bool useSignedSlip = GameManager.CurrentGame switch
-                {
-                    Game.Automobilista2 => true,
-                    _ => false
-                };
-
-                float slipRatioFrontLeft, slipRatioFrontRight, slipRatioRearLeft, slipRatioRearRight;
-
-                if (useSignedSlip)
-                {
-                    // For signed slip games: only use positive values (wheel spin)
-                    slipRatioFrontLeft = slipRatios[0] > 0 ? slipRatios[0] : 0f;
-                    slipRatioFrontRight = slipRatios[1] > 0 ? slipRatios[1] : 0f;
-                    slipRatioRearLeft = slipRatios[2] > 0 ? slipRatios[2] : 0f;
-                    slipRatioRearRight = slipRatios[3] > 0 ? slipRatios[3] : 0f;
-                }
-                else
-                {
-                    // For unsigned slip games: use absolute values directly
-                    slipRatioFrontLeft = Math.Abs(slipRatios[0]);
-                    slipRatioFrontRight = Math.Abs(slipRatios[1]);
-                    slipRatioRearLeft = Math.Abs(slipRatios[2]);
-                    slipRatioRearRight = Math.Abs(slipRatios[3]);
-                }
-
-                float slipRatioFront = Math.Max(slipRatioFrontLeft, slipRatioFrontRight);
-                float slipRatioRear = Math.Max(slipRatioRearLeft, slipRatioRearRight);
+                // All data providers should return absolute slip values
+                float slipRatioFront = Math.Max(Math.Abs(slipRatios[0]), Math.Abs(slipRatios[1]));
+                float slipRatioRear = Math.Max(Math.Abs(slipRatios[2]), Math.Abs(slipRatios[3]));
 
                 if (slipRatioFront > config.ThrottleSlip.FrontSlipThreshold || slipRatioRear > config.ThrottleSlip.RearSlipThreshold)
                 {

--- a/Race Element.HUD.Common/Overlays/Driving/WaterTemperature/WaterTemperatureConfiguration.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/WaterTemperature/WaterTemperatureConfiguration.cs
@@ -1,0 +1,84 @@
+using RaceElement.HUD.Overlay.Configuration;
+using System.Drawing;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.WaterTemperature;
+
+internal sealed class WaterTemperatureConfiguration : OverlayConfiguration
+{
+    public WaterTemperatureConfiguration() => GenericConfiguration.AllowRescale = false;
+
+    [ConfigGrouping("General", "General options")]
+    public GeneralGrouping General { get; init; } = new();
+    public sealed class GeneralGrouping
+    {
+        [ToolTip("Display temperature in Celsius or Fahrenheit")]
+        public UnitChoice Units { get; init; } = UnitChoice.Celsius;
+
+        [ToolTip("Size of the font")]
+        [FloatRange(12.0f, 90.0f, 0.5f, 1)]
+        public float FontSize { get; init; } = 25.5f;
+
+        [ToolTip("Change the Font")]
+        public TemperatureTextFont Font { get; init; } = TemperatureTextFont.Roboto;
+
+        [ToolTip("Number of digits to display")]
+        [IntRange(2, 3, 1)]
+        public int Digits { get; init; } = 3;
+
+        [IntRange(-10, 30, 1)]
+        public int ExtraDigitSpacing { get; init; } = -8;
+
+        [IntRange(1, 100, 1)]
+        public int RefreshRate { get; init; } = 10;
+
+        [ToolTip("Show the unit symbol (°C or °F)")]
+        public bool ShowUnit { get; init; } = true;
+
+        [ToolTip("Show label text")]
+        public bool ShowLabel { get; init; } = true;
+
+        [ToolTip("Label text to display")]
+        public string LabelText { get; init; } = "H₂O";
+    }
+
+    [ConfigGrouping("Colors", "Adjust colors")]
+    public ColorsGrouping Colors { get; init; } = new();
+    public sealed class ColorsGrouping
+    {
+        public Color TextColor { get; init; } = Color.FromArgb(255, 255, 255, 255);
+        
+        [IntRange(75, 255, 1)]
+        public int TextOpacity { get; init; } = 255;
+
+        public Color BackgroundColor { get; init; } = Color.FromArgb(255, 0, 0, 0);
+
+        [ToolTip("Changes the background opacity, 0 is invisible.")]
+        [IntRange(0, 255, 1)]
+        public int BackgroundOpacity { get; init; } = 175;
+
+        [ToolTip("Color when temperature is in normal range")]
+        public Color NormalColor { get; init; } = Color.FromArgb(255, 100, 200, 100);
+
+        [ToolTip("Color when temperature is getting hot")]
+        public Color WarningColor { get; init; } = Color.FromArgb(255, 255, 200, 0);
+
+        [ToolTip("Color when temperature is critical")]
+        public Color DangerColor { get; init; } = Color.FromArgb(255, 255, 50, 50);
+    }
+
+    [ConfigGrouping("Warning Thresholds", "Temperature warning thresholds")]
+    public ThresholdsGrouping Thresholds { get; init; } = new();
+    public sealed class ThresholdsGrouping
+    {
+        [ToolTip("Temperature (°C) above which warning color is used")]
+        [IntRange(70, 120, 1)]
+        public int WarningTemperature { get; init; } = 95;
+
+        [ToolTip("Temperature (°C) above which danger color is used")]
+        [IntRange(80, 130, 1)]
+        public int DangerTemperature { get; init; } = 105;
+    }
+
+    public enum TemperatureTextFont { Roboto, Conthrax, Obitron, Segoe }
+    public enum UnitChoice { Celsius, Fahrenheit }
+}

--- a/Race Element.HUD.Common/Overlays/Driving/WaterTemperature/WaterTemperatureOverlay.cs
+++ b/Race Element.HUD.Common/Overlays/Driving/WaterTemperature/WaterTemperatureOverlay.cs
@@ -1,0 +1,220 @@
+using RaceElement.Data.Common;
+using RaceElement.HUD.Overlay.Internal;
+using RaceElement.HUD.Overlay.OverlayUtil;
+using RaceElement.HUD.Overlay.Util;
+using RaceElement.Util.SystemExtensions;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+
+namespace RaceElement.HUD.Common.Overlays.Driving.WaterTemperature;
+
+[Overlay(
+    Name = "Water Temperature",
+    Description = "Shows engine water (coolant) temperature with color-coded warnings",
+    Authors = ["Aaron"],
+    SupportedGames = Data.Games.Game.RichardBurnsRally
+)]
+internal sealed class WaterTemperatureOverlay(Rectangle rectangle) : CommonAbstractOverlay(rectangle, "Water Temperature")
+{
+    private readonly WaterTemperatureConfiguration _config = new();
+
+    private CachedBitmap? _cachedBackground;
+    private TemperatureBitmaps? _bitmaps;
+    private Font? _unitFont;
+    private Font? _labelFont;
+
+    public override void BeforeStart()
+    {
+        RefreshRateHz = _config.General.RefreshRate;
+
+        _bitmaps = new TemperatureBitmaps(_config);
+        
+        // Calculate width: digits + spacing + unit + label
+        int digitsWidth = _config.General.Digits * _bitmaps.BitmapDimension.Width + 
+                         _config.General.ExtraDigitSpacing * (_config.General.Digits - 1);
+        
+        int unitWidth = 0;
+        if (_config.General.ShowUnit)
+        {
+            _unitFont = _config.General.Font switch
+            {
+                WaterTemperatureConfiguration.TemperatureTextFont.Conthrax => FontUtil.FontConthrax(_config.General.FontSize * 0.6f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Obitron => FontUtil.FontOrbitron(_config.General.FontSize * 0.6f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Roboto => FontUtil.FontRoboto(_config.General.FontSize * 0.6f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Segoe => FontUtil.FontSegoeMono(_config.General.FontSize * 0.6f),
+                _ => FontUtil.FontRoboto(_config.General.FontSize * 0.6f),
+            };
+            string unitText = _config.General.Units == WaterTemperatureConfiguration.UnitChoice.Celsius ? "°C" : "°F";
+            unitWidth = (int)FontUtil.MeasureWidth(_unitFont, unitText) + 5;
+        }
+
+        int labelWidth = 0;
+        if (_config.General.ShowLabel)
+        {
+            _labelFont = _config.General.Font switch
+            {
+                WaterTemperatureConfiguration.TemperatureTextFont.Conthrax => FontUtil.FontConthrax(_config.General.FontSize * 0.8f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Obitron => FontUtil.FontOrbitron(_config.General.FontSize * 0.8f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Roboto => FontUtil.FontRoboto(_config.General.FontSize * 0.8f),
+                WaterTemperatureConfiguration.TemperatureTextFont.Segoe => FontUtil.FontSegoeMono(_config.General.FontSize * 0.8f),
+                _ => FontUtil.FontRoboto(_config.General.FontSize * 0.8f),
+            };
+            labelWidth = (int)FontUtil.MeasureWidth(_labelFont, _config.General.LabelText) + 10;
+        }
+
+        Width = digitsWidth + unitWidth + labelWidth + 10;
+        Height = _bitmaps.BitmapDimension.Height;
+
+        _cachedBackground = new(Width, Height, g =>
+        {
+            RectangleF barArea = new(0, 0, Width - 1, Height - 1);
+
+            g.CompositingQuality = CompositingQuality.HighQuality;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+
+            using SolidBrush darkBrush = new(Color.FromArgb(_config.Colors.BackgroundOpacity, _config.Colors.BackgroundColor));
+            g.FillRoundedRectangle(darkBrush, Rectangle.Round(barArea), 3);
+            using Pen darkPen = new(darkBrush, 1);
+            g.DrawRoundedRectangle(darkPen, Rectangle.Round(barArea), 3);
+        });
+    }
+
+    public override void BeforeStop()
+    {
+        _cachedBackground?.Dispose();
+        _bitmaps?.Dispose();
+        _unitFont?.Dispose();
+        _labelFont?.Dispose();
+    }
+
+    public override void Render(Graphics g)
+    {
+        if (_config.Colors.BackgroundOpacity != 0) _cachedBackground?.Draw(g);
+
+        if (_bitmaps == null) return;
+
+        int x = 5;
+
+        // Draw label if enabled
+        if (_config.General.ShowLabel && _labelFont != null)
+        {
+            using SolidBrush labelBrush = new(Color.FromArgb(_config.Colors.TextOpacity, _config.Colors.TextColor));
+            g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+            g.DrawString(_config.General.LabelText, _labelFont, labelBrush, x, Height / 2 - _labelFont.Height / 2);
+            x += (int)FontUtil.MeasureWidth(_labelFont, _config.General.LabelText) + 10;
+        }
+
+        // Get water temperature
+        float waterTempCelsius = SimDataProvider.LocalCar.Engine.WaterTemperature;
+        float displayTemp = waterTempCelsius;
+        
+        if (_config.General.Units == WaterTemperatureConfiguration.UnitChoice.Fahrenheit)
+            displayTemp = waterTempCelsius * 9f / 5f + 32f;
+
+        // Determine color based on temperature
+        Color tempColor = GetTemperatureColor(waterTempCelsius);
+
+        // Format temperature
+        string tempStr = $"{displayTemp:f0}".FillStart(_config.General.Digits, ' ');
+
+        // Draw digits
+        for (int i = 0; i < _config.General.Digits; i++)
+        {
+            if (byte.TryParse(tempStr.AsSpan(i, 1), out byte number))
+            {
+                if (i != 0 || number != 0) // do not draw leading zeros
+                {
+                    _bitmaps.GetForNumber(number, tempColor).Draw(g, new(x, 0));
+                }
+            }
+
+            x += _bitmaps.BitmapDimension.Width + _config.General.ExtraDigitSpacing;
+        }
+
+        // Draw unit if enabled
+        if (_config.General.ShowUnit && _unitFont != null)
+        {
+            using SolidBrush unitBrush = new(Color.FromArgb(_config.Colors.TextOpacity, tempColor));
+            g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+            string unitText = _config.General.Units == WaterTemperatureConfiguration.UnitChoice.Celsius ? "°C" : "°F";
+            g.DrawString(unitText, _unitFont, unitBrush, x + 5, Height / 2 - _unitFont.Height / 2);
+        }
+    }
+
+    private Color GetTemperatureColor(float tempCelsius)
+    {
+        if (tempCelsius >= _config.Thresholds.DangerTemperature)
+            return _config.Colors.DangerColor;
+        else if (tempCelsius >= _config.Thresholds.WarningTemperature)
+            return _config.Colors.WarningColor;
+        else
+            return _config.Colors.NormalColor;
+    }
+
+    private sealed class TemperatureBitmaps : IDisposable
+    {
+        private readonly Dictionary<(byte, Color), CachedBitmap> _bitmapCache = new();
+        public readonly (int Width, int Height) BitmapDimension;
+        private readonly WaterTemperatureConfiguration _config;
+        private readonly Font _font;
+
+        public TemperatureBitmaps(WaterTemperatureConfiguration config)
+        {
+            _config = config;
+            _font = config.General.Font switch
+            {
+                WaterTemperatureConfiguration.TemperatureTextFont.Conthrax => FontUtil.FontConthrax(config.General.FontSize),
+                WaterTemperatureConfiguration.TemperatureTextFont.Obitron => FontUtil.FontOrbitron(config.General.FontSize),
+                WaterTemperatureConfiguration.TemperatureTextFont.Roboto => FontUtil.FontRoboto(config.General.FontSize),
+                WaterTemperatureConfiguration.TemperatureTextFont.Segoe => FontUtil.FontSegoeMono(config.General.FontSize),
+                _ => FontUtil.FontConthrax(config.General.FontSize),
+            };
+
+            int bitmapWidth = (int)(config.General.FontSize + 4);
+            int bitmapHeight = bitmapWidth + 4;
+
+            if (bitmapHeight < FontUtil.MeasureHeight(_font, "0123456789"))
+                bitmapHeight = (int)Math.Round(FontUtil.MeasureHeight(_font, "0123456789"));
+
+            BitmapDimension = (bitmapWidth, bitmapHeight);
+        }
+
+        public CachedBitmap GetForNumber(byte number, Color color)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(number, 9);
+
+            var key = (number, color);
+            if (!_bitmapCache.TryGetValue(key, out CachedBitmap? bitmap))
+            {
+                bitmap = CreateBitmap(number, color);
+                _bitmapCache[key] = bitmap;
+            }
+
+            return bitmap;
+        }
+
+        private CachedBitmap CreateBitmap(byte number, Color color)
+        {
+            using StringFormat format = StringFormat.GenericDefault;
+            format.Alignment = StringAlignment.Center;
+            format.LineAlignment = StringAlignment.Center;
+
+            return new(BitmapDimension.Width, BitmapDimension.Height, g =>
+            {
+                g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+                using SolidBrush textBrush = new(Color.FromArgb(_config.Colors.TextOpacity, color));
+                g.DrawStringWithShadow($"{number}", _font, textBrush, 
+                    new RectangleF(0, 2, BitmapDimension.Width, BitmapDimension.Height - 2), format);
+            });
+        }
+
+        public void Dispose()
+        {
+            foreach (var bitmap in _bitmapCache.Values)
+                bitmap?.Dispose();
+            _bitmapCache.Clear();
+            _font?.Dispose();
+        }
+    }
+}

--- a/Race_Element.HUD.ACC/Overlays/Driving/DSX/TriggerHaptics.cs
+++ b/Race_Element.HUD.ACC/Overlays/Driving/DSX/TriggerHaptics.cs
@@ -1,4 +1,4 @@
-﻿using RaceElement.Util.SystemExtensions;
+using RaceElement.Util.SystemExtensions;
 using System;
 using System.Collections.Generic;
 using static RaceElement.ACCSharedMemory;
@@ -79,7 +79,7 @@ internal static class TriggerHaptics
 
         float rearLeftSlip = pagePhysics.SlipRatio[(int)Wheel.RearLeft];
         float rearRightSlip = pagePhysics.SlipRatio[(int)Wheel.RearRight];
-        float averageRearTyreSlip = rearLeftSlip + rearRightSlip / 2;
+        float averageRearTyreSlip = (rearLeftSlip + rearRightSlip) / 2;
 
         if (averageRearTyreSlip > 1)
         {


### PR DESCRIPTION
## What changed

### Data and game adapters
- **LocalCarData**: Add engine coolant (water) and oil temperature fields for overlays.
- Richard Burns Rally (**RBRDataProvider**): Map relevant temperatures from Kelvin to Celsius for consistency with other titles.
- Automobilista 2 (**Mapper**): Compute signed slip ratio per wheel from wheel speed and ground speed; fix longitudinal acceleration unit conversion (m/s² → g).

### New overlay
- **WaterTemperature**: New overlay with configurable font, threshold-based coloring, and Celsius/Fahrenheit unit selection (WaterTemperatureConfiguration + WaterTemperatureOverlay).

### DSX
- Shared DSX (**Race Element.HUD.Common**): AMS2 support including signed slip handling; 
- extract CalculateFrequency helper; 
- add InvertFrequency for brake and throttle.
- Bugfix: AddCustomAdaptiveTriggerToPacket no longer overwrites the valueMode argument (DsxPacketExtensions / DsxOverlay and related call sites).
- ACC-specific (Race_Element.HUD.ACC): Fix operator precedence for averageRearTyreSlip so the expression evaluates correctly.

## Files touched (high level)
- Race Element.Data/Common/SimulatorData/LocalCar/LocalCarData.cs
- Race Element.Data/Games/Automobilista2/DataMapper/Mapper.cs
- Race Element.Data/Games/RichardBurnsRally/RBRDataProvider.cs
- Race Element.HUD.Common/Overlays/Driving/DSX/* ( and new WaterTemperature/* )
- Race_Element.HUD.ACC/Overlays/Driving/DSX/TriggerHaptics.cs

## Suggested checks for reviewers
- AMS2: Verify per-wheel slip sign and DSX trigger behaviour (including reverse / opposite slip).
- RBR: Confirm coolant temperatures match expectations versus other readouts.
- ACC DSX: Compare rear-slip-driven haptics before/after the precedence fix under similar conditions.
- Water temperature overlay: Threshold colours and ℃/℉ switching.
